### PR TITLE
Rename onShout() and add onListen()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
     -   Added a `local` bot which is stored in the browser's local storage.
         -   The `local` bot is a bot that is unique to the device and channel.
         -   You can access the bot by querying for it: `getBot("#id", "local")`.
+    -   Renamed `onShout()` to `onAnyListen()`.
+    -   Added `onListen()` which is an alternative to `onAnyListen()` that is only called on the targeted bots.
 
 ## V0.10.3
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -545,5 +545,6 @@ export const KNOWN_TAGS: string[] = [
     'onPaymentFailed()',
     'onWebhook()',
     'onAnyListen()',
+    'onListen()',
     'onAnyAction()',
 ];

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -544,6 +544,6 @@ export const KNOWN_TAGS: string[] = [
     'onPaymentSuccessful()',
     'onPaymentFailed()',
     'onWebhook()',
-    'onShout()',
+    'onAnyListen()',
     'onAnyAction()',
 ];

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -164,9 +164,14 @@ export const ON_PAYMENT_FAILED_ACTION_NAME: string = 'onPaymentFailed';
 export const ON_WEBHOOK_ACTION_NAME: string = 'onWebhook';
 
 /**
+ * The name of the event that is triggered on every bot when a shout has been executed.
+ */
+export const ON_ANY_SHOUT_ACTION_NAME: string = 'onAnyListen';
+
+/**
  * The name of the event that is triggered when a shout has been executed.
  */
-export const ON_SHOUT_ACTION_NAME: string = 'onShout';
+export const ON_SHOUT_ACTION_NAME: string = 'onListen';
 
 /**
  * The name of the event that is triggered before an action is executed.

--- a/src/aux-common/bots/BotsChannel.ts
+++ b/src/aux-common/bots/BotsChannel.ts
@@ -113,7 +113,6 @@ export function calculateBotActionEvents(
     }
 
     if (executeOnShout) {
-
         let argument = {
             that: event.argument,
             name: event.eventName,
@@ -124,12 +123,24 @@ export function calculateBotActionEvents(
 
         const [extraEvents] = calculateActionResultsUsingContext(
             state,
+            action(
+                ON_SHOUT_ACTION_NAME,
+                bots.map(b => b.id),
+                event.userId,
+                argument
+            ),
+            context,
+            false
+        );
+
+        const [anyExtraEvents] = calculateActionResultsUsingContext(
+            state,
             action(ON_ANY_SHOUT_ACTION_NAME, null, event.userId, argument),
             context,
             false
         );
 
-        events.push(...extraEvents);
+        events.push(...extraEvents, ...anyExtraEvents);
     }
 
     return [events, results, listeners];

--- a/src/aux-common/bots/BotsChannel.ts
+++ b/src/aux-common/bots/BotsChannel.ts
@@ -9,6 +9,8 @@ import {
     DEFAULT_ENERGY,
     hasValue,
     COMBINE_ACTION_NAME,
+    ON_ANY_SHOUT_ACTION_NAME,
+    ON_SHOUT_ACTION_NAME,
 } from './BotCalculations';
 import {
     getActions,
@@ -41,7 +43,7 @@ export function calculateActionEventsUsingContext(
  * @param state The current bots state that the action should use.
  * @param action The action to run.
  * @param context The context that the action should be run in.
- * @param executeOnShout Whether to execute the onShout() callback for this action.
+ * @param executeOnShout Whether to execute the onAnyListen() callback for this action.
  */
 export function calculateActionResultsUsingContext(
     state: BotsState,
@@ -111,15 +113,18 @@ export function calculateBotActionEvents(
     }
 
     if (executeOnShout) {
+
+        let argument = {
+            that: event.argument,
+            name: event.eventName,
+            targets: bots,
+            listeners: listeners,
+            responses: results,
+        };
+
         const [extraEvents] = calculateActionResultsUsingContext(
             state,
-            action('onShout', null, event.userId, {
-                that: event.argument,
-                name: event.eventName,
-                targets: bots,
-                listeners: listeners,
-                responses: results,
-            }),
+            action(ON_ANY_SHOUT_ACTION_NAME, null, event.userId, argument),
             context,
             false
         );

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -531,15 +531,15 @@ export function botActionsTests(
             expect(events.events).toEqual([toast('test')]);
         });
 
-        describe('onShout()', () => {
-            it('should send a onShout() for actions', () => {
+        describe('onAnyListen()', () => {
+            it('should send a onAnyListen() for actions', () => {
                 expect.assertions(1);
 
                 const state: BotsState = {
                     bot1: {
                         id: 'bot1',
                         tags: {
-                            'onShout()': `
+                            'onAnyListen()': `
                                 setTag(this, 'name', that.name);
                                 setTag(this, 'that', that.that);
                                 setTag(this, 'targets', that.targets.map(b => b.id));
@@ -597,14 +597,14 @@ export function botActionsTests(
                 ]);
             });
 
-            it('should send a onShout() for actions that dont have listeners', () => {
+            it('should send a onAnyListen() for actions that dont have listeners', () => {
                 expect.assertions(1);
 
                 const state: BotsState = {
                     bot1: {
                         id: 'bot1',
                         tags: {
-                            'onShout()': `
+                            'onAnyListen()': `
                                 setTag(this, 'name', that.name);
                                 setTag(this, 'that', that.that);
                                 setTag(this, 'targets', that.targets.map(b => b.id));
@@ -658,14 +658,14 @@ export function botActionsTests(
                 ]);
             });
 
-            it('should send a onShout() for whispers', () => {
+            it('should send a onAnyListen() for whispers', () => {
                 expect.assertions(1);
 
                 const state: BotsState = {
                     bot1: {
                         id: 'bot1',
                         tags: {
-                            'onShout()': `
+                            'onAnyListen()': `
                                 if (that.name !== 'whisper') {
                                     return;
                                 }
@@ -718,14 +718,14 @@ export function botActionsTests(
                 ]);
             });
 
-            it('should include extra events from the onShout() call', () => {
+            it('should include extra events from the onAnyListen() call', () => {
                 expect.assertions(1);
 
                 const state: BotsState = {
                     bot1: {
                         id: 'bot1',
                         tags: {
-                            'onShout()': `player.toast('Hi!');`,
+                            'onAnyListen()': `player.toast('Hi!');`,
                         },
                     },
                     bot2: {
@@ -755,7 +755,7 @@ export function botActionsTests(
                     bot1: {
                         id: 'bot1',
                         tags: {
-                            'onShout()': `
+                            'onAnyListen()': `
                                 if (that.name !== 'number') {
                                     return;
                                 }
@@ -812,7 +812,7 @@ export function botActionsTests(
                     bot1: {
                         id: 'bot1',
                         tags: {
-                            'onShout()': `
+                            'onAnyListen()': `
                                 if (that.name !== 'number') {
                                     return;
                                 }
@@ -867,7 +867,7 @@ export function botActionsTests(
                     bot1: {
                         id: 'bot1',
                         tags: {
-                            'onShout()': `
+                            'onAnyListen()': `
                                 if (that.name !== 'number') {
                                     return;
                                 }
@@ -913,6 +913,121 @@ export function botActionsTests(
                         },
                     }),
                 ]);
+            });
+        });
+
+        describe('onListen()', () => {
+            it('should send a onListen() for actions to the bot that was listening', () => {
+                expect.assertions(1);
+
+                const state: BotsState = {
+                    bot1: {
+                        id: 'bot1',
+                        tags: {
+                            'test()': 'return 1;',
+                            'onListen()': `
+                                setTag(this, 'name', that.name);
+                                setTag(this, 'that', that.that);
+                                setTag(this, 'targets', that.targets.map(b => b.id));
+                                setTag(this, 'listeners', that.listeners.map(b => b.id));
+                                setTag(this, 'responses', that.responses);
+                            `,
+                        },
+                    },
+                    bot3: {
+                        id: 'bot3',
+                        tags: {
+                            'test()': 'return 2;',
+                        },
+                    },
+                    bot4: {
+                        id: 'bot4',
+                        tags: {},
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action(
+                    'test',
+                    ['bot1', 'bot3', 'bot4'],
+                    null,
+                    {
+                        abc: 'def',
+                    }
+                );
+                const events = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(events.events).toEqual([
+                    botUpdated('bot1', {
+                        tags: {
+                            name: 'test',
+                            that: {
+                                abc: 'def',
+                            },
+                            targets: ['bot1', 'bot3', 'bot4'],
+                            listeners: ['bot1', 'bot3'],
+                            responses: [1, 2],
+                        },
+                    }),
+                ]);
+            });
+
+            it('should not send a onListen() for actions every bot', () => {
+                expect.assertions(1);
+
+                const state: BotsState = {
+                    bot1: {
+                        id: 'bot1',
+                        tags: {
+                            'onListen()': `
+                                setTag(this, 'name', that.name);
+                                setTag(this, 'that', that.that);
+                                setTag(this, 'targets', that.targets.map(b => b.id));
+                                setTag(this, 'listeners', that.listeners.map(b => b.id));
+                                setTag(this, 'responses', that.responses);
+                            `,
+                        },
+                    },
+                    bot2: {
+                        id: 'bot2',
+                        tags: {
+                            'test()': 'return 1;',
+                        },
+                    },
+                    bot3: {
+                        id: 'bot3',
+                        tags: {
+                            'test()': 'return 2;',
+                        },
+                    },
+                    bot4: {
+                        id: 'bot4',
+                        tags: {},
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action(
+                    'test',
+                    ['bot2', 'bot3', 'bot4'],
+                    null,
+                    {
+                        abc: 'def',
+                    }
+                );
+                const events = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(events.events).toEqual([]);
             });
         });
 


### PR DESCRIPTION
### Changes:

-   Improvements
    -   Renamed `onShout()` to `onAnyListen()`.
    -   Added `onListen()` which is an alternative to `onAnyListen()` that is only called on the targeted bots.