### PR TITLE
Make the menu badge a lighter gray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # AUX Changelog
 
+## V0.10.9
+
+### Date: TBD
+
+### Changes:
+
+-   Improvements
+    -   Made the menu item count badge a lighter gray.
+
 ## V0.10.8
 
 ### Date: 10/09/2019

--- a/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
+++ b/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
@@ -127,5 +127,6 @@ html.ar-app .webxr-sessions canvas {
 }
 
 .md-badge.md-primary.menu-badge {
-    background-color: #707070;
+    background-color: #c5c5c5;
+    color: rgba(0, 0, 0.54);
 }


### PR DESCRIPTION
### Changes:

-   Improvements
    -   Made the menu item count badge a lighter gray.