### PR TITLE
Add the ability to automatically push information to the directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## V0.9.33
 
-### Date: 9/10/2019
+### Date: TBD
 
 ### Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # AUX Changelog
 
+## V0.9.33
+
+### Date: 9/10/2019
+
+### Changes:
+
+-   Improvements
+    -   Added a service which can send information to the configured directory at periodic intervals.
+        -   By default, the information gets sent on startup and every 5 minutes afterwards.
+            -   `key`: The SHA-256 hash of the hostname plus the loopback interface's MAC address.
+            -   `password`: The password that was generated on the device to authenticate to the directory.
+            -   `publicName`: The hostname of the device.
+            -   `privateIpAddress`: The IPv4 Address of the first non-loopback interface sorted by interface name. This is supposed to be the LAN IP that the device has.
+        -   The directory that the client reports to (the upstream) can be configured using the `UPSTREAM_DIRECTORY` environment variable. If it is not set, then the client is disabled in production.
+
 ## V0.9.32
 
 ### Date: 9/10/2019

--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -3,13 +3,19 @@
 const axios = jest.genMockFromModule('axios');
 
 let lastPost;
+let lastPut;
 axios.post = (url, data) => {
     lastPost = [url, data];
 };
+axios.put = (url, data) => {
+    lastPut = [url, data];
+};
 
 axios.__getLastPost = () => lastPost;
+axios.__getLastPut = () => lastPut;
 axios.__reset = () => {
     lastPost = undefined;
+    lastPut = undefined;
 };
 
 module.exports = axios;

--- a/__mocks__/os.js
+++ b/__mocks__/os.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const os = jest.genMockFromModule('os');
+
+let hostname = 'hostname';
+let interfaces = {
+    lo0: [
+        {
+            address: '::1',
+            family: 'IPv6',
+            internal: true,
+            mac: 'local:address',
+        },
+        {
+            address: '127.0.0.1',
+            family: 'IPv4',
+            internal: true,
+            mac: 'local:address',
+        },
+    ],
+    eth0: [
+        {
+            address: '192.168.1.65',
+            family: 'IPv4',
+            internal: false,
+            max: 'ethernet:address',
+        },
+    ],
+    wlan0: [
+        {
+            address: '192.168.1.128',
+            family: 'IPv4',
+            internal: false,
+            max: 'wlan:address',
+        },
+    ],
+};
+
+os.__setHostname = name => {
+    hostname = name;
+};
+os.hostname = () => hostname;
+os.networkInterfaces = () => interfaces;
+
+module.exports = os;

--- a/src/aux-server/server/config.dev.ts
+++ b/src/aux-server/server/config.dev.ts
@@ -31,7 +31,9 @@ const config: Config = {
             secret: 'test',
             webhook: null,
         },
-        client: null,
+        client: {
+            upstream: 'http://localhost:3000',
+        },
         dbName: 'aux-directory',
     },
     dist: path.resolve(__dirname, '..', '..', 'aux-web', 'dist'),

--- a/src/aux-server/server/config.dev.ts
+++ b/src/aux-server/server/config.dev.ts
@@ -27,8 +27,11 @@ const config: Config = {
         dbName: 'aux-trees',
     },
     directory: {
-        secret: 'test',
-        webhook: null,
+        server: {
+            secret: 'test',
+            webhook: null,
+        },
+        client: null,
         dbName: 'aux-directory',
     },
     dist: path.resolve(__dirname, '..', '..', 'aux-web', 'dist'),

--- a/src/aux-server/server/config.prod.ts
+++ b/src/aux-server/server/config.prod.ts
@@ -10,6 +10,7 @@ const httpPort = parseInt(process.env.NODE_PORT) || 3000;
 
 const directoryTokenSecret = process.env.DIRECTORY_TOKEN_SECRET;
 const directoryWebhook = process.env.DIRECTORY_WEBHOOK;
+const directoryUpstream = process.env.UPSTREAM_DIRECTORY;
 
 const config: Config = {
     socket: {
@@ -38,13 +39,20 @@ const config: Config = {
     trees: {
         dbName: 'aux-trees',
     },
-    directory: directoryWebhook
-        ? {
-              secret: directoryTokenSecret,
-              webhook: directoryWebhook,
-              dbName: 'aux-directory',
-          }
-        : null,
+    directory: {
+        server: directoryWebhook
+            ? {
+                  secret: directoryTokenSecret,
+                  webhook: directoryWebhook,
+              }
+            : null,
+        client: directoryUpstream
+            ? {
+                  upstream: directoryUpstream,
+              }
+            : null,
+        dbName: 'aux-directory',
+    },
     dist: path.resolve(__dirname, '..', '..', 'aux-web', 'dist'),
 };
 

--- a/src/aux-server/server/config.ts
+++ b/src/aux-server/server/config.ts
@@ -36,6 +36,13 @@ export interface CausalTreeServerConfig {
 }
 
 export interface DirectoryConfig {
+    server: DirectoryServerConfig;
+    client: DirectoryClientConfig;
+
+    dbName: string;
+}
+
+export interface DirectoryServerConfig {
     /**
      * The secret that should be used for signing/verifying tokens.
      */
@@ -45,9 +52,11 @@ export interface DirectoryConfig {
      * The URL that webhooks should be sent to.
      */
     webhook: string;
+}
 
+export interface DirectoryClientConfig {
     /**
-     * The name of the Mongo DB that the directory should store data in.
+     * The base address of the directory that this AUXPlayer should upload its data to.
      */
-    dbName: string;
+    upstream: string;
 }

--- a/src/aux-server/server/directory/DirectoryClient.spec.ts
+++ b/src/aux-server/server/directory/DirectoryClient.spec.ts
@@ -1,0 +1,118 @@
+import { DirectoryClient } from './DirectoryClient';
+import { DirectoryStore } from './DirectoryStore';
+import { MemoryDirectoryStore } from './MemoryDirectoryStore';
+import { DEFAULT_PING_INTERVAL } from './DirectoryClientSettings';
+
+jest.mock('axios');
+jest.mock('os');
+jest.useFakeTimers();
+
+describe('DirectoryClient', () => {
+    let client: DirectoryClient;
+    let store: DirectoryStore;
+
+    beforeEach(async () => {
+        require('os').__setHostname('testHostname');
+
+        store = new MemoryDirectoryStore();
+
+        await store.init();
+
+        client = new DirectoryClient(store, {
+            upstream: 'https://example.com',
+        });
+    });
+
+    describe('init()', () => {
+        it('should create an initial version of the settings', async () => {
+            await client.init();
+
+            const settings = await store.getClientSettings();
+
+            expect(settings).toEqual({
+                pingInterval: DEFAULT_PING_INTERVAL,
+                token: null,
+                password: expect.any(String),
+            });
+        });
+
+        it('should use the stored version of the settings', async () => {
+            await store.saveClientSettings({
+                pingInterval: 100,
+                token: null,
+                password: 'def',
+            });
+
+            await client.init();
+
+            const settings = await store.getClientSettings();
+
+            expect(settings).toEqual({
+                pingInterval: 100,
+                token: null,
+                password: 'def',
+            });
+        });
+    });
+
+    describe('upstream', () => {
+        beforeEach(async () => {
+            require('axios').__reset();
+            await store.saveClientSettings({
+                pingInterval: 100,
+                token: null,
+                password: 'def',
+            });
+            await client.init();
+        });
+
+        it('should send a PUT request to the upstread each time the ping interval is up', async () => {
+            let request = require('axios').__getLastPut();
+            expect(request).toMatchInlineSnapshot(`
+                Array [
+                  "https://example.com/api/directory",
+                  Object {
+                    "key": "8c1a3f6e96e480fd4a265e3aeeab162771ae584cfdc3c03449a37403a1352ac1",
+                    "password": "def",
+                    "privateIpAddress": "192.168.1.65",
+                    "publicName": "testHostname",
+                  },
+                ]
+            `);
+
+            // 100 minutes + 1ms
+            jest.advanceTimersByTime(1000 * 60 * 100 + 1);
+
+            request = require('axios').__getLastPut();
+            expect(request).toMatchInlineSnapshot(`
+                Array [
+                  "https://example.com/api/directory",
+                  Object {
+                    "key": "8c1a3f6e96e480fd4a265e3aeeab162771ae584cfdc3c03449a37403a1352ac1",
+                    "password": "def",
+                    "privateIpAddress": "192.168.1.65",
+                    "publicName": "testHostname",
+                  },
+                ]
+            `);
+
+            require('axios').__reset();
+
+            // 100 minutes + 1ms
+            jest.advanceTimersByTime(1000 * 60 * 100 + 1);
+
+            request = require('axios').__getLastPut();
+            expect(request).toMatchInlineSnapshot(`
+                Array [
+                  "https://example.com/api/directory",
+                  Object {
+                    "key": "8c1a3f6e96e480fd4a265e3aeeab162771ae584cfdc3c03449a37403a1352ac1",
+                    "password": "def",
+                    "privateIpAddress": "192.168.1.65",
+                    "publicName": "testHostname",
+                  },
+                ]
+            `);
+        });
+    });
+});

--- a/src/aux-server/server/directory/DirectoryClient.ts
+++ b/src/aux-server/server/directory/DirectoryClient.ts
@@ -1,0 +1,104 @@
+import { DirectoryStore } from './DirectoryStore';
+import { DirectoryClientConfig } from '../config';
+import {
+    DEFAULT_PING_INTERVAL,
+    DirectoryClientSettings,
+} from './DirectoryClientSettings';
+import { randomBytes } from 'crypto';
+import { hostname, networkInterfaces } from 'os';
+import { sha256 } from 'sha.js';
+import axios from 'axios';
+
+/**
+ * Defines a client for the directory.
+ */
+export class DirectoryClient {
+    private _config: DirectoryClientConfig;
+    private _store: DirectoryStore;
+    private _timeoutId: NodeJS.Timeout;
+    private _settings: DirectoryClientSettings;
+
+    constructor(store: DirectoryStore, config: DirectoryClientConfig) {
+        this._store = store;
+        this._config = config;
+    }
+
+    async init(): Promise<void> {
+        this._settings = await this._store.getClientSettings();
+
+        if (!this._settings) {
+            this._settings = {
+                pingInterval: DEFAULT_PING_INTERVAL,
+                password: generatePassword(),
+                token: null,
+            };
+            await this._store.saveClientSettings(this._settings);
+        }
+
+        await this._ping();
+        this._updateTimeout();
+    }
+
+    private _updateTimeout() {
+        if (this._timeoutId) {
+            clearInterval(this._timeoutId);
+        }
+        this._timeoutId = setInterval(async () => {
+            await this._ping();
+        }, this._settings.pingInterval * 60 * 1000);
+    }
+
+    private async _ping() {
+        const iface = getNetworkInterface(false);
+        const url = new URL('/api/directory', this._config.upstream);
+        await axios.put(url.href, {
+            key: getKey(),
+            password: this._settings.password,
+            publicName: hostname(),
+            privateIpAddress: iface.address,
+        });
+    }
+}
+
+function getKey() {
+    const iface = getNetworkInterface(true);
+    if (!iface) {
+        throw new Error(
+            'Cannot calculate key because no valid network interfaces are available.'
+        );
+    }
+    const str = `${hostname()}.${iface.mac}`;
+    const hash = new sha256();
+    hash.update(str);
+    return hash.digest().toString('hex');
+}
+
+function generatePassword() {
+    const bytes = randomBytes(16);
+    const str = bytes.toString('base64');
+    return str;
+}
+
+/**
+ * Gets the first IPv4 Network interface.
+ * @param local Whether to include the loopback interface.
+ */
+function getNetworkInterface(local: boolean = false) {
+    const net = networkInterfaces();
+    const keys = Object.keys(net).sort();
+    for (let key of keys) {
+        const ifname = net[key];
+
+        if (!ifname) {
+            continue;
+        }
+
+        for (let i = 0; i < ifname.length; i++) {
+            const iface = ifname[i];
+            if ((iface.internal && !local) || iface.family !== 'IPv4') {
+                continue;
+            }
+            return iface;
+        }
+    }
+}

--- a/src/aux-server/server/directory/DirectoryClientSettings.ts
+++ b/src/aux-server/server/directory/DirectoryClientSettings.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_PING_INTERVAL = 5;
+
+/**
+ * The settings that the directory client currently has.
+ */
+export interface DirectoryClientSettings {
+    /**
+     * The amount of time between pings in minutes.
+     */
+    pingInterval: number;
+
+    /**
+     * The password that the client is using.
+     */
+    password: string;
+
+    /**
+     * The JWT that the client last got from the server.
+     */
+    token: string;
+}

--- a/src/aux-server/server/directory/DirectoryService.spec.ts
+++ b/src/aux-server/server/directory/DirectoryService.spec.ts
@@ -28,7 +28,6 @@ describe('DirectoryService', () => {
         service = new DirectoryService(store, {
             secret: 'secret',
             webhook: null,
-            dbName: 'dbName',
         });
 
         require('axios').__reset();
@@ -142,7 +141,6 @@ describe('DirectoryService', () => {
             it('should send a post request to the webhook URL', async () => {
                 service = new DirectoryService(store, {
                     secret: 'secret',
-                    dbName: 'dbName',
                     webhook: 'http://www.example.com/test',
                 });
                 const entry: DirectoryUpdate = {
@@ -171,7 +169,6 @@ describe('DirectoryService', () => {
             it('should not send a post when no webhook is configured', async () => {
                 service = new DirectoryService(store, {
                     secret: 'secret',
-                    dbName: 'dbName',
                     webhook: null,
                 });
                 const entry: DirectoryUpdate = {
@@ -193,7 +190,6 @@ describe('DirectoryService', () => {
             it('should not send a post when neither IP address is updated', async () => {
                 service = new DirectoryService(store, {
                     secret: 'secret',
-                    dbName: 'dbName',
                     webhook: 'http://www.example.com/test',
                 });
                 await service.update({
@@ -224,7 +220,6 @@ describe('DirectoryService', () => {
             it('should send a post when the public IP address is updated', async () => {
                 service = new DirectoryService(store, {
                     secret: 'secret',
-                    dbName: 'dbName',
                     webhook: 'http://www.example.com/test',
                 });
                 await service.update({
@@ -262,7 +257,6 @@ describe('DirectoryService', () => {
             it('should send a post when the private IP address is updated', async () => {
                 service = new DirectoryService(store, {
                     secret: 'secret',
-                    dbName: 'dbName',
                     webhook: 'http://www.example.com/test',
                 });
                 await service.update({

--- a/src/aux-server/server/directory/DirectoryService.ts
+++ b/src/aux-server/server/directory/DirectoryService.ts
@@ -5,7 +5,7 @@ import { DirectoryUpdate, DirectoryUpdateSchema } from './DirectoryUpdate';
 import { DirectoryResult } from './DirectoryResult';
 import { compareSync, hashSync, genSaltSync } from 'bcryptjs';
 import { sign } from 'jsonwebtoken';
-import { DirectoryConfig } from '../config';
+import { DirectoryConfig, DirectoryServerConfig } from '../config';
 import axios from 'axios';
 
 /**
@@ -18,9 +18,9 @@ export const DEFAULT_TOKEN_EXPIRATION_TIME = 60 * 60 * 24;
  */
 export class DirectoryService {
     private _store: DirectoryStore;
-    private _config: DirectoryConfig;
+    private _config: DirectoryServerConfig;
 
-    constructor(store: DirectoryStore, config: DirectoryConfig) {
+    constructor(store: DirectoryStore, config: DirectoryServerConfig) {
         this._store = store;
         this._config = config;
     }

--- a/src/aux-server/server/directory/DirectoryStore.ts
+++ b/src/aux-server/server/directory/DirectoryStore.ts
@@ -1,4 +1,5 @@
 import { DirectoryEntry } from './DirectoryEntry';
+import { DirectoryClientSettings } from './DirectoryClientSettings';
 
 /**
  * Defines a store for directory values.
@@ -23,4 +24,16 @@ export interface DirectoryStore {
      * @param hash The hash.
      */
     findByHash(hash: string): Promise<DirectoryEntry>;
+
+    /**
+     * Gets the settings for the client.
+     * Returns null if no settings have been saved.
+     */
+    getClientSettings(): Promise<DirectoryClientSettings>;
+
+    /**
+     * Saves the given settings.
+     * @param settings The settings.
+     */
+    saveClientSettings(settings: DirectoryClientSettings): Promise<void>;
 }

--- a/src/aux-server/server/directory/MemoryDirectoryStore.ts
+++ b/src/aux-server/server/directory/MemoryDirectoryStore.ts
@@ -1,11 +1,13 @@
 import { DirectoryStore } from './DirectoryStore';
 import { DirectoryEntry } from './DirectoryEntry';
+import { DirectoryClientSettings } from './DirectoryClientSettings';
 
 /**
  * Defines a directory store which stores data in memory.
  */
 export class MemoryDirectoryStore implements DirectoryStore {
     private _map: Map<string, DirectoryEntry>;
+    private _settings: DirectoryClientSettings;
 
     constructor() {
         this._map = new Map();
@@ -24,5 +26,13 @@ export class MemoryDirectoryStore implements DirectoryStore {
 
     async findByHash(hash: string): Promise<DirectoryEntry> {
         return this._map.get(hash);
+    }
+
+    async getClientSettings(): Promise<DirectoryClientSettings> {
+        return this._settings;
+    }
+
+    async saveClientSettings(settings: DirectoryClientSettings): Promise<void> {
+        this._settings = settings;
     }
 }

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -52,6 +52,9 @@ import {
 import { BackupModule } from './modules';
 import { DirectoryService } from './directory/DirectoryService';
 import { MongoDBDirectoryStore } from './directory/MongoDBDirectoryStore';
+import { DirectoryStore } from './directory/DirectoryStore';
+import { DirectoryClient } from './directory/DirectoryClient';
+import { DirectoryClientSettings } from './directory/DirectoryClientSettings';
 
 const connect = pify(MongoClient.connect);
 
@@ -370,6 +373,8 @@ export class Server {
     private _channelManager: AuxChannelManager;
     private _adminChannel: AuxLoadedChannel;
     private _directory: DirectoryService;
+    private _directoryStore: DirectoryStore;
+    private _directoryClient: DirectoryClient;
 
     constructor(config: Config) {
         this._config = config;
@@ -478,71 +483,14 @@ export class Server {
             })
         );
 
-        if (this._config.directory.server) {
-            const directoryStore = new MongoDBDirectoryStore(
-                this._mongoClient,
-                this._config.directory.dbName
-            );
-            await directoryStore.init();
-            this._directory = new DirectoryService(
-                directoryStore,
-                this._config.directory.server
-            );
+        this._directoryStore = new MongoDBDirectoryStore(
+            this._mongoClient,
+            this._config.directory.dbName
+        );
+        await this._directoryStore.init();
 
-            this._app.get(
-                '/api/directory',
-                asyncMiddleware(async (req, res) => {
-                    const ip = req.ip;
-                    const result = await this._directory.findEntries(ip);
-
-                    if (result.type === 'query_results') {
-                        return res.send(
-                            result.entries.map(e => ({
-                                publicName: e.publicName,
-                                url: url.format({
-                                    protocol: req.protocol,
-                                    hostname: `${e.subhost}.${req.hostname}`,
-                                    port: this._config.httpPort,
-                                }),
-                            }))
-                        );
-                    } else if (result.type === 'not_authorized') {
-                        return res.sendStatus(403);
-                    } else {
-                        return res.sendStatus(500);
-                    }
-                })
-            );
-
-            this._app.put(
-                '/api/directory',
-                asyncMiddleware(async (req, res) => {
-                    const ip = req.ip;
-                    const result = await this._directory.update({
-                        key: req.body.key,
-                        password: req.body.password,
-                        publicName: req.body.publicName,
-                        privateIpAddress: req.body.privateIpAddress,
-                        publicIpAddress: ip,
-                    });
-
-                    if (result.type === 'entry_updated') {
-                        return res.send({
-                            token: result.token,
-                        });
-                    } else if (result.type === 'not_authorized') {
-                        return res.sendStatus(403);
-                    } else if (result.type === 'bad_request') {
-                        res.status(400);
-                        res.send({
-                            errors: result.errors,
-                        });
-                    } else {
-                        return res.sendStatus(500);
-                    }
-                })
-            );
-        }
+        await this._serveDirectory();
+        await this._startDirectoryClient();
 
         this._app.use(this._client.app);
 
@@ -555,10 +503,101 @@ export class Server {
         // });
     }
 
+    private async _serveDirectory() {
+        if (!this._config.directory.server) {
+            console.log(
+                '[Server] Disabling Directory Server because no config is available for it.'
+            );
+            return;
+        }
+
+        console.log('[Server] Starting Directory Server.');
+
+        this._directory = new DirectoryService(
+            this._directoryStore,
+            this._config.directory.server
+        );
+        this._app.get(
+            '/api/directory',
+            asyncMiddleware(async (req, res) => {
+                const ip = req.ip;
+                const result = await this._directory.findEntries(ip);
+                if (result.type === 'query_results') {
+                    return res.send(
+                        result.entries.map(e => ({
+                            publicName: e.publicName,
+                            url: url.format({
+                                protocol: req.protocol,
+                                hostname: `${e.subhost}.${req.hostname}`,
+                                port: this._config.httpPort,
+                            }),
+                        }))
+                    );
+                } else if (result.type === 'not_authorized') {
+                    return res.sendStatus(403);
+                } else {
+                    return res.sendStatus(500);
+                }
+            })
+        );
+        this._app.put(
+            '/api/directory',
+            asyncMiddleware(async (req, res) => {
+                const ip = req.ip;
+                const result = await this._directory.update({
+                    key: req.body.key,
+                    password: req.body.password,
+                    publicName: req.body.publicName,
+                    privateIpAddress: req.body.privateIpAddress,
+                    publicIpAddress: ip,
+                });
+                if (result.type === 'entry_updated') {
+                    return res.send({
+                        token: result.token,
+                    });
+                } else if (result.type === 'not_authorized') {
+                    return res.sendStatus(403);
+                } else if (result.type === 'bad_request') {
+                    res.status(400);
+                    res.send({
+                        errors: result.errors,
+                    });
+                } else {
+                    return res.sendStatus(500);
+                }
+            })
+        );
+    }
+
+    private async _startDirectoryClient() {
+        if (!this._config.directory.client) {
+            console.log(
+                '[Server] Disabling Directory Client because no config is available for it.'
+            );
+            return;
+        }
+
+        console.log(
+            `[Server] Configuring Directory Client for ${
+                this._config.directory.client.upstream
+            }`
+        );
+
+        this._directoryClient = new DirectoryClient(
+            this._directoryStore,
+            this._config.directory.client
+        );
+    }
+
     start() {
         this._http.listen(this._config.httpPort, () =>
             console.log(`Server listening on port ${this._config.httpPort}!`)
         );
+
+        if (this._directoryClient) {
+            console.log(`[Server] Starting Directory Client`);
+            this._directoryClient.init();
+        }
     }
 
     private async _configureSocketServices() {

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -478,7 +478,7 @@ export class Server {
             })
         );
 
-        if (this._config.directory) {
+        if (this._config.directory.server) {
             const directoryStore = new MongoDBDirectoryStore(
                 this._mongoClient,
                 this._config.directory.dbName
@@ -486,7 +486,7 @@ export class Server {
             await directoryStore.init();
             this._directory = new DirectoryService(
                 directoryStore,
-                this._config.directory
+                this._config.directory.server
             );
 
             this._app.get(


### PR DESCRIPTION
When merged, this PR will add a service that runs in the background which periodically sends basic information to the configured upstream directory.

By default, it is configured to send pings on start and every 5 minutes afterwards.
Here is a list of the information that is sent:

- `key`: The SHA-256 hash of the hostname plus the loopback interface's MAC address.
- `password`: The password that was generated on the device to authenticate to the directory.
- `publicName`: The hostname of the device.
- `privateIpAddress`: The IPv4 Address of the first non-loopback interface sorted by interface name. This is supposed to be the LAN IP that the device has.