### PR TITLE
Fix actions to support comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,14 @@
     -   Improved the server to update a tag indicating whether a user is active or not.
         -   The tag is `aux.user.active` and is on every player bot.
         -   The user frustums have been updated to use this value for detecting if a player is active or not.
+    -   Removed the `event()` function from action scripts.
 -   Bug Fixes
     -   Destroying a bot will no longer keep a mod of the bot in the selection.
     -   Modballs will no longer appear as the file rendered when searching for bots.
     -   Added the missing `onPointerDown()` tag to the tag dropdown list.
     -   Fixed an issue that would cause the browser to be refreshed while in the process of Forking an AUX.
     -   The `player.currentChannel()` function will now work in builder.
+    -   Fixed actions to be able to support using comments at the end of scripts.
 
 ## V0.9.26
 

--- a/src/aux-common/Files/FilesChannel.ts
+++ b/src/aux-common/Files/FilesChannel.ts
@@ -123,7 +123,7 @@ function eventActions(
         .map(f => {
             const result = calculateFileValue(context, file, f.tag);
             if (result) {
-                return `(function() { ${result.toString()} }).call(this)`;
+                return `(function() { \n${result.toString()}\n }).call(this)`;
             } else {
                 return result;
             }

--- a/src/aux-common/Files/test/FileActionsTests.ts
+++ b/src/aux-common/Files/test/FileActionsTests.ts
@@ -478,6 +478,63 @@ export function fileActionsTests(
             expect(events.events).toEqual([]);
         });
 
+        it('should support single-line scripts with a comment at the end', () => {
+            expect.assertions(1);
+
+            const state: FilesState = {
+                userFile: {
+                    id: 'userFile',
+                    tags: {},
+                },
+                thisFile: {
+                    id: 'thisFile',
+                    tags: {
+                        'test()': 'player.toast("test"); // this is a test',
+                    },
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const fileAction = action('test', ['thisFile'], 'userFile');
+            const events = calculateActionEvents(
+                state,
+                fileAction,
+                createSandbox
+            );
+
+            expect(events.events).toEqual([toast('test')]);
+        });
+
+        it('should support multi-line scripts with a comment at the end', () => {
+            expect.assertions(1);
+
+            const state: FilesState = {
+                userFile: {
+                    id: 'userFile',
+                    tags: {},
+                },
+                thisFile: {
+                    id: 'thisFile',
+                    tags: {
+                        'test()':
+                            'player.toast("test"); // comment 1\n// this is a test',
+                    },
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const fileAction = action('test', ['thisFile'], 'userFile');
+            const events = calculateActionEvents(
+                state,
+                fileAction,
+                createSandbox
+            );
+
+            expect(events.events).toEqual([toast('test')]);
+        });
+
         describe('arguments', () => {
             it('should not convert the argument to a proxy object if it is a file', () => {
                 const state: FilesState = {


### PR DESCRIPTION
When merged, this PR will fix the ability to add line comments to the end of scripts. Without this fix, adding a comment to the end of a action script would cause the script to be invalid and therefore not be able to be executed.