### PR TITLE
Add onShout()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@
                 -   `url` - The URL that the request was made to.
                 -   `data` - The JSON data that the request included.
                 -   `headers` - The HTTP headers that were included with the request.
+    -   Added the ability to spy on shouts and whispers via the `onShout()` event.
+        -   `onShout()` is executed on every bot whenever a shout or whisper happens.
+            -   It is useful for tracking what shouts are being made and modifying responses.
+            -   Also useful for providing default behaviors.
+            -   `that` is an object with the following properties:
+                -   `name` is the name of the action being shouted.
+                -   `that` is the argument which was provided for the shout.
+                -   `targets` is an array of bots that the shout was sent to.
+                -   `listeners` is an array of bots that ran a script for the shout.
+                -   `responses` is an array of responses that were returned from the listeners.
 
 ## V0.9.40
 

--- a/src/aux-common/Files/File.ts
+++ b/src/aux-common/Files/File.ts
@@ -518,4 +518,5 @@ export const KNOWN_TAGS: string[] = [
     'onPaymentSuccessful()',
     'onPaymentFailed()',
     'onWebhook()',
+    'onShout()',
 ];

--- a/src/aux-common/Files/FileCalculations.ts
+++ b/src/aux-common/Files/FileCalculations.ts
@@ -164,6 +164,11 @@ export const ON_PAYMENT_FAILED_ACTION_NAME: string = 'onPaymentFailed';
 export const ON_WEBHOOK_ACTION_NAME: string = 'onWebhook';
 
 /**
+ * The name of the event that is triggered when a shout has been executed.
+ */
+export const ON_SHOUT_ACTION_NAME: string = 'onShout';
+
+/**
  * The default energy for actions.
  */
 export const DEFAULT_ENERGY: number = 100_000;

--- a/src/aux-common/Files/test/FileActionsTests.ts
+++ b/src/aux-common/Files/test/FileActionsTests.ts
@@ -529,6 +529,270 @@ export function fileActionsTests(
             expect(events.events).toEqual([toast('test')]);
         });
 
+        describe('onShout()', () => {
+            it('should send a onShout() for actions', () => {
+                expect.assertions(1);
+
+                const state: FilesState = {
+                    file1: {
+                        id: 'file1',
+                        tags: {
+                            'onShout()': `
+                                setTag(this, 'name', that.name);
+                                setTag(this, 'that', that.that);
+                                setTag(this, 'targets', that.targets.map(b => b.id));
+                                setTag(this, 'listeners', that.listeners.map(b => b.id));
+                                setTag(this, 'responses', that.responses);
+                            `,
+                        },
+                    },
+                    file2: {
+                        id: 'file2',
+                        tags: {
+                            'test()': 'return 1;',
+                        },
+                    },
+                    file3: {
+                        id: 'file3',
+                        tags: {
+                            'test()': 'return 2;',
+                        },
+                    },
+                    file4: {
+                        id: 'file4',
+                        tags: {},
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const fileAction = action(
+                    'test',
+                    ['file2', 'file3', 'file4'],
+                    null,
+                    {
+                        abc: 'def',
+                    }
+                );
+                const events = calculateActionEvents(
+                    state,
+                    fileAction,
+                    createSandbox
+                );
+
+                expect(events.events).toEqual([
+                    fileUpdated('file1', {
+                        tags: {
+                            name: 'test',
+                            that: {
+                                abc: 'def',
+                            },
+                            targets: ['file2', 'file3', 'file4'],
+                            listeners: ['file2', 'file3'],
+                            responses: [1, 2],
+                        },
+                    }),
+                ]);
+            });
+
+            it('should include extra events from the onShout() call', () => {
+                expect.assertions(1);
+
+                const state: FilesState = {
+                    file1: {
+                        id: 'file1',
+                        tags: {
+                            'onShout()': `player.toast('Hi!');`,
+                        },
+                    },
+                    file2: {
+                        id: 'file2',
+                        tags: {
+                            'test()': 'return 1;',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const fileAction = action('test', ['file2']);
+                const events = calculateActionEvents(
+                    state,
+                    fileAction,
+                    createSandbox
+                );
+
+                expect(events.events).toEqual([toast('Hi!')]);
+            });
+
+            it('should allow changing responses', () => {
+                expect.assertions(1);
+
+                const state: FilesState = {
+                    file1: {
+                        id: 'file1',
+                        tags: {
+                            'onShout()': `
+                                if (that.name !== 'number') {
+                                    return;
+                                }
+                                for (let i = 0; i < that.responses.length; i++) {
+                                    that.responses[i] = that.responses[i] * 2;
+                                }
+                            `,
+                        },
+                    },
+                    file2: {
+                        id: 'file2',
+                        tags: {
+                            'number()': 'return 1;',
+                        },
+                    },
+                    file3: {
+                        id: 'file3',
+                        tags: {
+                            'number()': 'return 2;',
+                        },
+                    },
+                    file4: {
+                        id: 'file4',
+                        tags: {
+                            'test()': `
+                                setTag(this, 'responses', shout('number'))
+                            `,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const fileAction = action('test', ['file4']);
+                const events = calculateActionEvents(
+                    state,
+                    fileAction,
+                    createSandbox
+                );
+
+                expect(events.events).toEqual([
+                    fileUpdated('file4', {
+                        tags: {
+                            responses: [2, 4],
+                        },
+                    }),
+                ]);
+            });
+
+            it('should allow removing responses', () => {
+                expect.assertions(1);
+
+                const state: FilesState = {
+                    file1: {
+                        id: 'file1',
+                        tags: {
+                            'onShout()': `
+                                if (that.name !== 'number') {
+                                    return;
+                                }
+                                that.responses.length = 0;
+                            `,
+                        },
+                    },
+                    file2: {
+                        id: 'file2',
+                        tags: {
+                            'number()': 'return 1;',
+                        },
+                    },
+                    file3: {
+                        id: 'file3',
+                        tags: {
+                            'number()': 'return 2;',
+                        },
+                    },
+                    file4: {
+                        id: 'file4',
+                        tags: {
+                            'test()': `
+                                setTag(this, 'responses', shout('number'))
+                            `,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const fileAction = action('test', ['file4']);
+                const events = calculateActionEvents(
+                    state,
+                    fileAction,
+                    createSandbox
+                );
+
+                expect(events.events).toEqual([
+                    fileUpdated('file4', {
+                        tags: {
+                            responses: [],
+                        },
+                    }),
+                ]);
+            });
+
+            it('should allow adding responses', () => {
+                expect.assertions(1);
+
+                const state: FilesState = {
+                    file1: {
+                        id: 'file1',
+                        tags: {
+                            'onShout()': `
+                                if (that.name !== 'number') {
+                                    return;
+                                }
+                                that.responses.unshift(0);
+                            `,
+                        },
+                    },
+                    file2: {
+                        id: 'file2',
+                        tags: {
+                            'number()': 'return 1;',
+                        },
+                    },
+                    file3: {
+                        id: 'file3',
+                        tags: {
+                            'number()': 'return 2;',
+                        },
+                    },
+                    file4: {
+                        id: 'file4',
+                        tags: {
+                            'test()': `
+                                setTag(this, 'responses', shout('number'))
+                            `,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const fileAction = action('test', ['file4']);
+                const events = calculateActionEvents(
+                    state,
+                    fileAction,
+                    createSandbox
+                );
+
+                expect(events.events).toEqual([
+                    fileUpdated('file4', {
+                        tags: {
+                            responses: [0, 1, 2],
+                        },
+                    }),
+                ]);
+            });
+        });
+
         describe('arguments', () => {
             it('should not convert the argument to a proxy object if it is a file', () => {
                 const state: FilesState = {


### PR DESCRIPTION
When merged, this PR will add support for onShout() which gets called whenever a shout or whisper happens.

### Changes
-   Added the ability to spy on shouts and whispers via the `onShout()` event.
    -   `onShout()` is executed on every bot whenever a shout or whisper happens.
        -   It is useful for tracking what shouts are being made and modifying responses.
        -   Also useful for providing default behaviors.
        -   `that` is an object with the following properties:
            -   `name` is the name of the action being shouted.
            -   `that` is the argument which was provided for the shout.
            -   `targets` is an array of bots that the shout was sent to.
            -   `listeners` is an array of bots that ran a script for the shout.
            -   `responses` is an array of responses that were returned from the listeners.