### PR TITLE
Add support for automatically building a tunnel from a client to a proxy server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # AUX Changelog
 
+## V0.9.38
+
+### Date: TBD
+
+### Changes:
+
+-   Improvements
+    -   Added the ability for the directory client to automatically connect to an AUX Proxy.
+
 ## V0.9.37
 
 ### Date: 9/13/2019

--- a/src/aux-proxy/config.dev.ts
+++ b/src/aux-proxy/config.dev.ts
@@ -1,8 +1,8 @@
 import { Config } from './config';
 
 const config: Config = {
-    secret: 'secret',
-    httpPort: 3000,
+    secret: 'test',
+    httpPort: 3001,
     loginTimeout: 60,
     proxy: null,
     homeDir: '/home',

--- a/src/aux-proxy/package.json
+++ b/src/aux-proxy/package.json
@@ -27,7 +27,7 @@
         "url": "git+https://github.com/casual-simulation/aux.git"
     },
     "scripts": {
-        "build": "npm run webpack && npm run package",
+        "build": "npm run webpack",
         "webpack": "webpack --config webpack.config.js",
         "package": "docker build -t casualsimulation/aux-proxy -f Dockerfile .",
         "start": "node dist/main.js"

--- a/src/aux-proxy/package.json
+++ b/src/aux-proxy/package.json
@@ -39,8 +39,10 @@
         "url": "https://github.com/casual-simulation/aux/issues"
     },
     "dependencies": {
+        "@casual-simulation/tunnel": "^0.9.37",
         "express": "^4.16.4",
         "jsonwebtoken": "8.5.1",
-        "sshpk": "1.16.1"
+        "sshpk": "1.16.1",
+        "http-proxy": "1.17.0"
     }
 }

--- a/src/aux-proxy/package.json
+++ b/src/aux-proxy/package.json
@@ -27,7 +27,7 @@
         "url": "git+https://github.com/casual-simulation/aux.git"
     },
     "scripts": {
-        "build": "npm run webpack",
+        "build": "npm run webpack && npm run package",
         "webpack": "webpack --config webpack.config.js",
         "package": "docker build -t casualsimulation/aux-proxy -f Dockerfile .",
         "start": "node dist/main.js"
@@ -43,6 +43,8 @@
         "express": "^4.16.4",
         "jsonwebtoken": "8.5.1",
         "sshpk": "1.16.1",
-        "http-proxy": "1.17.0"
+        "http-proxy": "1.17.0",
+        "uuid": "^3.3.2",
+        "ws": "7.1.2"
     }
 }

--- a/src/aux-proxy/server.ts
+++ b/src/aux-proxy/server.ts
@@ -81,6 +81,18 @@ export class Server {
             }
         });
 
+        server.tunnelDropped.subscribe(r => {
+            if (r.direction === 'reverse') {
+                const decoded: { key: string } = <any>(
+                    verify(r.authorization, this._config.secret)
+                );
+
+                const host = decoded.key.substring(0, 32);
+                const external = `external-${host}`;
+                this._hostMap.delete(external);
+            }
+        });
+
         this._http.on(
             'upgrade',
             (request: IncomingMessage, socket: Socket, head: Buffer) => {

--- a/src/aux-proxy/server.ts
+++ b/src/aux-proxy/server.ts
@@ -98,9 +98,9 @@ export class Server {
             'upgrade',
             (request: IncomingMessage, socket: Socket, head: Buffer) => {
                 const url = requestUrl(request, 'https');
-                console.log('Upgrade', url);
-
-                const mapped = this._hostMap.get(url.hostname);
+                const domains = url.hostname.split('.');
+                const first = domains[0];
+                const mapped = this._hostMap.get(first);
                 if (mapped) {
                     const targetUrl = new URL(
                         request.url,
@@ -108,9 +108,7 @@ export class Server {
                     );
                     const target = targetUrl.href;
                     console.log(
-                        `[Server] Found host for ${
-                            url.host
-                        }. Forwarding to ${target}`
+                        `[Server] Found host for ${first}. Forwarding to ${target}`
                     );
                     this._proxy.ws(request, socket, head, {
                         target: target,
@@ -119,7 +117,7 @@ export class Server {
                     });
                 } else {
                     console.log(
-                        `[Server] Host not found, trying to setup tunnel...`
+                        `[Server] Host not found for ${first}, trying to setup tunnel...`
                     );
                     server.upgradeRequest(request, socket, head);
                 }
@@ -127,7 +125,8 @@ export class Server {
         );
 
         this._app.use('*', (req, res) => {
-            const host = req.hostname;
+            const domains = req.hostname.split('.');
+            const host = domains[0];
             const mapped = this._hostMap.get(host);
 
             if (mapped) {

--- a/src/aux-proxy/server.ts
+++ b/src/aux-proxy/server.ts
@@ -83,6 +83,7 @@ export class Server {
 
         server.tunnelDropped.subscribe(r => {
             if (r.direction === 'reverse') {
+                console.log('Reverse tunnel closed!');
                 const decoded: { key: string } = <any>(
                     verify(r.authorization, this._config.secret)
                 );

--- a/src/aux-proxy/webpack.config.js
+++ b/src/aux-proxy/webpack.config.js
@@ -13,7 +13,7 @@ const latestTag = childProcess
     .trim();
 
 module.exports = {
-    mode: 'production',
+    mode: 'development',
     devtool: 'none',
     entry: path.resolve(__dirname, 'index.ts'),
     target: 'node',

--- a/src/aux-server/package.json
+++ b/src/aux-server/package.json
@@ -54,6 +54,7 @@
         "@casual-simulation/crypto": "^0.9.7",
         "@casual-simulation/crypto-browser": "^0.9.8",
         "@casual-simulation/crypto-node": "^0.9.7",
+        "@casual-simulation/tunnel": "^0.9.37",
         "@chenfengyuan/vue-qrcode": "^1.0.0",
         "@hapi/joi": "15.1.1",
         "@juggle/resize-observer": "2.3.0",

--- a/src/aux-server/package.json
+++ b/src/aux-server/package.json
@@ -72,7 +72,7 @@
         "express": "^4.16.4",
         "filepond": "^3.8.2",
         "filepond-plugin-file-validate-type": "^1.2.1",
-        "http-proxy": "^1.17.0",
+        "http-proxy": "1.17.0",
         "jsbarcode": "3.11.0",
         "jsonwebtoken": "8.5.1",
         "jszip": "3.2.2",

--- a/src/aux-server/server/config.dev.ts
+++ b/src/aux-server/server/config.dev.ts
@@ -33,6 +33,7 @@ const config: Config = {
         },
         client: {
             upstream: 'http://localhost:3000',
+            tunnel: 'ws://localhost:3001',
         },
         dbName: 'aux-directory',
     },

--- a/src/aux-server/server/config.dev.ts
+++ b/src/aux-server/server/config.dev.ts
@@ -33,7 +33,7 @@ const config: Config = {
         },
         client: {
             upstream: 'http://localhost:3000',
-            tunnel: 'ws://localhost:3001',
+            tunnel: null,
         },
         dbName: 'aux-directory',
     },

--- a/src/aux-server/server/config.prod.ts
+++ b/src/aux-server/server/config.prod.ts
@@ -11,6 +11,7 @@ const httpPort = parseInt(process.env.NODE_PORT) || 3000;
 const directoryTokenSecret = process.env.DIRECTORY_TOKEN_SECRET;
 const directoryWebhook = process.env.DIRECTORY_WEBHOOK;
 const directoryUpstream = process.env.UPSTREAM_DIRECTORY;
+const tunnel = process.env.PROXY_TUNNEL;
 const trustProxy = process.env.PROXY_IP_RANGE;
 
 const config: Config = {
@@ -50,6 +51,7 @@ const config: Config = {
         client: directoryUpstream
             ? {
                   upstream: directoryUpstream,
+                  tunnel: tunnel,
               }
             : null,
         dbName: 'aux-directory',

--- a/src/aux-server/server/config.ts
+++ b/src/aux-server/server/config.ts
@@ -60,6 +60,11 @@ export interface DirectoryClientConfig {
      * The base address of the directory that this AUXPlayer should upload its data to.
      */
     upstream: string;
+
+    /**
+     * The base address of the tunnel server that the AUXPlayer should connect to.
+     */
+    tunnel: string;
 }
 
 /**

--- a/src/aux-server/server/directory/DirectoryClient.spec.ts
+++ b/src/aux-server/server/directory/DirectoryClient.spec.ts
@@ -25,10 +25,15 @@ describe('DirectoryClient', () => {
         await store.init();
 
         tunnel = new TestClient();
-        client = new DirectoryClient(store, tunnel, {
-            upstream: 'https://example.com',
-            tunnel: null,
-        });
+        client = new DirectoryClient(
+            store,
+            tunnel,
+            {
+                upstream: 'https://example.com',
+                tunnel: null,
+            },
+            3000
+        );
     });
 
     describe('init()', () => {

--- a/src/aux-server/server/directory/DirectoryClient.spec.ts
+++ b/src/aux-server/server/directory/DirectoryClient.spec.ts
@@ -491,6 +491,45 @@ describe('DirectoryClient', () => {
             });
         });
 
+        it('should open a new tunnel after 5 seconds if the last one closed', async () => {
+            require('axios').__setResponse({
+                data: {
+                    token: 'token',
+                },
+            });
+
+            let requests: TestRequest[] = [];
+            tunnel.requests.subscribe(r => requests.push(r));
+
+            await client.init();
+
+            expect(requests).toHaveLength(1);
+            expect(requests[0].request).toEqual({
+                direction: 'reverse',
+                token: 'token',
+                localHost: '127.0.0.1',
+                localPort: 3000,
+            });
+
+            requests[0].accept();
+
+            jest.advanceTimersByTime(1000);
+
+            requests[0].close();
+
+            expect(requests).toHaveLength(1);
+
+            jest.advanceTimersByTime(5000);
+
+            expect(requests).toHaveLength(2);
+            expect(requests[1].request).toEqual({
+                direction: 'reverse',
+                token: 'token',
+                localHost: '127.0.0.1',
+                localPort: 3000,
+            });
+        });
+
         it('should retry with the new token', async () => {
             require('axios').__setResponse({
                 data: {

--- a/src/aux-server/server/directory/DirectoryClient.spec.ts
+++ b/src/aux-server/server/directory/DirectoryClient.spec.ts
@@ -2,6 +2,7 @@ import { DirectoryClient } from './DirectoryClient';
 import { DirectoryStore } from './DirectoryStore';
 import { MemoryDirectoryStore } from './MemoryDirectoryStore';
 import { DEFAULT_PING_INTERVAL } from './DirectoryClientSettings';
+import { TestClient, TestRequest } from '@casual-simulation/tunnel';
 
 console.error = jest.fn();
 console.log = jest.fn();
@@ -11,6 +12,7 @@ jest.mock('os');
 jest.useFakeTimers();
 
 describe('DirectoryClient', () => {
+    let tunnel: TestClient;
     let client: DirectoryClient;
     let store: DirectoryStore;
 
@@ -22,8 +24,10 @@ describe('DirectoryClient', () => {
 
         await store.init();
 
-        client = new DirectoryClient(store, {
+        tunnel = new TestClient();
+        client = new DirectoryClient(store, tunnel, {
             upstream: 'https://example.com',
+            tunnel: null,
         });
     });
 
@@ -359,6 +363,172 @@ describe('DirectoryClient', () => {
 
             let [url, request] = require('axios').__getLastPut();
             expect(request.privateIpAddress).toEqual('172.16.99.1');
+        });
+    });
+
+    describe('tunnel', () => {
+        beforeEach(async () => {
+            require('axios').__reset();
+            require('os').__setInterfaces({
+                eth0: [
+                    {
+                        address: '192.168.1.65',
+                        family: 'IPv4',
+                        internal: false,
+                        max: 'ethernet:address',
+                    },
+                ],
+            });
+
+            await store.saveClientSettings({
+                pingInterval: 5,
+                token: null,
+                password: 'def',
+                key: 'test',
+            });
+        });
+
+        it('should open a tunnel after getting a token', async () => {
+            require('axios').__setResponse({
+                data: {
+                    token: 'token',
+                },
+            });
+
+            let requests: TestRequest[] = [];
+            tunnel.requests.subscribe(r => requests.push(r));
+
+            await client.init();
+
+            expect(requests).toHaveLength(1);
+            expect(requests[0].request).toEqual({
+                direction: 'reverse',
+                token: 'token',
+                localHost: '127.0.0.1',
+                localPort: 3000,
+            });
+        });
+
+        it('should not open a tunnel if the token is null', async () => {
+            require('axios').__setResponse({
+                data: {
+                    token: null,
+                },
+            });
+
+            let requests: TestRequest[] = [];
+            tunnel.requests.subscribe(r => requests.push(r));
+
+            await client.init();
+
+            expect(requests).toHaveLength(0);
+        });
+
+        it('should not open a tunnel if one is already open', async () => {
+            require('axios').__setResponse({
+                data: {
+                    token: 'token',
+                },
+            });
+
+            let requests: TestRequest[] = [];
+            tunnel.requests.subscribe(r => requests.push(r));
+
+            await client.init();
+
+            expect(requests).toHaveLength(1);
+            expect(requests[0].request).toEqual({
+                direction: 'reverse',
+                token: 'token',
+                localHost: '127.0.0.1',
+                localPort: 3000,
+            });
+
+            requests[0].accept();
+
+            // 5 minutes + 100ms
+            jest.advanceTimersByTime(5 * 60 * 1000 + 100);
+
+            expect(requests).toHaveLength(1);
+        });
+
+        it('should open a new tunnel after 5 seconds if the last one failed', async () => {
+            require('axios').__setResponse({
+                data: {
+                    token: 'token',
+                },
+            });
+
+            let requests: TestRequest[] = [];
+            tunnel.requests.subscribe(r => requests.push(r));
+
+            await client.init();
+
+            expect(requests).toHaveLength(1);
+            expect(requests[0].request).toEqual({
+                direction: 'reverse',
+                token: 'token',
+                localHost: '127.0.0.1',
+                localPort: 3000,
+            });
+
+            requests[0].accept();
+
+            jest.advanceTimersByTime(1000);
+
+            requests[0].error(new Error('Tunnel failed.'));
+
+            expect(requests).toHaveLength(1);
+
+            jest.advanceTimersByTime(5000);
+
+            expect(requests).toHaveLength(2);
+            expect(requests[1].request).toEqual({
+                direction: 'reverse',
+                token: 'token',
+                localHost: '127.0.0.1',
+                localPort: 3000,
+            });
+        });
+
+        it('should retry with the new token', async () => {
+            require('axios').__setResponse({
+                data: {
+                    token: 'token',
+                },
+            });
+
+            let requests: TestRequest[] = [];
+            tunnel.requests.subscribe(r => requests.push(r));
+
+            await client.init();
+
+            expect(requests).toHaveLength(1);
+
+            requests[0].accept();
+
+            require('axios').__setResponse({
+                data: {
+                    token: 'token2',
+                },
+            });
+
+            jest.advanceTimersByTime(5 * 60 * 1000 + 100);
+            await client.pendingOperations;
+
+            requests[0].error(new Error('Tunnel failed.'));
+
+            expect(requests).toHaveLength(1);
+
+            jest.advanceTimersByTime(5000);
+
+            expect(requests).toHaveLength(2);
+            expect(requests[1].request).toEqual({
+                direction: 'reverse',
+                token: 'token2',
+                localHost: '127.0.0.1',
+                localPort: 3000,
+            });
         });
     });
 });

--- a/src/aux-server/server/directory/DirectoryClient.ts
+++ b/src/aux-server/server/directory/DirectoryClient.ts
@@ -9,6 +9,9 @@ import { hostname, networkInterfaces } from 'os';
 import { sha256 } from 'sha.js';
 import axios from 'axios';
 import { sortBy } from 'lodash';
+import { SubscriptionLike, timer, Observable, defer } from 'rxjs';
+import { retryWhen, delayWhen, finalize, tap } from 'rxjs/operators';
+import { WebSocketClient, TunnelClient } from '@casual-simulation/tunnel';
 
 /**
  * Defines a client for the directory.
@@ -18,9 +21,21 @@ export class DirectoryClient {
     private _store: DirectoryStore;
     private _timeoutId: NodeJS.Timeout;
     private _settings: DirectoryClientSettings;
+    private _tunnelClient: TunnelClient;
+    private _tunnelSub: SubscriptionLike;
+    private _pendingPing: Promise<any>;
 
-    constructor(store: DirectoryStore, config: DirectoryClientConfig) {
+    get pendingOperations(): Promise<void> {
+        return this._pendingPing || Promise.resolve();
+    }
+
+    constructor(
+        store: DirectoryStore,
+        tunnelClient: TunnelClient,
+        config: DirectoryClientConfig
+    ) {
         this._store = store;
+        this._tunnelClient = tunnelClient;
         this._config = config;
     }
 
@@ -49,8 +64,8 @@ export class DirectoryClient {
         if (this._timeoutId) {
             clearInterval(this._timeoutId);
         }
-        this._timeoutId = setInterval(async () => {
-            await this._ping();
+        this._timeoutId = setInterval(() => {
+            this._pendingPing = this._ping();
         }, this._settings.pingInterval * 60 * 1000);
     }
 
@@ -81,10 +96,56 @@ export class DirectoryClient {
                 this._settings.token = data.token;
 
                 await this._store.saveClientSettings(this._settings);
+                this._openTunnel();
             }
         } catch (ex) {
             console.error('Unable to ping upstream directory.', ex);
         }
+    }
+
+    private _openTunnel() {
+        if (!this._tunnelClient) {
+            return;
+        }
+
+        if (!this._settings.token) {
+            return;
+        }
+
+        if (this._tunnelSub) {
+            return;
+        }
+
+        const deferred = defer(() => {
+            return this._tunnelClient.open({
+                direction: 'reverse',
+                token: this._settings.token,
+                localHost: '127.0.0.1',
+                localPort: 3000, // TODO: Config
+            });
+        });
+
+        this._tunnelSub = deferred
+            .pipe(
+                tap(
+                    x => console.log('[DirectoryClient] Tunnel Connected!'),
+                    err => console.error(err)
+                ),
+                retryWhen(errors =>
+                    errors.pipe(
+                        tap(x =>
+                            console.log(
+                                '[DirectoryClient] Disconnected from tunnel. Retrying in 5 seconds...'
+                            )
+                        ),
+                        delayWhen(() => timer(5000))
+                    )
+                ),
+                finalize(() => (this._tunnelSub = null))
+            )
+            .subscribe(null, err => {
+                console.log(err);
+            });
     }
 }
 

--- a/src/aux-server/server/directory/DirectoryClient.ts
+++ b/src/aux-server/server/directory/DirectoryClient.ts
@@ -38,6 +38,7 @@ export class DirectoryClient {
     private _tunnelClient: TunnelClient;
     private _tunnelSub: SubscriptionLike;
     private _pendingPing: Promise<any>;
+    private _httpPort: number;
 
     get pendingOperations(): Promise<void> {
         return this._pendingPing || Promise.resolve();
@@ -46,11 +47,13 @@ export class DirectoryClient {
     constructor(
         store: DirectoryStore,
         tunnelClient: TunnelClient,
-        config: DirectoryClientConfig
+        config: DirectoryClientConfig,
+        httpPort: number
     ) {
         this._store = store;
         this._tunnelClient = tunnelClient;
         this._config = config;
+        this._httpPort = httpPort;
     }
 
     async init(): Promise<void> {
@@ -135,7 +138,7 @@ export class DirectoryClient {
                 direction: 'reverse',
                 token: this._settings.token,
                 localHost: '127.0.0.1',
-                localPort: 3000, // TODO: Config
+                localPort: this._httpPort, // TODO: Config
             });
         });
 

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -55,6 +55,7 @@ import { MongoDBDirectoryStore } from './directory/MongoDBDirectoryStore';
 import { DirectoryStore } from './directory/DirectoryStore';
 import { DirectoryClient } from './directory/DirectoryClient';
 import { DirectoryClientSettings } from './directory/DirectoryClientSettings';
+import { WebSocketClient } from '@casual-simulation/tunnel';
 
 const connect = pify(MongoClient.connect);
 
@@ -588,6 +589,9 @@ export class Server {
 
         this._directoryClient = new DirectoryClient(
             this._directoryStore,
+            this._config.directory.client.tunnel
+                ? new WebSocketClient(this._config.directory.client.tunnel)
+                : null,
             this._config.directory.client
         );
     }

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -600,7 +600,8 @@ export class Server {
         this._directoryClient = new DirectoryClient(
             this._directoryStore,
             tunnelClient,
-            this._config.directory.client
+            this._config.directory.client,
+            this._config.httpPort
         );
     }
 

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -587,11 +587,19 @@ export class Server {
             }`
         );
 
+        const tunnelClient = this._config.directory.client.tunnel
+            ? new WebSocketClient(this._config.directory.client.tunnel)
+            : null;
+
+        if (!tunnelClient) {
+            console.log(
+                '[Server] Disabling tunneling because there is no config available for it.'
+            );
+        }
+
         this._directoryClient = new DirectoryClient(
             this._directoryStore,
-            this._config.directory.client.tunnel
-                ? new WebSocketClient(this._config.directory.client.tunnel)
-                : null,
+            tunnelClient,
             this._config.directory.client
         );
     }

--- a/src/tunnel/bin/tunnel.ts
+++ b/src/tunnel/bin/tunnel.ts
@@ -31,17 +31,19 @@ program
 
         let o: Observable<TunnelMessage>;
         if (cmd.reverse) {
+            const remotePort = parseInt(cmd.reverse);
             o = client.open({
                 direction: 'reverse',
                 localPort: cmd.port,
                 localHost: cmd.host,
-                remotePort: cmd.reverse || 8081,
+                remotePort: remotePort || 8081,
                 token: cmd.auth,
             });
         } else {
+            const localPort = parseInt(cmd.forward);
             o = client.open({
                 direction: 'forward',
-                localPort: cmd.forward || 8081,
+                localPort: localPort || 8081,
                 remoteHost: cmd.host,
                 remotePort: cmd.port,
                 token: cmd.auth,

--- a/src/tunnel/index.ts
+++ b/src/tunnel/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/src/tunnel/src/TunnelServer.ts
+++ b/src/tunnel/src/TunnelServer.ts
@@ -28,5 +28,10 @@ export interface TunnelServer extends SubscriptionLike {
      * Gets an observable which resolves whenever a new tunnel is accepted and
      * configured by the server.
      */
-    // tunnelAccepted: Observable<TunnelRequest>;
+    tunnelAccepted: Observable<TunnelRequest>;
+
+    /**
+     * Gets an observable which resolves whenever a tunnel is dropped.
+     */
+    tunnelDropped: Observable<TunnelRequest>;
 }

--- a/src/tunnel/src/index.ts
+++ b/src/tunnel/src/index.ts
@@ -1,3 +1,4 @@
 export * from './TunnelClient';
 export * from './TunnelServer';
 export * from './websocket';
+export * from './test';

--- a/src/tunnel/src/test/TestClient.ts
+++ b/src/tunnel/src/test/TestClient.ts
@@ -1,0 +1,43 @@
+import { TunnelClient } from '../TunnelClient';
+import { TunnelRequest } from '../ClientTunnelRequest';
+import { TunnelMessage } from '../TunnelResponse';
+import { Observable, Observer, Subject } from 'rxjs';
+
+export interface TestRequest {
+    accept(): void;
+    close(): void;
+    error(error: any): void;
+    request: TunnelRequest;
+}
+
+/**
+ * Defines a tunnel client that can be used for testing.
+ */
+export class TestClient implements TunnelClient {
+    private _requests: Subject<TestRequest> = new Subject();
+
+    get requests(): Observable<TestRequest> {
+        return this._requests;
+    }
+
+    open(request: TunnelRequest): Observable<TunnelMessage> {
+        return Observable.create((observer: Observer<TunnelMessage>) => {
+            const req: TestRequest = {
+                request: request,
+                accept() {
+                    observer.next({
+                        type: 'connected',
+                    });
+                },
+                error(e) {
+                    observer.error(e);
+                },
+                close() {
+                    observer.complete();
+                },
+            };
+
+            this._requests.next(req);
+        });
+    }
+}

--- a/src/tunnel/src/test/index.ts
+++ b/src/tunnel/src/test/index.ts
@@ -1,0 +1,1 @@
+export * from './TestClient';

--- a/src/tunnel/src/websocket/WebSocketClient.ts
+++ b/src/tunnel/src/websocket/WebSocketClient.ts
@@ -10,6 +10,7 @@ import {
     takeUntil,
     last,
     publish,
+    startWith,
 } from 'rxjs/operators';
 import { TunnelMessage } from '../TunnelResponse';
 import {
@@ -106,6 +107,9 @@ function reverseRequest(
                             type: 'connected',
                         }
                 ),
+                startWith(<TunnelMessage>{
+                    type: 'connected',
+                }),
 
                 // Re-subscribe to the messages observable
                 // if a connection fails

--- a/src/tunnel/src/websocket/WebSocketClient.ts
+++ b/src/tunnel/src/websocket/WebSocketClient.ts
@@ -1,5 +1,6 @@
 import { TunnelClient } from '../TunnelClient';
 import { Observable, Observer } from 'rxjs';
+import { map, flatMap, tap, filter, retry } from 'rxjs/operators';
 import { TunnelMessage } from '../TunnelResponse';
 import {
     TunnelRequest,
@@ -7,8 +8,9 @@ import {
     ReverseTunnelRequest,
 } from '../ClientTunnelRequest';
 import WebSocket from 'ws';
-import { createServer, connect } from 'net';
+import { createServer } from 'net';
 import { wrap } from './WebSocket';
+import { listen, cleanup, websocket, messages, connect } from './utils';
 
 export class WebSocketClient implements TunnelClient {
     private _host: string;
@@ -30,120 +32,149 @@ function reverseRequest(
     request: ReverseTunnelRequest,
     host: string
 ): Observable<TunnelMessage> {
-    return Observable.create((observer: Observer<TunnelMessage>) => {
-        console.log('Create');
-        let url = new URL('/reverse', host);
-        url.search = `port=${encodeURIComponent(
-            request.remotePort.toString()
-        )}`;
+    let url = new URL('/reverse', host);
+    url.search = `port=${encodeURIComponent(request.remotePort.toString())}`;
 
-        const ws = new WebSocket(url.href, {
-            headers: {
-                Authorization: 'Bearer ' + request.token,
-            },
-        });
-
-        ws.on('message', data => {
-            if (typeof data === 'string') {
-                if (data.startsWith('NewConnection:')) {
-                    const id = data.substring('NewConnection:'.length);
-                    console.log('New Connection!', id);
-
+    return websocket(url.href, {
+        headers: {
+            Authorization: 'Bearer ' + request.token,
+        },
+    }).pipe(
+        flatMap(ws => {
+            return messages(ws).pipe(
+                filter(
+                    message =>
+                        typeof message === 'string' &&
+                        message.startsWith('NewConnection:')
+                ),
+                map(message => {
+                    const id = (<string>message).substring(
+                        'NewConnection:'.length
+                    );
                     let url = new URL('/connect', host);
                     url.search = `id=${encodeURIComponent(id)}`;
-
-                    const tcp = connect(
-                        {
+                    return url;
+                }),
+                flatMap(
+                    () =>
+                        connect({
                             host: request.localHost,
                             port: request.localPort,
-                        },
-                        () => {
-                            const client = new WebSocket(url.href, {
-                                headers: {
-                                    Authorization: 'Bearer ' + request.token,
-                                },
-                            });
-
-                            client.on('open', () => {
-                                const stream = wrap(client);
-                                tcp.pipe(stream).pipe(tcp);
-                                observer.next({
-                                    type: 'connected',
-                                });
-                            });
-
-                            client.on('error', err => {
-                                observer.error(err);
-                                tcp.destroy();
-                                client.close();
-                            });
+                        }),
+                    (url, connection) => ({ url, connection })
+                ),
+                flatMap(
+                    ({ url }) => {
+                        return websocket(url.href, {
+                            headers: {
+                                Authorization: 'Bearer ' + request.token,
+                            },
+                        });
+                    },
+                    (extra, ws) => ({ ...extra, ws })
+                ),
+                tap(({ connection, ws }) => {
+                    const wsStream = wrap(ws);
+                    wsStream.pipe(connection).pipe(wsStream);
+                }),
+                map(
+                    _ =>
+                        <TunnelMessage>{
+                            type: 'connected',
                         }
-                    );
+                ),
 
-                    tcp.on('error', err => {
-                        observer.error(err);
-                        tcp.destroy();
-                    });
-                }
-            }
-        });
-    });
+                // Re-subscribe to the messages observable
+                // if a connection fails
+                retry()
+            );
+        })
+    );
+
+    // return Observable.create((observer: Observer<TunnelMessage>) => {
+    //     console.log('Create');
+
+    //     const ws = new WebSocket(url.href, {
+    //         headers: {
+    //             Authorization: 'Bearer ' + request.token,
+    //         },
+    //     });
+
+    //     ws.on('message', data => {
+    //         if (typeof data === 'string') {
+    //             if (data.startsWith('NewConnection:')) {
+    //                 const id = data.substring('NewConnection:'.length);
+    //                 console.log('New Connection!', id);
+
+    //                 let url = new URL('/connect', host);
+    //                 url.search = `id=${encodeURIComponent(id)}`;
+
+    //                 const tcp = connect(
+    //                     {
+    //                         host: request.localHost,
+    //                         port: request.localPort,
+    //                     },
+    //                     () => {
+    //                         const client = new WebSocket(url.href, {
+    //                             headers: {
+    //                                 Authorization: 'Bearer ' + request.token,
+    //                             },
+    //                         });
+
+    //                         client.on('open', () => {
+    //                             const stream = wrap(client);
+    //                             tcp.pipe(stream).pipe(tcp);
+    //                             observer.next({
+    //                                 type: 'connected',
+    //                             });
+    //                         });
+
+    //                         client.on('error', err => {
+    //                             observer.error(err);
+    //                             tcp.destroy();
+    //                             client.close();
+    //                         });
+    //                     }
+    //                 );
+
+    //                 tcp.on('error', err => {
+    //                     observer.error(err);
+    //                     tcp.destroy();
+    //                 });
+    //             }
+    //         }
+    //     });
+    // });
 }
 
 function forwardRequest(
     request: ForwardTunnelRequest,
     host: string
 ): Observable<TunnelMessage> {
-    return Observable.create((observer: Observer<TunnelMessage>) => {
-        console.log('Create');
-        let url = new URL('/forward', host);
-        url.search = `host=${encodeURIComponent(
-            request.remoteHost
-        )}&port=${encodeURIComponent(request.remotePort.toString())}`;
+    let url = new URL('/forward', host);
+    url.search = `host=${encodeURIComponent(
+        request.remoteHost
+    )}&port=${encodeURIComponent(request.remotePort.toString())}`;
 
-        const server = createServer(c => {
-            console.log('[WSC] Recieved connection!');
-            const ws = new WebSocket(url.href, {
-                headers: {
-                    Authorization: 'Bearer ' + request.token,
-                },
-            });
+    const server = createServer();
 
-            ws.on('open', () => {
-                const wsStream = wrap(ws);
-                wsStream.on('error', err => {
-                    c.destroy();
-                    observer.error(err);
-                });
-                wsStream.pipe(c).pipe(wsStream);
-                observer.next({
-                    type: 'connected',
-                });
-            });
-
-            ws.on('close', () => {
-                c.destroy();
-                observer.complete();
-            });
-
-            ws.on('error', err => {
-                c.destroy();
-                observer.error(err);
-            });
-
-            c.on('error', err => {
-                ws.close();
-                observer.error(err);
-            });
-        });
-
-        server.listen(request.localPort);
-        console.log(
-            '[WSC] Waiting for connections to ' + request.localPort + '...'
-        );
-
-        server.on('error', err => {
-            observer.error(err);
-        });
-    });
+    return listen(server, request.localPort).pipe(
+        flatMap(connection => cleanup(connection)),
+        flatMap(
+            _ =>
+                websocket(url.href, {
+                    headers: {
+                        Authorization: 'Bearer ' + request.token,
+                    },
+                }),
+            (connection, ws) => ({ connection, ws })
+        ),
+        tap(({ connection, ws }) => {
+            const wsStream = wrap(ws);
+            wsStream.pipe(connection).pipe(wsStream);
+        }),
+        map(_ => ({
+            type: 'connected',
+        }))
+    );
 }

--- a/src/tunnel/src/websocket/WebSocketServer.ts
+++ b/src/tunnel/src/websocket/WebSocketServer.ts
@@ -148,6 +148,7 @@ export class WebSocketServer implements TunnelServer {
                 ws.close();
             });
             const s = connection.pipe(wsStream).pipe(connection);
+            connection.resume();
 
             s.on('error', e => {
                 console.error('Pipe error', e);
@@ -174,6 +175,7 @@ export class WebSocketServer implements TunnelServer {
         this._server.handleUpgrade(req, socket, head, ws => {
             const server = createServer(c => {
                 const id = uuid();
+                c.pause();
                 this._map.set(id, c);
                 ws.send('NewConnection:' + id);
             });

--- a/src/tunnel/src/websocket/WebSocketServer.ts
+++ b/src/tunnel/src/websocket/WebSocketServer.ts
@@ -157,8 +157,8 @@ export class WebSocketServer implements TunnelServer {
         }
 
         const upgrade = handleUpgrade(this._server, req, socket, head).pipe(
-            share()
-        );
+            publish()
+        ) as ConnectableObservable<WebSocket>;
 
         const observable = upgrade.pipe(
             tap(ws => {
@@ -177,6 +177,8 @@ export class WebSocketServer implements TunnelServer {
         observable.subscribe(null, err => {
             console.error('Connection error:', err);
         });
+
+        upgrade.connect();
     }
 
     private _reverseUpgrade(

--- a/src/tunnel/src/websocket/index.ts
+++ b/src/tunnel/src/websocket/index.ts
@@ -1,2 +1,3 @@
 export * from './WebSocketClient';
 export * from './WebSocketServer';
+export * from './utils';

--- a/src/tunnel/src/websocket/utils.ts
+++ b/src/tunnel/src/websocket/utils.ts
@@ -1,4 +1,13 @@
 import { IncomingMessage } from 'http';
+import { Observable, Observer, fromEventPattern } from 'rxjs';
+import {
+    Socket,
+    createServer,
+    Server,
+    NetConnectOpts,
+    connect as netConnect,
+} from 'net';
+import WebSocket from 'ws';
 
 /**
  * Calculates the full request URL for the given message.
@@ -10,4 +19,116 @@ export function requestUrl(request: IncomingMessage, protocol: string): URL {
     const host = request.headers.host;
 
     return new URL(path, `${protocol}://${host}`);
+}
+
+/**
+ * Opens a socket connection.
+ * @param options The options.
+ */
+export function connect(options: NetConnectOpts): Observable<Socket> {
+    return Observable.create((observer: Observer<Socket>) => {
+        const tcp = netConnect(options, () => {
+            observer.next(tcp);
+        });
+
+        tcp.on('close', () => {
+            observer.complete();
+        });
+
+        tcp.on('error', err => {
+            observer.error(err);
+        });
+
+        return () => {
+            tcp.destroy();
+        };
+    });
+}
+
+/**
+ * Listens for connections with the given server on the given port.
+ * @param server The server.
+ * @param port The port to listen on.
+ */
+export function listen(server: Server, port?: number): Observable<Socket> {
+    return Observable.create((observer: Observer<Socket>) => {
+        server.on('connection', socket => {
+            observer.next(socket);
+        });
+
+        server.on('error', err => {
+            server.close();
+            observer.error(err);
+        });
+
+        server.listen(port);
+
+        return () => {
+            server.close();
+        };
+    });
+}
+
+/**
+ * Wraps the given socket in an observable.
+ * @param connection The socket to wrap.
+ */
+export function cleanup(socket: Socket): Observable<Socket> {
+    return Observable.create((observer: Observer<Socket>) => {
+        socket.on('close', () => {
+            observer.complete();
+        });
+
+        socket.on('error', err => {
+            socket.destroy();
+            observer.error(err);
+        });
+
+        observer.next(socket);
+
+        return () => {
+            socket.destroy();
+        };
+    });
+}
+
+/**
+ * Opens a websocket connection to the given address.
+ * @param address The address to open the connection to.
+ * @param options The options to use.
+ */
+export function websocket(
+    address: string,
+    options?: WebSocket.ClientOptions
+): Observable<WebSocket> {
+    return Observable.create((observer: Observer<WebSocket>) => {
+        const socket = new WebSocket(address, options);
+
+        socket.on('open', () => {
+            observer.next(socket);
+        });
+
+        socket.on('close', () => {
+            observer.complete();
+        });
+
+        socket.on('error', err => {
+            observer.error(err);
+        });
+
+        return () => {
+            socket.close();
+        };
+    });
+}
+
+/**
+ * Gets an observable list of messages from the given websocket.
+ * @param websocket The websocket.
+ */
+export function messages(websocket: WebSocket): Observable<WebSocket.Data> {
+    return fromEventPattern(
+        h => websocket.on('message', h),
+        h => websocket.off('message', h)
+    );
 }

--- a/src/tunnel/src/websocket/utils.ts
+++ b/src/tunnel/src/websocket/utils.ts
@@ -8,6 +8,7 @@ import {
     connect as netConnect,
 } from 'net';
 import WebSocket from 'ws';
+import { takeUntil, last } from 'rxjs/operators';
 
 /**
  * Calculates the full request URL for the given message.
@@ -168,4 +169,8 @@ export function messages(websocket: WebSocket): Observable<WebSocket.Data> {
         h => websocket.on('message', h),
         h => websocket.off('message', h)
     );
+}
+
+export function completeWith<T>(observable: Observable<any>) {
+    return takeUntil<T>(observable.pipe(last()));
 }

--- a/src/tunnel/src/websocket/utils.ts
+++ b/src/tunnel/src/websocket/utils.ts
@@ -1,0 +1,13 @@
+import { IncomingMessage } from 'http';
+
+/**
+ * Calculates the full request URL for the given message.
+ * @param request The request.
+ * @param protocol The protocol.
+ */
+export function requestUrl(request: IncomingMessage, protocol: string): URL {
+    const path = request.url;
+    const host = request.headers.host;
+
+    return new URL(path, `${protocol}://${host}`);
+}


### PR DESCRIPTION
When merged, this PR will add the ability for the directory client to initiate a tunnel connection with an `aux-proxy` server. In effect, this lets AUX servers inside a private network be reachable from outside the network as long as the following is true:

- HTTP and WebSocket requests are made to the proxy. (DNS records point to the proxy server) 
- The first subdomain part matches the key of the directory entry in the following form: `external-{key}`.
- The directory client has an active connection to the server.