### PR TITLE
Add support for specifying Proxy IP Addresses so Express can trust the headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # AUX Changelog
 
+## V0.9.34
+
+### Date: 9/10/2019
+
+### Changes:
+
+-   Improvements
+    -   Added the ability to set which IP Addresses should be trusted as reverse proxies.
+        -   Setting this value will allow the server to determine the actual IP Address of visiting users and which protocol they are actually using to load data.
+        -   Can be controlled with the `PROXY_IP_RANGE` environment variable.
+            -   Supports a single IP Address, or a CIDR IP Address range.
+
 ## V0.9.33
 
 ### Date: 9/10/2019

--- a/src/aux-server/server/config.dev.ts
+++ b/src/aux-server/server/config.dev.ts
@@ -36,6 +36,7 @@ const config: Config = {
         },
         dbName: 'aux-directory',
     },
+    proxy: null,
     dist: path.resolve(__dirname, '..', '..', 'aux-web', 'dist'),
 };
 

--- a/src/aux-server/server/config.prod.ts
+++ b/src/aux-server/server/config.prod.ts
@@ -11,6 +11,7 @@ const httpPort = parseInt(process.env.NODE_PORT) || 3000;
 const directoryTokenSecret = process.env.DIRECTORY_TOKEN_SECRET;
 const directoryWebhook = process.env.DIRECTORY_WEBHOOK;
 const directoryUpstream = process.env.UPSTREAM_DIRECTORY;
+const trustProxy = process.env.PROXY_IP_RANGE;
 
 const config: Config = {
     socket: {
@@ -53,6 +54,11 @@ const config: Config = {
             : null,
         dbName: 'aux-directory',
     },
+    proxy: trustProxy
+        ? {
+              trust: trustProxy,
+          }
+        : null,
     dist: path.resolve(__dirname, '..', '..', 'aux-web', 'dist'),
 };
 

--- a/src/aux-server/server/config.ts
+++ b/src/aux-server/server/config.ts
@@ -14,6 +14,7 @@ export interface Config {
     redis: RedisConfig;
     trees: CausalTreeServerConfig;
     directory: DirectoryConfig;
+    proxy: ProxyConfig;
     dist: string;
 }
 
@@ -59,4 +60,14 @@ export interface DirectoryClientConfig {
      * The base address of the directory that this AUXPlayer should upload its data to.
      */
     upstream: string;
+}
+
+/**
+ * The proxy config.
+ */
+export interface ProxyConfig {
+    /**
+     * The IP Address range of proxies that should be trusted.
+     */
+    trust: string;
 }

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -392,6 +392,10 @@ export class Server {
     }
 
     async configure() {
+        if (this._config.proxy && this._config.proxy.trust) {
+            this._app.set('trust proxy', this._config.proxy.trust);
+        }
+
         this._mongoClient = await connect(this._config.mongodb.url);
         this._store = new MongoDBTreeStore(
             this._mongoClient,
@@ -529,7 +533,6 @@ export class Server {
                             url: url.format({
                                 protocol: req.protocol,
                                 hostname: `${e.subhost}.${req.hostname}`,
-                                port: this._config.httpPort,
                             }),
                         }))
                     );


### PR DESCRIPTION
When merged, this PR will allow environment variables to specify which IP Addresses should be trusted as proxies. This allows the `X-Forwarded-For` and `X-Forwarded-Proto` headers to be used in the server which makes the directory function better.