### PR TITLE
Add options to limit camera control for contexts and add `player.moveTo()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
         -   `aux.context.pannable`: Controls whether the main camera is able to be panned.
         -   `aux.context.zoomable`: Controls whether the main camera is able to be zoomed.
         -   `aux.context.rotatable`: Controls whether the main camera is able to be rotated.
+    -   Added `player.moveTo()` to instantly tween the camera to a bot.
+        -   In the future, custom tween durations will be supported.
+-   Bug Fixes
+    -   Fixed `player.tweenTo()` to not change the zoom level when it is not specified.
 
 ## V0.10.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # AUX Changelog
 
+## V0.10.3
+
+### Date: TBD
+
+### Changes:
+
+-   Improvements
+    -   Added tags to control panning, zooming, and rotating the main camera.
+        -   `aux.context.pannable`: Controls whether the main camera is able to be panned.
+        -   `aux.context.zoomable`: Controls whether the main camera is able to be zoomed.
+        -   `aux.context.rotatable`: Controls whether the main camera is able to be rotated.
+
 ## V0.10.2
 
 ### Date: 09/27/2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
         -   `aux.context.rotatable`: Controls whether the main camera is able to be rotated.
     -   Added `player.moveTo()` to instantly tween the camera to a bot.
         -   In the future, custom tween durations will be supported.
+    -   Changed the low camera angle limit to 32 degrees from 10 degrees.
 -   Bug Fixes
     -   Fixed `player.tweenTo()` to not change the zoom level when it is not specified.
 

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -1721,10 +1721,27 @@ function tweenTo(
     bot: Bot | string,
     zoomValue?: number,
     rotX?: number,
+    rotY?: number,
+    duration?: number
+) {
+    const event = calcTweenTo(getBotId(bot), zoomValue, rotX, rotY, duration);
+    return addAction(event);
+}
+
+/**
+ * Instantly moves the user's camera to view the given bot.
+ * @param bot The bot to view.
+ * @param zoomValue The zoom value to use.
+ * @param rotX The X rotation.
+ * @param rotY The Y rotation.
+ */
+function moveTo(
+    bot: Bot | string,
+    zoomValue?: number,
+    rotX?: number,
     rotY?: number
 ) {
-    const event = calcTweenTo(getBotId(bot), zoomValue, rotX, rotY);
-    return addAction(event);
+    return tweenTo(bot, zoomValue, rotX, rotY, 0);
 }
 
 /**
@@ -1957,6 +1974,7 @@ const player = {
     getInventoryContext,
     toast,
     tweenTo,
+    moveTo,
     openQRCodeScanner,
     closeQRCodeScanner,
     openBarcodeScanner,

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -163,6 +163,9 @@ export interface BotTags {
     ['aux.context.player.rotation.y']?: number;
     ['aux.context.player.zoom']?: number;
     ['aux.context.devices.visible']?: boolean | null;
+    ['aux.context.pannable']?: number | null;
+    ['aux.context.zoomable']?: number | null;
+    ['aux.context.rotatable']?: number | null;
 
     // Stripe tags
     ['stripe.publishableKey']?: string;
@@ -393,6 +396,9 @@ export const KNOWN_TAGS: string[] = [
     'aux.context.inventory.resizable',
     'aux.context.inventory.rotatable',
     'aux.context.inventory.zoomable',
+    'aux.context.pannable',
+    'aux.context.zoomable',
+    'aux.context.rotatable',
     'aux.scene.color',
     'aux.scene.user.player.color',
     'aux.scene.user.builder.color',

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -5,6 +5,7 @@ import {
     RemoteAction,
 } from '@casual-simulation/causal-trees';
 import { clamp } from '../utils';
+import { hasValue } from './BotCalculations';
 
 /**
  * Defines a union type for all the possible events that can be emitted from a bots channel.
@@ -418,6 +419,11 @@ export interface TweenToAction extends Action {
         x: number;
         y: number;
     };
+
+    /**
+     * The duration that the tween should take.
+     */
+    duration: number | null;
 }
 
 /**
@@ -893,27 +899,38 @@ export function toast(message: string): ShowToastAction {
  * Creates a new TweenToAction.
  * @param botId The ID of the bot to tween to.
  * @param zoomValue The zoom value to use.
+ * @param rotX The X rotation value.
+ * @param rotY The Y rotation value.
+ * @param duration The duration.
  */
 export function tweenTo(
     botId: string,
-    zoomValue: number = -1,
+    zoomValue: number = null,
     rotX: number = null,
-    rotY: number = null
+    rotY: number = null,
+    duration: number = null
 ): TweenToAction {
     if (rotY != null && rotX != null && rotY > 0 && rotX === 0) {
         rotX = 1;
     }
 
-    rotY = clamp(rotY, -180, 180);
-    rotX = clamp(rotX, 1, 90);
-    zoomValue = clamp(zoomValue, 0, 80);
+    if (hasValue(zoomValue)) {
+        zoomValue = clamp(zoomValue, 0, 80);
+    }
+    if (hasValue(rotY)) {
+        rotY = clamp(rotY, -180, 180);
+    }
+    if (hasValue(rotX)) {
+        rotX = clamp(rotX, 1, 90);
+    }
 
-    if (rotX === null || rotY === null) {
+    if (!hasValue(rotX) || !hasValue(rotY)) {
         return {
             type: 'tween_to',
             botId: botId,
             zoomValue: zoomValue,
             rotationValue: null,
+            duration: duration,
         };
     } else {
         return {
@@ -924,6 +941,7 @@ export function tweenTo(
                 x: rotX / 180,
                 y: rotY / 180,
             },
+            duration: duration,
         };
     }
 }

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -3308,7 +3308,7 @@ export function botActionsTests(
             });
         });
 
-        describe('tweenTo()', () => {
+        describe('player.tweenTo()', () => {
             it('should emit a TweenToAction', () => {
                 const state: BotsState = {
                     thisBot: {
@@ -3355,6 +3355,67 @@ export function botActionsTests(
                 expect(result.hasUserDefinedEvents).toBe(true);
 
                 expect(result.events).toEqual([tweenTo('thisBot')]);
+            });
+
+            it('should support specifying a duration', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()':
+                                'player.tweenTo("test", undefined, undefined, undefined, 10)',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    tweenTo('test', undefined, undefined, undefined, 10),
+                ]);
+            });
+        });
+
+        describe('player.moveTo()', () => {
+            it('should emit a TweenToAction with the duration set to 0', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': 'player.moveTo("test")',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    {
+                        type: 'tween_to',
+                        botId: 'test',
+                        zoomValue: null,
+                        rotationValue: null,
+                        duration: 0,
+                    },
+                ]);
             });
         });
 

--- a/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
@@ -95,6 +95,42 @@ export class PlayerGame extends Game {
         return null;
     }
 
+    getPannable(): boolean {
+        for (let i = 0; i < this.playerSimulations.length; i++) {
+            const sim = this.playerSimulations[i];
+
+            if (sim.pannable != null) {
+                return sim.pannable;
+            }
+        }
+
+        return null;
+    }
+
+    getZoomable(): boolean {
+        for (let i = 0; i < this.playerSimulations.length; i++) {
+            const sim = this.playerSimulations[i];
+
+            if (sim.zoomable != null) {
+                return sim.zoomable;
+            }
+        }
+
+        return null;
+    }
+
+    getRotatable(): boolean {
+        for (let i = 0; i < this.playerSimulations.length; i++) {
+            const sim = this.playerSimulations[i];
+
+            if (sim.rotatable != null) {
+                return sim.rotatable;
+            }
+        }
+
+        return null;
+    }
+
     getInventoryVisible(): boolean {
         for (let i = 0; i < this.playerSimulations.length; i++) {
             const sim = this.playerSimulations[i];
@@ -841,6 +877,15 @@ export class PlayerGame extends Game {
             this.invController.controls.enablePan = this.getInventoryPannable();
             this.invController.controls.enableRotate = this.getInventoryRotatable();
             this.invController.controls.enableZoom = this.getInventoryZoomable();
+        }
+
+        const mainControls = this.interaction.cameraRigControllers.find(
+            c => c.rig.name === this.mainCameraRig.name
+        );
+        if (mainControls) {
+            mainControls.controls.enablePan = this.getPannable();
+            mainControls.controls.enableRotate = this.getRotatable();
+            mainControls.controls.enableZoom = this.getZoomable();
         }
 
         if (!this.getInventoryResizable()) {

--- a/src/aux-server/aux-web/aux-player/scene/PlayerSimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerSimulation3D.ts
@@ -57,6 +57,10 @@ export class PlayerSimulation3D extends Simulation3D {
     private _inventoryRotatable: boolean = true;
     private _inventoryZoomable: boolean = true;
 
+    private _pannable: boolean = true;
+    private _rotatable: boolean = true;
+    private _zoomable: boolean = true;
+
     private _inventoryHeight: number = 0;
     private _playerRotationX: number = null;
     private _playerRotationY: number = null;
@@ -86,6 +90,39 @@ export class PlayerSimulation3D extends Simulation3D {
     get inventoryVisible() {
         if (this._inventoryVisible != null) {
             return this._inventoryVisible;
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Gets the pannability of the inventory camera that the simulation defines.
+     */
+    get pannable() {
+        if (this._pannable != null) {
+            return this._pannable;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Gets if rotation is allowed in the inventory that the simulation defines.
+     */
+    get rotatable() {
+        if (this._rotatable != null) {
+            return this._rotatable;
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Gets if zooming is allowed in the inventory that the simulation defines.
+     */
+    get zoomable() {
+        if (this._zoomable != null) {
+            return this._zoomable;
         } else {
             return true;
         }
@@ -323,6 +360,27 @@ export class PlayerSimulation3D extends Simulation3D {
                             )
                                 ? new Color(contextBackgroundColor)
                                 : undefined;
+
+                            this._pannable = calculateBooleanTagValue(
+                                calc,
+                                bot,
+                                `aux.context.pannable`,
+                                true
+                            );
+
+                            this._zoomable = calculateBooleanTagValue(
+                                calc,
+                                bot,
+                                `aux.context.zoomable`,
+                                true
+                            );
+
+                            this._rotatable = calculateBooleanTagValue(
+                                calc,
+                                bot,
+                                `aux.context.rotatable`,
+                                true
+                            );
 
                             this._inventoryVisible = calculateBooleanTagValue(
                                 calc,

--- a/src/aux-server/aux-web/shared/interaction/CameraControls.ts
+++ b/src/aux-server/aux-web/shared/interaction/CameraControls.ts
@@ -28,7 +28,7 @@ export class CameraControls {
     // How far you can orbit vertically, upper and lower limits.
     // Range is 0 to Math.PI radians.
     public minPolarAngle: number = ThreeMath.degToRad(0); // radians
-    public maxPolarAngle: number = ThreeMath.degToRad(80); // radians
+    public maxPolarAngle: number = ThreeMath.degToRad(90 - 32); // radians
 
     // How far you can orbit horizontally, upper and lower limits.
     // If set, must be a sub-interval of the interval [ - Math.PI, Math.PI ].

--- a/src/aux-server/aux-web/shared/interaction/TweenCameraToOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/TweenCameraToOperation.ts
@@ -16,6 +16,7 @@ export class TweenCameraToOperation implements IOperation {
     private _finished: boolean;
     private _zoomValue: number;
     private _rotValue: Vector2;
+    private _duration: number;
     private _instant: boolean;
 
     get simulation(): Simulation {
@@ -29,6 +30,7 @@ export class TweenCameraToOperation implements IOperation {
      * @param interaction The interaction manager.
      * @param target The target location to tween to.
      * @param zoomValue The zoom amount the camera sets to the bot.
+     * @param duration The duration in seconds that the tween should take.
      */
     constructor(
         cameraRig: CameraRig,
@@ -36,14 +38,16 @@ export class TweenCameraToOperation implements IOperation {
         target: Vector3,
         zoomValue?: number,
         rotationValue?: Vector2,
-        instantTween?: boolean
+        duration?: number
     ) {
         this._interaction = interaction;
         this._finished = false;
         this._zoomValue = zoomValue;
         this._rotValue = rotationValue;
         this._target = target;
-        this._instant = instantTween;
+
+        // TODO: Implement proper duration
+        this._instant = duration <= 0;
 
         this._rigControls = this._interaction.cameraRigControllers.find(
             c => c.rig.name === cameraRig.name

--- a/src/aux-server/aux-web/shared/scene/Game.ts
+++ b/src/aux-server/aux-web/shared/scene/Game.ts
@@ -342,12 +342,14 @@ export abstract class Game implements AuxBot3DFinder {
      * @param cameraRig The camera rig to tween.
      * @param botId The ID of the bot to view.
      * @param zoomValue The zoom value to use.
+     * @param duration The time that the tween should last.
      */
     tweenCameraToBot(
         cameraRig: CameraRig,
         botId: string,
         zoomValue?: number,
-        rotationValue?: Vector2
+        rotationValue?: Vector2,
+        duration?: number
     ) {
         // find the bot with the given ID
         const sims = this.getSimulations();
@@ -368,7 +370,8 @@ export abstract class Game implements AuxBot3DFinder {
                 cameraRig,
                 targetPosition,
                 zoomValue,
-                rotationValue
+                rotationValue,
+                duration
             );
         }
     }
@@ -383,7 +386,8 @@ export abstract class Game implements AuxBot3DFinder {
         cameraRig: CameraRig,
         position: Vector3,
         zoomValue?: number,
-        rotationValue?: Vector2
+        rotationValue?: Vector2,
+        duration?: number
     ) {
         this.interaction.addOperation(
             new TweenCameraToOperation(
@@ -391,7 +395,8 @@ export abstract class Game implements AuxBot3DFinder {
                 this.interaction,
                 position,
                 zoomValue,
-                rotationValue
+                rotationValue,
+                duration
             )
         );
     }
@@ -415,7 +420,7 @@ export abstract class Game implements AuxBot3DFinder {
                 position,
                 zoomValue,
                 rotationValue,
-                true
+                0
             )
         );
     }

--- a/src/aux-server/aux-web/shared/scene/Simulation3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Simulation3D.ts
@@ -121,7 +121,8 @@ export abstract class Simulation3D extends Object3D
                                               e.rotationValue.x,
                                               e.rotationValue.y
                                           )
-                                        : undefined
+                                        : undefined,
+                                    e.duration
                                 );
                             }
                         }


### PR DESCRIPTION
When merged, this PR will add pannable, rotatable, and zoomable options for the camera controls in a context and also add `player.moveTo()` which triggers an instant tween.

### Changes:

-   Improvements
    -   Added tags to control panning, zooming, and rotating the main camera.
        -   `aux.context.pannable`: Controls whether the main camera is able to be panned.
        -   `aux.context.zoomable`: Controls whether the main camera is able to be zoomed.
        -   `aux.context.rotatable`: Controls whether the main camera is able to be rotated.
    -   Added `player.moveTo()` to instantly tween the camera to a bot.
        -   In the future, custom tween durations will be supported.
-   Bug Fixes
    -   Fixed `player.tweenTo()` to not change the zoom level when it is not specified.