### PR TITLE
Add the ability to choose which camera is used for the QR and Barcode scanners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 -   Improvements
     -   Improved initial loading time by up to 70%.
+    -   Added the ability to choose which camera is used for QR and Barcode scanning.
+        -   The following functions have been improved:
+            -   `player.openQRCodeScanner(camera)`
+            -   `player.openBarcodeScanner(camera)`
+        -   The `camera` parameter is optional and takes 2 values: `"front"` or `"rear"`.
 -   Changes
     -   User bots no longer register their own context. Instead, a new bot has been created to host the `aux.users` context.
         -   Improves performance of AUXes with many user bots with the same username.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8612,6 +8612,11 @@
 				"caller-callsite": "^2.0.0"
 			}
 		},
+		"callforth": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/callforth/-/callforth-0.3.1.tgz",
+			"integrity": "sha512-Q2zPfqnwoKsb1DTVCr4lmhe49wKNBsMmNlbudjleu3/co+Nw1pOqFHYJHrW3VZ253ou9AAr+xauQR0C55NPdzA=="
+		},
 		"callsite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -9574,9 +9579,9 @@
 			}
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -24105,13 +24110,13 @@
 			}
 		},
 		"vue-qrcode-reader": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/vue-qrcode-reader/-/vue-qrcode-reader-1.4.2.tgz",
-			"integrity": "sha512-V1+ObiYXrz2EbAnWv6nNxSRvzWXqch9WDlrxBH/i9GEypE5XklWRvOHiNeB0kQBVdv7f8G43BUWAwVNBfZvIQg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/vue-qrcode-reader/-/vue-qrcode-reader-2.1.1.tgz",
+			"integrity": "sha512-rIxV0RAuiomNi4n03L7XVbCKRtq4sT1LYtIk3osuBdJA/1W6y8yDtP4SvGpBdRCLaurfHaicpAZxQB98mejSCg==",
 			"requires": {
 				"babel-runtime": "^6.26.0",
-				"jsqr": "^1.1.0",
-				"lodash": "^4.17.11",
+				"callforth": "^0.3.0",
+				"jsqr": "^1.2.0",
 				"webrtc-adapter": "^6.2.1"
 			}
 		},

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -324,6 +324,11 @@ interface BotFilterFunction {
 type Mod = BotTags | Bot;
 
 /**
+ * Defines the possible camera types.
+ */
+type CameraType = 'front' | 'rear';
+
+/**
  * Sums the given array of numbers and returns the result.
  * If any value in the list is not a number, it will be converted to one.
  * If the given value is not an array, then it will be converted to a number and returned.
@@ -1779,9 +1784,10 @@ function moveTo(
 
 /**
  * Opens the QR Code Scanner.
+ * @param camera The camera that should be used.
  */
-function openQRCodeScanner() {
-    const event = calcOpenQRCodeScanner(true);
+function openQRCodeScanner(camera: CameraType = 'rear') {
+    const event = calcOpenQRCodeScanner(true, camera);
     return addAction(event);
 }
 
@@ -1812,9 +1818,10 @@ function hideQRCode() {
 
 /**
  * Opens the barcode scanner.
+ * @param camera The camera that should be used.
  */
-function openBarcodeScanner() {
-    const event = calcOpenBarcodeScanner(true);
+function openBarcodeScanner(camera?: CameraType) {
+    const event = calcOpenBarcodeScanner(true, camera);
     return addAction(event);
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -406,6 +406,11 @@ export interface TweenToAction extends Action {
 }
 
 /**
+ * The possible camera types.
+ */
+export type CameraType = 'front' | 'rear';
+
+/**
  * An event that is used to show or hide the QR Code Scanner.
  */
 export interface OpenQRCodeScannerAction extends Action {
@@ -415,6 +420,11 @@ export interface OpenQRCodeScannerAction extends Action {
      * Whether the QR Code scanner should be visible.
      */
     open: boolean;
+
+    /**
+     * The camera that should be used.
+     */
+    cameraType: CameraType;
 }
 
 /**
@@ -427,6 +437,11 @@ export interface OpenBarcodeScannerAction extends Action {
      * Whether the barcode scanner should be visible.
      */
     open: boolean;
+
+    /**
+     * The camera that should be used.
+     */
+    cameraType: CameraType;
 }
 
 /**
@@ -983,11 +998,16 @@ export function tweenTo(
 /**
  * Creates a new OpenQRCodeScannerAction.
  * @param open Whether the QR Code scanner should be open or closed.
+ * @param cameraType The camera type that should be used.
  */
-export function openQRCodeScanner(open: boolean): OpenQRCodeScannerAction {
+export function openQRCodeScanner(
+    open: boolean,
+    cameraType?: CameraType
+): OpenQRCodeScannerAction {
     return {
         type: 'show_qr_code_scanner',
         open: open,
+        cameraType: cameraType,
     };
 }
 
@@ -1007,11 +1027,16 @@ export function showQRCode(open: boolean, code?: string): ShowQRCodeAction {
 /**
  * Creates a new OpenBarcodeScannerAction.
  * @param open Whether the barcode scanner should be open or closed.
+ * @param cameraType The camera type that should be used.
  */
-export function openBarcodeScanner(open: boolean): OpenBarcodeScannerAction {
+export function openBarcodeScanner(
+    open: boolean,
+    cameraType?: CameraType
+): OpenBarcodeScannerAction {
     return {
         type: 'show_barcode_scanner',
         open: open,
+        cameraType: cameraType,
     };
 }
 

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -3715,7 +3715,35 @@ export function botActionsTests(
 
                 expect(result.hasUserDefinedEvents).toBe(true);
 
-                expect(result.events).toEqual([openQRCodeScanner(true)]);
+                expect(result.events).toEqual([
+                    openQRCodeScanner(true, 'rear'),
+                ]);
+            });
+
+            it('should use the given camera type', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': 'player.openQRCodeScanner("front")',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    openQRCodeScanner(true, 'front'),
+                ]);
             });
         });
 
@@ -3819,7 +3847,35 @@ export function botActionsTests(
 
                 expect(result.hasUserDefinedEvents).toBe(true);
 
-                expect(result.events).toEqual([openBarcodeScanner(true)]);
+                expect(result.events).toEqual([
+                    openBarcodeScanner(true, 'rear'),
+                ]);
+            });
+
+            it('should use the given camera type', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': 'player.openBarcodeScanner("front")',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    openBarcodeScanner(true, 'front'),
+                ]);
             });
         });
 
@@ -5228,9 +5284,12 @@ export function botActionsTests(
                 ['player.goToURL("url")', goToURL('url')],
                 ['player.tweenTo("id")', tweenTo('id')],
                 ['player.openURL("url")', openURL('url')],
-                ['player.openQRCodeScanner()', openQRCodeScanner(true)],
+                ['player.openQRCodeScanner()', openQRCodeScanner(true, 'rear')],
                 ['player.closeQRCodeScanner()', openQRCodeScanner(false)],
-                ['player.openBarcodeScanner()', openBarcodeScanner(true)],
+                [
+                    'player.openBarcodeScanner()',
+                    openBarcodeScanner(true, 'rear'),
+                ],
                 ['player.closeBarcodeScanner()', openBarcodeScanner(false)],
                 ['player.showBarcode("code")', showBarcode(true, 'code')],
                 ['player.hideBarcode()', showBarcode(false)],

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -37,6 +37,7 @@ import {
     ON_CHANNEL_STREAM_LOST_ACTION_NAME,
     ON_CHANNEL_UNSUBSCRIBED_ACTION_NAME,
     parseSimulationId,
+    CameraType,
 } from '@casual-simulation/aux-common';
 import SnackbarOptions from '../../shared/SnackbarOptions';
 import { copyToClipboard, navigateToUrl } from '../../shared/SharedUtils';
@@ -184,6 +185,11 @@ export default class PlayerApp extends Vue {
      * Whether to show the barcode scanner.
      */
     showBarcodeScanner: boolean = false;
+
+    /**
+     * The camera type that should be used for the scanner.
+     */
+    camera: CameraType;
 
     /**
      * Whether to show the Login code.
@@ -565,6 +571,7 @@ export default class PlayerApp extends Vue {
                     };
                 } else if (e.type === 'show_qr_code_scanner') {
                     if (this.showQRScanner !== e.open) {
+                        this.camera = e.cameraType;
                         this.showQRScanner = e.open;
                         if (e.open) {
                             this._superAction(
@@ -578,6 +585,7 @@ export default class PlayerApp extends Vue {
                     }
                 } else if (e.type === 'show_barcode_scanner') {
                     if (this.showBarcodeScanner !== e.open) {
+                        this.camera = e.cameraType;
                         this.showBarcodeScanner = e.open;
                         if (e.open) {
                             this._superAction(

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -147,7 +147,7 @@
             >
                 <div class="qr-scanner-container">
                     <h3>Scan a QR Code</h3>
-                    <qrcode-stream @decode="onQRCodeScanned"></qrcode-stream>
+                    <qrcode-stream @decode="onQRCodeScanned" :camera="camera"></qrcode-stream>
                 </div>
                 <md-dialog-actions>
                     <md-button class="md-primary" @click="hideQRCodeScanner()">Close</md-button>
@@ -161,7 +161,7 @@
             >
                 <div class="barcode-scanner-container">
                     <h3>Scan a Barcode</h3>
-                    <barcode-stream @decode="onBarcodeScanned"></barcode-stream>
+                    <barcode-stream @decode="onBarcodeScanned" :camera="camera"></barcode-stream>
                 </div>
                 <md-dialog-actions>
                     <md-button class="md-primary" @click="hideBarcodeScanner()">Close</md-button>

--- a/src/aux-server/aux-web/shared/public/VueQuagga/Scanner/Scanner.ts
+++ b/src/aux-server/aux-web/shared/public/VueQuagga/Scanner/Scanner.ts
@@ -96,6 +96,11 @@ export default {
       }),
       validator: (o: any) => typeof o.min === 'number' && typeof o.max === 'number',
     },
+    camera: {
+        type: String,
+        default: 'rear',
+        validator: (s: any) => ['rear', 'front'].indexOf(s) >= 0
+    }
   },
   data: function() {
     return {
@@ -105,7 +110,7 @@ export default {
           constraints: {
             width: { min: this.readerSize.width },
             height: { min: this.readerSize.height },
-            facingMode: 'environment',
+            facingMode: { ideal: this.camera === 'rear' ? 'environment' : 'user' },
             aspectRatio: { min: 1, max: 2 },
           },
         },

--- a/src/aux-server/aux-web/shared/vue-components/BarcodeScanner/BarcodeScanner.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BarcodeScanner/BarcodeScanner.ts
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import VueQuagga from '../../public/VueQuagga';
+import { Prop } from 'vue-property-decorator';
+import { CameraType } from '@casual-simulation/aux-common';
 
 const defaultReaders = [
     'code_128_reader',
@@ -33,6 +35,8 @@ interface BarcodeResult {
 export default class BarcodeScanner extends Vue {
     private _lastCode: string;
     private _lastScanTime: number;
+
+    @Prop() camera: CameraType;
 
     readers: string[];
 

--- a/src/aux-server/aux-web/shared/vue-components/BarcodeScanner/BarcodeScanner.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BarcodeScanner/BarcodeScanner.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="barcode-scanner-container">
-        <v-barcode :onDetected="barcodeDetected" :readerTypes="readers"></v-barcode>
+        <v-barcode
+            :onDetected="barcodeDetected"
+            :readerTypes="readers"
+            :camera="camera"
+        ></v-barcode>
     </div>
 </template>
 <script src="./BarcodeScanner.ts"></script>

--- a/src/aux-server/package.json
+++ b/src/aux-server/package.json
@@ -103,7 +103,7 @@
         "vue-filepond": "^4.0.3",
         "vue-material": "^1.0.0-beta-10.2",
         "vue-property-decorator": "^7.2.0",
-        "vue-qrcode-reader": "^1.4.2",
+        "vue-qrcode-reader": "2.1.1",
         "vue-router": "^3.0.1",
         "vue-shortkey": "^3.1.6",
         "webvr-polyfill": "^0.10.10"


### PR DESCRIPTION
### Changes
-   Added the ability to choose which camera is used for QR and Barcode scanning.
    -   The following functions have been improved:
        -   `player.openQRCodeScanner(camera)`
        -   `player.openBarcodeScanner(camera)`
    -   The `camera` parameter is optional and takes 2 values: `"front"` or `"rear"`.