### PR TITLE
Add the ability to send and receive webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # AUX Changelog
 
+## V0.9.41
+
+### Date: TBD
+
+### Changes:
+
+-   Improvements
+    -   Added the ability to send and receive webhooks.
+        -   Send webhooks using the following functions:
+            -   `webhook(options)` - options is an object that takes the following properties:
+                -   `method` - The HTTP Method that should be used for the request.
+                -   `url` - The URL that the request should be made to.
+                -   `responseShout` - (Optional) The shout that should happen when a response is received from the server.
+                -   `headers` - (Optional) The HTTP headers that should be sent with the request.
+                -   `data` - (Optional) The data that should be sent with the request.
+            -   `webhook.post(url, data, options)` - Sends a HTTP Post request.
+                -   `url` - The URL that the request should be made to.
+                -   `data` - (Optional) The data that should be sent with the request.
+                -   `options` - (Optional) An object that takes the following properties:
+                    -   `responseShout` - (Optional) The shout that should happen when a response is received from the server.
+                    -   `headers` - (Optional) The headers that should be sent with the request.
+
 ## V0.9.40
 
 ### Date: 09/20/2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
                 -   `options` - (Optional) An object that takes the following properties:
                     -   `responseShout` - (Optional) The shout that should happen when a response is received from the server.
                     -   `headers` - (Optional) The headers that should be sent with the request.
+        -   Receive webhooks by registering a handler for the `onWebhook()` action and send requests to `https://auxplayer.com/{context}/{channel}/whatever-you-want`.
+            -   `onWebhook()` is shouted to the channel that the request was made to and `that` is an object with the following properties:
+                -   `method` - The HTTP Method that the request was made with.
+                -   `url` - The URL that the request was made to.
+                -   `data` - The JSON data that the request included.
+                -   `headers` - The HTTP headers that were included with the request.
 
 ## V0.9.40
 

--- a/src/aux-common/Files/FileCalculations.ts
+++ b/src/aux-common/Files/FileCalculations.ts
@@ -159,6 +159,11 @@ export const ON_PAYMENT_SUCCESSFUL_ACTION_NAME: string = 'onPaymentSuccessful';
 export const ON_PAYMENT_FAILED_ACTION_NAME: string = 'onPaymentFailed';
 
 /**
+ * The name of the event that is triggered when webhooks have been received.
+ */
+export const ON_WEBHOOK_ACTION_NAME: string = 'onWebhook';
+
+/**
  * The default energy for actions.
  */
 export const DEFAULT_ENERGY: number = 100_000;

--- a/src/aux-common/Files/FileEvents.ts
+++ b/src/aux-common/Files/FileEvents.ts
@@ -34,6 +34,7 @@ export type LocalEvents =
     | LoadSimulationEvent
     | UnloadSimulationEvent
     | SuperShoutEvent
+    | SendWebhookEvent
     | GoToContextEvent
     | GoToURLEvent
     | OpenURLEvent
@@ -561,6 +562,50 @@ export interface SuperShoutEvent extends LocalEvent {
      * The argument to pass as the "that" variable to scripts.
      */
     argument?: any;
+}
+
+/**
+ * Defines an event that sends a web request to a server.
+ */
+export interface SendWebhookEvent extends LocalEvent {
+    name: 'send_webhook';
+
+    /**
+     * The options for the webhook.
+     */
+    options: WebhookOptions;
+}
+
+/**
+ * Defines a set of options for a webhook.
+ */
+export interface WebhookOptions {
+    /**
+     * The HTTP Method that the request should use.
+     */
+    method: string;
+
+    /**
+     * The URL that the request should be made to.
+     */
+    url: string;
+
+    /**
+     * The headers to include in the request.
+     */
+    headers?: {
+        [key: string]: string;
+    };
+
+    /**
+     * The data to send with the request.
+     */
+    data?: any;
+
+    /**
+     * The shout that should be made when the request finishes.
+     */
+    responseShout: string;
 }
 
 /**
@@ -1250,5 +1295,17 @@ export function finishCheckout(
         description: description,
         token: token,
         extra: extra,
+    };
+}
+
+/**
+ * Creates a new SendWebhookEvent.
+ * @param options The options for the webhook.
+ */
+export function webhook(options: WebhookOptions): SendWebhookEvent {
+    return {
+        type: 'local',
+        name: 'send_webhook',
+        options: options,
     };
 }

--- a/src/aux-common/Files/test/FileActionsTests.ts
+++ b/src/aux-common/Files/test/FileActionsTests.ts
@@ -27,6 +27,7 @@ import {
     showBarcode,
     checkout,
     finishCheckout,
+    webhook,
 } from '../FileEvents';
 import {
     COMBINE_ACTION_NAME,
@@ -1284,6 +1285,85 @@ export function fileActionsTests(
                     ]);
                 }
             );
+        });
+
+        describe('webhook()', () => {
+            it('should emit a SendWebhookEvent', () => {
+                const state: FilesState = {
+                    file1: {
+                        id: 'file1',
+                        tags: {
+                            'test()': `webhook({
+                                method: 'POST',
+                                url: 'https://example.com',
+                                data: {
+                                    test: 'abc'
+                                },
+                                responseShout: 'test.response()'
+                            })`,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const fileAction = action('test', ['file1']);
+                const result = calculateActionEvents(
+                    state,
+                    fileAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    webhook({
+                        method: 'POST',
+                        url: 'https://example.com',
+                        data: {
+                            test: 'abc',
+                        },
+                        responseShout: 'test.response()',
+                    }),
+                ]);
+            });
+        });
+
+        describe('webhook.post()', () => {
+            it('should emit a SendWebhookEvent', () => {
+                const state: FilesState = {
+                    file1: {
+                        id: 'file1',
+                        tags: {
+                            'test()': `webhook.post('https://example.com', { test: 'abc' }, {
+                                responseShout: 'test.response()'
+                            })`,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const fileAction = action('test', ['file1']);
+                const result = calculateActionEvents(
+                    state,
+                    fileAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    webhook({
+                        method: 'POST',
+                        url: 'https://example.com',
+                        data: {
+                            test: 'abc',
+                        },
+                        responseShout: 'test.response()',
+                    }),
+                ]);
+            });
         });
 
         describe('removeTags()', () => {

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -32,6 +32,7 @@ import {
     showBarcode as calcShowBarcode,
     checkout as calcCheckout,
     finishCheckout as calcFinishCheckout,
+    webhook as calcWebhook,
 } from '../Files/FileEvents';
 import { calculateActionResultsUsingContext } from '../Files/FilesChannel';
 import uuid from 'uuid/v4';
@@ -224,6 +225,38 @@ interface FinishCheckoutOptions {
      * Any extra info that should be included in the onPaymentSuccessful() or onPaymentFailed() events for this checkout.
      */
     extra: any;
+}
+
+/**
+ * Defines a set of options for a webhook.
+ */
+export interface WebhookOptions {
+    /**
+     * The HTTP Method that the request should use.
+     */
+    method?: string;
+
+    /**
+     * The URL that the request should be made to.
+     */
+    url?: string;
+
+    /**
+     * The headers to include in the request.
+     */
+    headers?: {
+        [key: string]: string;
+    };
+
+    /**
+     * The data to send with the request.
+     */
+    data?: any;
+
+    /**
+     * The shout that should be made when the request finishes.
+     */
+    responseShout?: string;
 }
 
 /**
@@ -749,6 +782,48 @@ function superShout(eventName: string, arg?: any) {
     const event = calcSuperShout(trimEvent(eventName), arg);
     return addAction(event);
 }
+
+/**
+ * Sends a web request based on the given options.
+ * @param options The options that specify where and what to send in the web request.
+ *
+ * @example
+ * // Send a HTTP POST request to https://www.example.com/api/createThing
+ * webhook({
+ *   method: 'POST',
+ *   url: 'https://www.example.com/api/createThing',
+ *   data: {
+ *     hello: 'world'
+ *   },
+ *   responseShout: 'requestFinished'
+ * });
+ */
+function webhook(options: WebhookOptions) {
+    const event = calcWebhook(<any>options);
+    return addAction(event);
+}
+
+/**
+ * Sends a HTTP POST request to the given URL with the given data.
+ *
+ * @param url The URL that the request should be sent to.
+ * @param data That that should be sent.
+ * @param options The options that should be included in the request.
+ *
+ * @example
+ * // Send a HTTP POST request to https://www.example.com/api/createThing
+ * webhook.post('https://www.example.com/api/createThing', {
+ *   hello: 'world'
+ * }, { responseShout: 'requestFinished' });
+ */
+webhook.post = function(url: string, data?: any, options?: WebhookOptions) {
+    return webhook({
+        ...options,
+        method: 'POST',
+        url: url,
+        data: data,
+    });
+};
 
 /**
  * Asks the given bots to run the given action.
@@ -1949,6 +2024,7 @@ export default {
     superShout,
     whisper,
     remote,
+    webhook,
 
     getBot,
     getBots,

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -798,24 +798,29 @@ function superShout(eventName: string, arg?: any) {
  *   responseShout: 'requestFinished'
  * });
  */
-function webhook(options: WebhookOptions) {
+let webhook: {
+    (options: WebhookOptions): FileEvent;
+
+    /**
+     * Sends a HTTP POST request to the given URL with the given data.
+     *
+     * @param url The URL that the request should be sent to.
+     * @param data That that should be sent.
+     * @param options The options that should be included in the request.
+     *
+     * @example
+     * // Send a HTTP POST request to https://www.example.com/api/createThing
+     * webhook.post('https://www.example.com/api/createThing', {
+     *   hello: 'world'
+     * }, { responseShout: 'requestFinished' });
+     */
+    post: (url: string, data?: any, options?: WebhookOptions) => FileEvent;
+};
+
+webhook = <any>function(options: WebhookOptions) {
     const event = calcWebhook(<any>options);
     return addAction(event);
-}
-
-/**
- * Sends a HTTP POST request to the given URL with the given data.
- *
- * @param url The URL that the request should be sent to.
- * @param data That that should be sent.
- * @param options The options that should be included in the request.
- *
- * @example
- * // Send a HTTP POST request to https://www.example.com/api/createThing
- * webhook.post('https://www.example.com/api/createThing', {
- *   hello: 'world'
- * }, { responseShout: 'requestFinished' });
- */
+};
 webhook.post = function(url: string, data?: any, options?: WebhookOptions) {
     return webhook({
         ...options,

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -55,6 +55,7 @@ import BarcodeScanner from '../../shared/vue-components/BarcodeScanner/BarcodeSc
 import Checkout from '../Checkout/Checkout';
 import LoginPopup from '../../shared/vue-components/LoginPopup/LoginPopup';
 import AuthorizePopup from '../../shared/vue-components/AuthorizeAccountPopup/AuthorizeAccountPopup';
+import { sendWebhook } from '../../shared/WebhookUtils';
 
 export interface SidebarItem {
     id: string;
@@ -616,6 +617,8 @@ export default class PlayerApp extends Vue {
                     });
                 } else if (e.name === 'open_console') {
                     this.showConsole = e.open;
+                } else if (e.name === 'send_webhook') {
+                    sendWebhook(simulation, e);
                 }
             }),
             simulation.connection.connectionStateChanged.subscribe(

--- a/src/aux-server/aux-web/aux-projector/BuilderApp/BuilderApp.ts
+++ b/src/aux-server/aux-web/aux-projector/BuilderApp/BuilderApp.ts
@@ -56,6 +56,7 @@ import download from 'downloadjs';
 import VueBarcode from '../../shared/public/VueBarcode';
 import LoginPopup from '../../shared/vue-components/LoginPopup/LoginPopup';
 import AuthorizePopup from '../../shared/vue-components/AuthorizeAccountPopup/AuthorizeAccountPopup';
+import { sendWebhook } from '../../shared/WebhookUtils';
 
 const FilePond = vueFilePond();
 
@@ -548,6 +549,8 @@ export default class BuilderApp extends Vue {
                                 `[BuilderApp] Downloading ${e.filename}...`
                             );
                             download(e.data, e.filename, e.mimeType);
+                        } else if (e.name === 'send_webhook') {
+                            sendWebhook(fileManager, e);
                         }
                     }),
                     fileManager.login.deviceChanged.subscribe(info => {

--- a/src/aux-server/aux-web/shared/FormulaHelpers.ts
+++ b/src/aux-server/aux-web/shared/FormulaHelpers.ts
@@ -7,22 +7,7 @@ import formulaDefinitions from 'raw-loader!@casual-simulation/aux-common/Formula
 import { keys } from 'lodash';
 
 function typeMap(key: string, obj: any, root: string = ''): string {
-    if (typeof obj[key] === 'object') {
-        return [
-            '{',
-            ...keys(obj[key]).map(
-                k => `  ${k}: ${typeMap(k, obj[key], key + '.')};`
-            ),
-            '}',
-        ].join('\n');
-    } else {
-        let replacement = typeDefinitionMap.get(root + key);
-        if (replacement) {
-            return `typeof ${replacement}`;
-        } else {
-            return `typeof ${key}`;
-        }
-    }
+    return `typeof _default['${key}']`;
 }
 
 /**

--- a/src/aux-server/aux-web/shared/WebhookUtils.ts
+++ b/src/aux-server/aux-web/shared/WebhookUtils.ts
@@ -1,0 +1,37 @@
+import { SendWebhookEvent } from '@casual-simulation/aux-common';
+import { Simulation } from '@casual-simulation/aux-vm';
+import axios from 'axios';
+
+/**
+ * Processes webhook event for the given simulation.
+ * @param simulation The simulation.
+ * @param event The event.
+ */
+export async function sendWebhook(
+    simulation: Simulation,
+    event: SendWebhookEvent
+) {
+    const { responseShout, ...axiosOptions } = event.options;
+
+    try {
+        const response = await axios(axiosOptions);
+        if (responseShout) {
+            const { request, config, ...responseData } = response;
+            await simulation.helper.action(responseShout, null, {
+                request: axiosOptions,
+                response: responseData,
+                success: true,
+            });
+        }
+    } catch (err) {
+        if (responseShout) {
+            await simulation.helper.action(responseShout, null, {
+                request: axiosOptions,
+                error: err,
+                success: false,
+            });
+        } else {
+            console.error(err);
+        }
+    }
+}

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -515,10 +515,6 @@ export class Server {
 
         this._app.use(this._client.app);
 
-        // this._app.all('/api/*', (req, res) => {
-        //     res.sendStatus(404);
-        // });
-
         this._app.all(
             '/:context/:channel',
             asyncMiddleware(async (req, res) => {


### PR DESCRIPTION
When merged, this PR will add the ability to send and receive HTTP requests on a per-channel basis.

-   Added the ability to send and receive webhooks.
    -   Send webhooks using the following functions:
        -   `webhook(options)` - options is an object that takes the following properties:
            -   `method` - The HTTP Method that should be used for the request.
            -   `url` - The URL that the request should be made to.
            -   `responseShout` - (Optional) The shout that should happen when a response is received from the server.
            -   `headers` - (Optional) The HTTP headers that should be sent with the request.
            -   `data` - (Optional) The data that should be sent with the request.
        -   `webhook.post(url, data, options)` - Sends a HTTP Post request.
            -   `url` - The URL that the request should be made to.
            -   `data` - (Optional) The data that should be sent with the request.
            -   `options` - (Optional) An object that takes the following properties:
                -   `responseShout` - (Optional) The shout that should happen when a response is received from the server.
                -   `headers` - (Optional) The headers that should be sent with the request.
    -   Receive webhooks by registering a handler for the `onWebhook()` action and send requests to `https://auxplayer.com/{context}/{channel}/whatever-you-want`.
        -   `onWebhook()` is shouted to the channel that the request was made to and `that` is an object with the following properties:
            -   `method` - The HTTP Method that the request was made with.
            -   `url` - The URL that the request was made to.
            -   `data` - The JSON data that the request included.
            -   `headers` - The HTTP headers that were included with the request.