### PR TITLE
Cleanup the side menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@
     -   Added the ability to save and load files.
         -   New functions:
             -   `server.saveFile(filename, data, options)`
-                -   `filename` is a string.
+                -   `filename` is a string and should start with `/drives/`.
                 -   `data` is a string of the data to store.
                 -   `options` is an object with the following properties:
                     -   `callbackShout` A shout that should happen on the server when the file is done saving.
                     -   `overwriteExistingFile` A boolean that indicates if existing files should be overwritten. (defaults to false)
             -   `server.loadFile(filename, options)`
-                -   `filename` is a string.
+                -   `filename` is a string and should start with `/drives/`.
                 -   `options` is an object with the following properties:
                     -   `callbackShout` A shout that should happen on the server when the file is done loading.
         -   Note that the save file and load file tasks must be enabled via the `onAnyAction()` listener.
@@ -37,6 +37,9 @@
                 }
             }
             ```
+        -   All files from USB drives are stored under the `/drives` directory and the USB drives themselves are numbered starting with 0.
+            -   To load a file from USB drive #1, use `server.loadFile("/drives/0/myFile")`.
+            -   To save a file to USB drive #2, use `server.saveFile("/drives/1/myFile", data)`.
 -   Bug Fixes
     -   Fixed an issue that prevented the `removeTags()` function from working when given an array of bots.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@
                 -   `filename` is a string.
                 -   `options` is an object with the following properties:
                     -   `callbackShout` A shout that should happen on the server when the file is done loading.
+        -   Note that the save file and load file tasks must be enabled via the `onAnyAction()` listener.
+            -   You can enable it via using this code:
+            ```javascript
+            if (that.action.type === 'device') {
+                if (
+                    ['save_file', 'load_file'].indexOf(
+                        that.action.event.type
+                    ) >= 0
+                ) {
+                    action.perform(that.action.event);
+                }
+            }
+            ```
 -   Bug Fixes
     -   Fixed an issue that prevented the `removeTags()` function from working when given an array of bots.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@
         -   All files from USB drives are stored under the `/drives` directory and the USB drives themselves are numbered starting with 0.
             -   To load a file from USB drive #1, use `server.loadFile("/drives/0/myFile")`.
             -   To save a file to USB drive #2, use `server.saveFile("/drives/1/myFile", data)`.
+    -   Removed several options from the side menu:
+        -   Removed the channel name from the top of the menu.
+        -   Removed the login status from the top of the menu.
+        -   Removed the login/logout options from the menu.
+            -   The "Logout" option will still be available if you are logged in as a non-guest.
+            -   Once you are logged out, then the option will dissapear.
+        -   Removed the "Add Channel" option from the menu in AUXPlayer.
 -   Bug Fixes
     -   Fixed an issue that prevented the `removeTags()` function from working when given an array of bots.
 

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -63,6 +63,7 @@ import LoginPopup from '../../shared/vue-components/LoginPopup/LoginPopup';
 import AuthorizePopup from '../../shared/vue-components/AuthorizeAccountPopup/AuthorizeAccountPopup';
 import { sendWebhook } from '../../../shared/WebhookUtils';
 import HtmlModal from '../../shared/vue-components/HtmlModal/HtmlModal';
+import { loginToSim, generateGuestId } from '../../shared/LoginUtils';
 
 export interface SidebarItem {
     id: string;
@@ -190,16 +191,6 @@ export default class PlayerApp extends Vue {
      * The camera type that should be used for the scanner.
      */
     camera: CameraType;
-
-    /**
-     * Whether to show the Login code.
-     */
-    showLoginCode: boolean = false;
-
-    /**
-     * Whether to show the login popup.
-     */
-    showLogin: boolean = false;
 
     /**
      * Whether to show the authorize account popup.
@@ -373,9 +364,11 @@ export default class PlayerApp extends Vue {
         this._subs.forEach(s => s.unsubscribe());
     }
 
-    logout() {
-        this.showNavigation = false;
-        this.showLogin = true;
+    async logout() {
+        await loginToSim(
+            appManager.simulationManager.primary,
+            generateGuestId()
+        );
     }
 
     snackbarClick(action: SnackbarOptions['action']) {
@@ -784,10 +777,6 @@ export default class PlayerApp extends Vue {
     private _hideBarcode() {
         this.barcode = null;
         this.showBarcode = false;
-    }
-
-    showLoginQRCode() {
-        this.showLoginCode = true;
     }
 
     // TODO: Move to a shared class/component

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -143,11 +143,6 @@ export default class PlayerApp extends Vue {
     simulations: SimulationInfo[] = [];
 
     /**
-     * Whether to show the add simulation dialog.
-     */
-    showAddSimulation: boolean = false;
-
-    /**
      * Whether to show the confirm remove simulation dialog.
      */
     showRemoveSimulation: boolean = false;
@@ -156,11 +151,6 @@ export default class PlayerApp extends Vue {
      * The simulation to remove.
      */
     simulationToRemove: SimulationInfo = null;
-
-    /**
-     * The ID of the simulation to add.
-     */
-    newSimulation: string = '';
 
     /**
      * The QR Code to show.
@@ -452,11 +442,6 @@ export default class PlayerApp extends Vue {
 
     onBarcodeScanned(code: string) {
         this._superAction(ON_BARCODE_SCANNED_ACTION_NAME, code);
-    }
-
-    addSimulation() {
-        this.newSimulation = '';
-        this.showAddSimulation = true;
     }
 
     async finishAddSimulation(id: string) {

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -6,16 +6,6 @@
             </md-button>
 
             <md-drawer :md-active.sync="showNavigation">
-                <div class="menu-header">
-                    <span class="md-title">{{ session || 'AUX Player' }} {{ setTitleToID() }}</span
-                    ><br />
-                    <div class="user-info" v-if="getUser() != null">
-                        <span class="md-body-1 username-label"
-                            >Logged In: {{ getUser().name }}</span
-                        >
-                        <span class="admin-badge" v-if="isAdmin">Admin</span>
-                    </div>
-                </div>
                 <md-list>
                     <md-list-item
                         @click="showQRCode = true"

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -14,17 +14,10 @@
                     >
                         <qr-code :value="url()" :options="{ width: 256 }" />
                     </md-list-item>
-                    <md-list-item
-                        v-if="getUser() != null && !getUser().isGuest"
-                        @click="showLoginQRCode()"
-                    >
-                        <md-icon>devices_other</md-icon>
-                        <span class="md-list-item-text">Login with Another Device</span>
-                    </md-list-item>
-                    <md-list-item @click="logout">
+                    <md-list-item @click="logout" v-if="getUser() != null && !getUser().isGuest">
                         <md-icon>exit_to_app</md-icon>
                         <span class="md-list-item-text">
-                            {{ !getUser() || getUser().isGuest ? 'Login' : 'Logout' }}
+                            Logout from {{ getUser().username }}
                         </span>
                     </md-list-item>
                     <router-link
@@ -98,19 +91,6 @@
                         "
                         >Close</md-button
                     >
-                </md-dialog-actions>
-            </md-dialog>
-
-            <md-dialog :md-active.sync="showLoginCode" class="qr-code-dialog">
-                <div class="qr-code-container" @click="copy(getLoginCode())">
-                    <span>{{ getLoginCode() }}</span>
-                    <qr-code
-                        :value="getLoginCode()"
-                        :options="{ width: 310, color: { dark: '#0044AA' } }"
-                    />
-                </div>
-                <md-dialog-actions>
-                    <md-button class="md-primary" @click="showLoginCode = false">Close</md-button>
                 </md-dialog-actions>
             </md-dialog>
 
@@ -242,7 +222,6 @@
                 </md-dialog-actions>
             </md-dialog>
 
-            <login :show="showLogin" @close="showLogin = false"></login>
             <authorize :show="showAuthorize" @close="showAuthorize = false"></authorize>
 
             <md-snackbar

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -28,10 +28,6 @@
                         <md-icon>home</md-icon>
                         <span class="md-list-item-text">Home</span>
                     </router-link>
-                    <md-list-item @click="addSimulation()" v-if="getUser() != null && authorized">
-                        <md-icon>cloud</md-icon>
-                        <span class="md-list-item-text">Add Channel</span>
-                    </md-list-item>
                     <md-list-item
                         v-for="simulation in simulations"
                         :key="simulation.id"
@@ -137,14 +133,6 @@
                     <md-button class="md-primary" @click="hideBarcodeScanner()">Close</md-button>
                 </md-dialog-actions>
             </md-dialog>
-
-            <md-dialog-prompt
-                :md-active.sync="showAddSimulation"
-                v-model="newSimulation"
-                md-title="Add Channel"
-                md-confirm-text="Add"
-                @md-confirm="finishAddSimulation"
-            />
 
             <md-dialog-confirm
                 v-if="simulationToRemove"

--- a/src/aux-server/aux-web/aux-projector/BuilderApp/BuilderApp.ts
+++ b/src/aux-server/aux-web/aux-projector/BuilderApp/BuilderApp.ts
@@ -55,10 +55,10 @@ import { recordMessage } from '../../shared/Console';
 import Tagline from '../../shared/vue-components/Tagline/Tagline';
 import download from 'downloadjs';
 import VueBarcode from '../../shared/public/VueBarcode';
-import LoginPopup from '../../shared/vue-components/LoginPopup/LoginPopup';
 import AuthorizePopup from '../../shared/vue-components/AuthorizeAccountPopup/AuthorizeAccountPopup';
 import HtmlModal from '../../shared/vue-components/HtmlModal/HtmlModal';
 import { sendWebhook } from '../../../shared/WebhookUtils';
+import { loginToSim, generateGuestId } from '../../shared/LoginUtils';
 
 const BotPond = vueBotPond();
 
@@ -81,7 +81,6 @@ const BotPond = vueBotPond();
         console: Console,
         hotkey: Hotkey,
         tagline: Tagline,
-        login: LoginPopup,
         authorize: AuthorizePopup,
     },
 })
@@ -188,16 +187,6 @@ export default class BuilderApp extends Vue {
      * option in the menu.
      */
     showCreateChannel: boolean = false;
-
-    /**
-     * Whether to show the login code.
-     */
-    showLoginCode: boolean = false;
-
-    /**
-     * Whether to show the login popup.
-     */
-    showLogin: boolean = false;
 
     /**
      * Whether to show the authorize account popup.
@@ -628,9 +617,11 @@ export default class BuilderApp extends Vue {
         this._subs.forEach(s => s.unsubscribe());
     }
 
-    logout() {
-        this.showNavigation = false;
-        this.showLogin = true;
+    async logout() {
+        await loginToSim(
+            appManager.simulationManager.primary,
+            generateGuestId()
+        );
     }
 
     download() {
@@ -759,10 +750,6 @@ export default class BuilderApp extends Vue {
 
     refreshPage() {
         window.location.reload();
-    }
-
-    showLoginQRCode() {
-        this.showLoginCode = true;
     }
 
     fixConflicts() {

--- a/src/aux-server/aux-web/aux-projector/BuilderApp/BuilderApp.vue
+++ b/src/aux-server/aux-web/aux-projector/BuilderApp/BuilderApp.vue
@@ -35,17 +35,10 @@
                             >Channel doesn't exist. Click here to create it.</span
                         >
                     </md-list-item>
-                    <md-list-item
-                        v-if="getUser() != null && !getUser().isGuest"
-                        @click="showLoginQRCode()"
-                    >
-                        <md-icon>devices_other</md-icon>
-                        <span class="md-list-item-text">Login with Another Device</span>
-                    </md-list-item>
-                    <md-list-item @click="logout">
+                    <md-list-item @click="logout" v-if="getUser() != null && !getUser().isGuest">
                         <md-icon>exit_to_app</md-icon>
                         <span class="md-list-item-text">
-                            {{ !getUser() || getUser().isGuest ? 'Login' : 'Logout' }}
+                            Logout from {{ getUser().username }}
                         </span>
                     </md-list-item>
                     <router-link
@@ -149,19 +142,6 @@
                         "
                         >Close</md-button
                     >
-                </md-dialog-actions>
-            </md-dialog>
-
-            <md-dialog :md-active.sync="showLoginCode" class="qr-code-dialog">
-                <div class="qr-code-container" @click="copy(getLoginCode())">
-                    <span class="qr-code-label">{{ getLoginCode() }}</span>
-                    <qr-code
-                        :value="getLoginCode()"
-                        :options="{ width: 310, color: { dark: '#0044AA' } }"
-                    />
-                </div>
-                <md-dialog-actions>
-                    <md-button class="md-primary" @click="showLoginCode = false">Close</md-button>
                 </md-dialog-actions>
             </md-dialog>
 
@@ -289,7 +269,6 @@
                 </md-dialog-actions>
             </md-dialog>
 
-            <login :show="showLogin" @close="showLogin = false"></login>
             <authorize :show="showAuthorize" @close="showAuthorize = false"></authorize>
 
             <md-snackbar

--- a/src/aux-server/aux-web/aux-projector/BuilderApp/BuilderApp.vue
+++ b/src/aux-server/aux-web/aux-projector/BuilderApp/BuilderApp.vue
@@ -18,16 +18,6 @@
             </md-toolbar>
 
             <md-drawer :md-active.sync="showNavigation">
-                <div class="menu-header">
-                    <span class="md-title"
-                        >{{ session || 'Channel Deser' }} {{ setTitleToID() }}</span
-                    ><br />
-                    <div class="user-info" v-if="getUser() != null">
-                        <span class="md-body-1 username-label"
-                            >Logged In: {{ getUser().name }}</span
-                        >
-                    </div>
-                </div>
                 <md-list>
                     <md-list-item
                         @click="showQRCode = true"

--- a/src/aux-server/aux-web/shared/scene/Game.ts
+++ b/src/aux-server/aux-web/shared/scene/Game.ts
@@ -293,28 +293,6 @@ export abstract class Game implements AuxBotVisualizerFinder {
             this.mainViewport
         );
 
-        // Update side bar item.
-        this.removeSidebarItem('toggle_camera_type');
-        if (this.currentCameraType === 'orthographic') {
-            this.addSidebarItem(
-                'toggle_camera_type',
-                'Enable Perspective Camera',
-                () => {
-                    this.setCameraType('perspective');
-                },
-                'videocam'
-            );
-        } else {
-            this.addSidebarItem(
-                'toggle_camera_type',
-                'Disable Perspective Camera',
-                () => {
-                    this.setCameraType('orthographic');
-                },
-                'videocam_off'
-            );
-        }
-
         if (this.htmlMixerContext) {
             this.htmlMixerContext.setupCssCamera(this.mainCameraRig.mainCamera);
         }


### PR DESCRIPTION
### Changes

-   Removed several options from the side menu:
    -   Removed the channel name from the top of the menu.
    -   Removed the login status from the top of the menu.
    -   Removed the login/logout options from the menu.
        -   The "Logout" option will still be available if you are logged in as a non-guest.
        -   Once you are logged out, then the option will dissapear.
    -   Removed the "Add Channel" option from the menu in AUXPlayer.