### PR TITLE
Remove the event() function from formulas and ensure mods can be applied to mods

### DIFF
--- a/src/aux-common/Files/test/FileActionsTests.ts
+++ b/src/aux-common/Files/test/FileActionsTests.ts
@@ -2324,6 +2324,37 @@ export function fileActionsTests(
                     }),
                 ]);
             });
+
+            it('should support merging mods into mods', () => {
+                const state: FilesState = {
+                    thisFile: {
+                        id: 'thisFile',
+                        tags: {
+                            'test()': `let m = { abc: true }; mod.apply(m, { def: 123 }); mod.apply(this, m);`,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const fileAction = action('test', ['thisFile']);
+                const result = calculateActionEvents(
+                    state,
+                    fileAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    fileUpdated('thisFile', {
+                        tags: {
+                            abc: true,
+                            def: 123,
+                        },
+                    }),
+                ]);
+            });
         });
 
         describe('addToContextDiff()', () => {

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -1384,7 +1384,6 @@ export default {
     combine,
     create: createFrom,
     destroy,
-    event,
     getBotsInContext,
     getBotsInStack,
     getNeighboringBots,


### PR DESCRIPTION
This PR, when merged, will remove the `event()` function from formula scripts and adds a test to verify that `mod.apply()` can be used to apply a mod onto another mod.