### PR TITLE
Add the ability to create temporary bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 -   Improvements
     -   Added the ability to create temporary bots using the `createTemp()` function.
         -   This function behaves exactly the same as `create()` but the created bot is temporary, which means it won't be shared and will be deleted upon refresh.
+-   Changes
+    -   Renamed the `local` bot to the `cookie` bot.
+        -   This is supposed to help make it clear that the bot data is stored in the browser and will be cleared when the browser's data is cleared.
 
 ## V0.11.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # AUX Changelog
 
+## V0.11.5
+
+### Date: TBD
+
+### Changes:
+
+-   Improvements
+    -   Added the ability to create temporary bots using the `createTemp()` function.
+        -   This function behaves exactly the same as `create()` but the created bot is temporary, which means it won't be shared and will be deleted upon refresh.
+
 ## V0.11.4
 
 ### Date: 10/29/2019

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -640,7 +640,7 @@ function destroyChildren(id: string) {
  * Creates a new bot that contains the given tags.
  * @param mods The mods that specify what tags to set on the bot.
  */
-function createFromMods(...mods: (Mod | Mod[])[]) {
+function createFromMods(idFactory: () => string, ...mods: (Mod | Mod[])[]) {
     let variants: Mod[][] = new Array<Mod[]>(1);
     variants[0] = [];
 
@@ -670,7 +670,7 @@ function createFromMods(...mods: (Mod | Mod[])[]) {
 
     let bots: Bot[] = variants.map(v => {
         let bot = {
-            id: uuid(),
+            id: idFactory(),
             tags: {},
         };
         apply(bot.tags, ...v);
@@ -712,10 +712,24 @@ function getBotId(bot: Bot | string): string {
     }
 }
 
+function createBase(
+    idFactory: () => string,
+    parent: Bot | string,
+    ...datas: Mod[]
+) {
+    let parentId = getBotId(parent);
+    let parentDiff = parentId
+        ? {
+              'aux.creator': parentId,
+          }
+        : {};
+    return createFromMods(idFactory, ...datas, parentDiff);
+}
+
 /**
  * Creates a new bot and returns it.
  * @param parent The bot that should be the parent of the new bot.
- * @param datas The mods which specify the new bot's tag values.
+ * @param mods The mods which specify the new bot's tag values.
  * @returns The bot(s) that were created.
  *
  * @example
@@ -730,14 +744,30 @@ function getBotId(bot: Bot | string): string {
  * ]);
  *
  */
-function create(parent: Bot | string, ...datas: Mod[]) {
-    let parentId = getBotId(parent);
-    let parentDiff = parentId
-        ? {
-              'aux.creator': parentId,
-          }
-        : {};
-    return createFromMods(...datas, parentDiff);
+function create(parent: Bot | string, ...mods: Mod[]) {
+    return createBase(() => uuid(), parent, ...mods);
+}
+
+/**
+ * Creates a new temporary bot and returns it.
+ * @param parent The bot that should be the parent of the new bot.
+ * @param mods The mods which specify the new bot's tag values.
+ * @returns The bot(s) that were created.
+ *
+ * @example
+ * // Create a red bot without a parent.
+ * let redBot = createTemp(null, { "aux.color": "red" });
+ *
+ * @example
+ * // Create a red bot and a blue bot with `this` as the parent.
+ * let [redBot, blueBot] = createTemp(this, [
+ *    { "aux.color": "red" },
+ *    { "aux.color": "blue" }
+ * ]);
+ *
+ */
+function createTemp(parent: Bot | string, ...mods: Mod[]) {
+    return createBase(() => `T-${uuid()}`, parent, ...mods);
 }
 
 /**
@@ -2146,6 +2176,7 @@ export default {
     // Global functions
     combine,
     create,
+    createTemp,
     createdBy,
     destroy,
     shout,

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -378,6 +378,11 @@ export const DEVICE_BOT_ID = 'device';
 export const LOCAL_BOT_ID = 'local';
 
 /**
+ * The ID of the cookie configuration bot.
+ */
+export const COOKIE_BOT_ID = 'cookie';
+
+/**
  * The partition ID for temporary bots.
  */
 export const TEMPORARY_BOT_PARTITION_ID = 'T-*';

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -378,6 +378,11 @@ export const DEVICE_BOT_ID = 'device';
 export const LOCAL_BOT_ID = 'local';
 
 /**
+ * The partition ID for temporary bots.
+ */
+export const TEMPORARY_BOT_PARTITION_ID = 'T-*';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -2099,587 +2099,8 @@ export function botActionsTests(
             });
         });
 
-        describe('create()', () => {
-            it('should create a new bot with aux.creator set to the original id', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()': 'create(this, { abc: "def" })',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            abc: 'def',
-                            'aux.creator': 'thisBot',
-                        },
-                    }),
-                ]);
-            });
-
-            it('should create a new bot with aux.creator set to the given id', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()': 'create("thisBot", { abc: "def" })',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            abc: 'def',
-                            'aux.creator': 'thisBot',
-                        },
-                    }),
-                ]);
-            });
-
-            it('should not allow overriding aux.creator', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'create("thisBot", { "aux.creator": "def" })',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                        },
-                    }),
-                ]);
-            });
-
-            it('should support multiple arguments', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'create("thisBot", { abc: "def" }, { ghi: 123 })',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            abc: 'def',
-                            ghi: 123,
-                            'aux.creator': 'thisBot',
-                        },
-                    }),
-                ]);
-            });
-
-            it('should support bots as arguments', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'create("thisBot", getBots("name", "that"))',
-                        },
-                    },
-                    thatBot: {
-                        id: 'thatBot',
-                        tags: {
-                            name: 'that',
-                            abc: 'def',
-                            formula: '=this.abc',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            abc: 'def',
-                            name: 'that',
-                            formula: '=this.abc',
-                            'aux.creator': 'thisBot',
-                        },
-                    }),
-                ]);
-            });
-
-            it('should return the created bot', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'setTag(this, "#newBotId", create(null, { abc: "def" }).id)',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            abc: 'def',
-                        },
-                    }),
-                    botUpdated('thisBot', {
-                        tags: {
-                            newBotId: 'uuid-0',
-                        },
-                    }),
-                ]);
-            });
-
-            it('should support modifying the returned bot', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'let newBot = create(null, { abc: "def" }); setTag(newBot, "#fun", true); setTag(newBot, "#num", 123);',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            abc: 'def',
-                        },
-                    }),
-                    botUpdated('uuid-0', {
-                        tags: {
-                            fun: true,
-                            num: 123,
-                        },
-                    }),
-                ]);
-            });
-
-            it('should add the new bot to the formulas', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'create(null, { name: "bob" }); setTag(this, "#botId", getBot("#name", "bob").id)',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            name: 'bob',
-                        },
-                    }),
-                    botUpdated('thisBot', {
-                        tags: {
-                            botId: 'uuid-0',
-                        },
-                    }),
-                ]);
-            });
-
-            it('should support formulas on the new bot', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'let newBot = create(null, { formula: "=getTag(this, \\"#num\\")", num: 100 }); setTag(this, "#result", getTag(newBot, "#formula"));',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            formula: '=getTag(this, "#num")',
-                            num: 100,
-                        },
-                    }),
-                    botUpdated('thisBot', {
-                        tags: {
-                            result: 100,
-                        },
-                    }),
-                ]);
-            });
-
-            it('should return normal javascript objects', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            num: 100,
-                            'test()':
-                                'let newBot = create(this, { abc: getTag(this, "#num") });',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            abc: 100,
-                        },
-                    }),
-                ]);
-            });
-
-            it('should trigger onCreate() on the created bot.', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            num: 1,
-                            'test()':
-                                'create(this, { abc: getTag(this, "#num"), "onCreate()": "setTag(this, \\"#num\\", 100)" });',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            abc: 1,
-                            'onCreate()': 'setTag(this, "#num", 100)',
-                        },
-                    }),
-                    botUpdated('uuid-0', {
-                        tags: {
-                            num: 100,
-                        },
-                    }),
-                ]);
-            });
-
-            it('should support arrays of diffs as arguments', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'setTag(this, "#num", create("thisBot", [ { hello: true }, { hello: false } ]).length)',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                let num = 0;
-                uuidMock.mockImplementation(() => `uuid-${num++}`);
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            hello: true,
-                        },
-                    }),
-                    botAdded({
-                        id: 'uuid-1',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            hello: false,
-                        },
-                    }),
-                    botUpdated('thisBot', {
-                        tags: {
-                            num: 2,
-                        },
-                    }),
-                ]);
-            });
-
-            it('should create every combination of diff', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'setTag(this, "#num", create("thisBot", [ { hello: true }, { hello: false } ], [ { wow: 1 }, { oh: "haha" }, { test: "a" } ]).length)',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                let num = 0;
-                uuidMock.mockImplementation(() => `uuid-${num++}`);
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            hello: true,
-                            wow: 1,
-                        },
-                    }),
-                    botAdded({
-                        id: 'uuid-1',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            hello: false,
-                            wow: 1,
-                        },
-                    }),
-                    botAdded({
-                        id: 'uuid-2',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            hello: true,
-                            oh: 'haha',
-                        },
-                    }),
-                    botAdded({
-                        id: 'uuid-3',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            hello: false,
-                            oh: 'haha',
-                        },
-                    }),
-                    botAdded({
-                        id: 'uuid-4',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            hello: true,
-                            test: 'a',
-                        },
-                    }),
-                    botAdded({
-                        id: 'uuid-5',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            hello: false,
-                            test: 'a',
-                        },
-                    }),
-                    botUpdated('thisBot', {
-                        tags: {
-                            num: 6,
-                        },
-                    }),
-                ]);
-            });
-
-            it('should duplicate each of the bots in the list', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            'test()':
-                                'create("thisBot", getBots("test", true))',
-                        },
-                    },
-                    aBot: {
-                        id: 'aBot',
-                        tags: {
-                            test: true,
-                            hello: true,
-                        },
-                    },
-                    bBot: {
-                        id: 'bBot',
-                        tags: {
-                            test: true,
-                            hello: false,
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                let num = 0;
-                uuidMock.mockImplementation(() => `uuid-${num++}`);
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    botAdded({
-                        id: 'uuid-0',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            test: true,
-                            hello: true,
-                        },
-                    }),
-                    botAdded({
-                        id: 'uuid-1',
-                        tags: {
-                            'aux.creator': 'thisBot',
-                            test: true,
-                            hello: false,
-                        },
-                    }),
-                ]);
-            });
-        });
+        createBotTests('create', 'uuid');
+        createBotTests('createTemp', 'uuid', 'T-uuid');
 
         describe('combine()', () => {
             it('should send the combine event to the given bots', () => {
@@ -5873,4 +5294,521 @@ export function botActionsTests(
             expect(final).toEqual([toastAction]);
         });
     });
+
+    function createBotTests(name: string, id: string, expectedId: string = id) {
+        describe(`${name}()`, () => {
+            it('should create a new bot with aux.creator set to the original id', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `${name}(this, { abc: "def" })`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            abc: 'def',
+                            'aux.creator': 'thisBot',
+                        },
+                    }),
+                ]);
+            });
+            it('should create a new bot with aux.creator set to the given id', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `${name}("thisBot", { abc: "def" })`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            abc: 'def',
+                            'aux.creator': 'thisBot',
+                        },
+                    }),
+                ]);
+            });
+            it('should not allow overriding aux.creator', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `${name}("thisBot", { "aux.creator": "def" })`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                        },
+                    }),
+                ]);
+            });
+            it('should support multiple arguments', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `${name}("thisBot", { abc: "def" }, { ghi: 123 })`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            abc: 'def',
+                            ghi: 123,
+                            'aux.creator': 'thisBot',
+                        },
+                    }),
+                ]);
+            });
+            it('should support bots as arguments', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `${name}("thisBot", getBots("name", "that"))`,
+                        },
+                    },
+                    thatBot: {
+                        id: 'thatBot',
+                        tags: {
+                            name: 'that',
+                            abc: 'def',
+                            formula: '=this.abc',
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            abc: 'def',
+                            name: 'that',
+                            formula: '=this.abc',
+                            'aux.creator': 'thisBot',
+                        },
+                    }),
+                ]);
+            });
+            it('should return the created bot', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `setTag(this, "#newBotId", ${name}(null, { abc: "def" }).id)`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            abc: 'def',
+                        },
+                    }),
+                    botUpdated('thisBot', {
+                        tags: {
+                            newBotId: expectedId,
+                        },
+                    }),
+                ]);
+            });
+            it('should support modifying the returned bot', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `let newBot = ${name}(null, { abc: "def" }); setTag(newBot, "#fun", true); setTag(newBot, "#num", 123);`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            abc: 'def',
+                        },
+                    }),
+                    botUpdated(expectedId, {
+                        tags: {
+                            fun: true,
+                            num: 123,
+                        },
+                    }),
+                ]);
+            });
+            it('should add the new bot to the formulas', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `${name}(null, { name: "bob" }); setTag(this, "#botId", getBot("#name", "bob").id)`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            name: 'bob',
+                        },
+                    }),
+                    botUpdated('thisBot', {
+                        tags: {
+                            botId: expectedId,
+                        },
+                    }),
+                ]);
+            });
+            it('should support formulas on the new bot', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `let newBot = ${name}(null, { formula: "=getTag(this, \\"#num\\")", num: 100 }); setTag(this, "#result", getTag(newBot, "#formula"));`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            formula: '=getTag(this, "#num")',
+                            num: 100,
+                        },
+                    }),
+                    botUpdated('thisBot', {
+                        tags: {
+                            result: 100,
+                        },
+                    }),
+                ]);
+            });
+            it('should return normal javascript objects', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            num: 100,
+                            'test()': `let newBot = ${name}(this, { abc: getTag(this, "#num") });`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            abc: 100,
+                        },
+                    }),
+                ]);
+            });
+            it('should trigger onCreate() on the created bot.', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            num: 1,
+                            'test()': `${name}(this, { abc: getTag(this, "#num"), "onCreate()": "setTag(this, \\"#num\\", 100)" });`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                uuidMock.mockReturnValue(id);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: expectedId,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            abc: 1,
+                            'onCreate()': 'setTag(this, "#num", 100)',
+                        },
+                    }),
+                    botUpdated(expectedId, {
+                        tags: {
+                            num: 100,
+                        },
+                    }),
+                ]);
+            });
+            it('should support arrays of diffs as arguments', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `setTag(this, "#num", ${name}("thisBot", [ { hello: true }, { hello: false } ]).length)`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                let num = 0;
+                uuidMock.mockImplementation(() => `${id}-${num++}`);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: `${expectedId}-0`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            hello: true,
+                        },
+                    }),
+                    botAdded({
+                        id: `${expectedId}-1`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            hello: false,
+                        },
+                    }),
+                    botUpdated('thisBot', {
+                        tags: {
+                            num: 2,
+                        },
+                    }),
+                ]);
+            });
+            it('should create every combination of diff', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `setTag(this, "#num", ${name}("thisBot", [ { hello: true }, { hello: false } ], [ { wow: 1 }, { oh: "haha" }, { test: "a" } ]).length)`,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                let num = 0;
+                uuidMock.mockImplementation(() => `${id}-${num++}`);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: `${expectedId}-0`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            hello: true,
+                            wow: 1,
+                        },
+                    }),
+                    botAdded({
+                        id: `${expectedId}-1`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            hello: false,
+                            wow: 1,
+                        },
+                    }),
+                    botAdded({
+                        id: `${expectedId}-2`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            hello: true,
+                            oh: 'haha',
+                        },
+                    }),
+                    botAdded({
+                        id: `${expectedId}-3`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            hello: false,
+                            oh: 'haha',
+                        },
+                    }),
+                    botAdded({
+                        id: `${expectedId}-4`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            hello: true,
+                            test: 'a',
+                        },
+                    }),
+                    botAdded({
+                        id: `${expectedId}-5`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            hello: false,
+                            test: 'a',
+                        },
+                    }),
+                    botUpdated('thisBot', {
+                        tags: {
+                            num: 6,
+                        },
+                    }),
+                ]);
+            });
+            it('should duplicate each of the bots in the list', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': `${name}("thisBot", getBots("test", true))`,
+                        },
+                    },
+                    aBot: {
+                        id: 'aBot',
+                        tags: {
+                            test: true,
+                            hello: true,
+                        },
+                    },
+                    bBot: {
+                        id: 'bBot',
+                        tags: {
+                            test: true,
+                            hello: false,
+                        },
+                    },
+                };
+                // specify the UUID to use next
+                let num = 0;
+                uuidMock.mockImplementation(() => `${id}-${num++}`);
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+                expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.events).toEqual([
+                    botAdded({
+                        id: `${expectedId}-0`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            test: true,
+                            hello: true,
+                        },
+                    }),
+                    botAdded({
+                        id: `${expectedId}-1`,
+                        tags: {
+                            'aux.creator': 'thisBot',
+                            test: true,
+                            hello: false,
+                        },
+                    }),
+                ]);
+            });
+        });
+    }
 }

--- a/src/aux-vm-browser/managers/BotManager.ts
+++ b/src/aux-vm-browser/managers/BotManager.ts
@@ -9,6 +9,7 @@ import {
     LOCAL_BOT_ID,
     botUpdated,
     TEMPORARY_BOT_PARTITION_ID,
+    COOKIE_BOT_ID,
 } from '@casual-simulation/aux-common';
 
 import {
@@ -113,7 +114,7 @@ export class BotManager extends BaseSimulation implements BrowserSimulation {
             bindBotToStorage(
                 this,
                 storageId(this.parsedId.channel, LOCAL_BOT_ID),
-                LOCAL_BOT_ID
+                COOKIE_BOT_ID
             )
         );
 
@@ -126,13 +127,14 @@ export class BotManager extends BaseSimulation implements BrowserSimulation {
                     host: parsedId.host,
                     treeName: getTreeName(parsedId.channel),
                 },
-                [LOCAL_BOT_ID]: {
+                [COOKIE_BOT_ID]: {
                     type: 'memory',
                     initialState: {
-                        [LOCAL_BOT_ID]:
+                        [COOKIE_BOT_ID]:
                             getStoredBot(
-                                storageId(parsedId.channel, LOCAL_BOT_ID)
-                            ) || createBot(LOCAL_BOT_ID),
+                                storageId(parsedId.channel, LOCAL_BOT_ID),
+                                COOKIE_BOT_ID
+                            ) || createBot(COOKIE_BOT_ID),
                     },
                 },
                 [TEMPORARY_BOT_PARTITION_ID]: {
@@ -195,10 +197,12 @@ function storageId(...parts: string[]): string {
     return parts.join('_');
 }
 
-function getStoredBot(key: string): Bot {
+function getStoredBot(key: string, id: string): Bot {
     const json = localStorage.getItem(key);
     if (json) {
-        return JSON.parse(json);
+        const bot: Bot = JSON.parse(json);
+        bot.id = id;
+        return bot;
     } else {
         return null;
     }
@@ -290,7 +294,7 @@ function updateStoredBot(key: string, id: string, update: Partial<Bot>) {
     if (!update.tags) {
         return;
     }
-    const oldBot = getStoredBot(key) || createBot(id);
+    const oldBot = getStoredBot(key, id) || createBot(id);
     const differentTags = pickBy(
         update.tags,
         (val, tag) => oldBot.tags[tag] !== val

--- a/src/aux-vm-browser/managers/BotManager.ts
+++ b/src/aux-vm-browser/managers/BotManager.ts
@@ -8,6 +8,7 @@ import {
     DEVICE_BOT_ID,
     LOCAL_BOT_ID,
     botUpdated,
+    TEMPORARY_BOT_PARTITION_ID,
 } from '@casual-simulation/aux-common';
 
 import {
@@ -133,6 +134,10 @@ export class BotManager extends BaseSimulation implements BrowserSimulation {
                                 storageId(parsedId.channel, LOCAL_BOT_ID)
                             ) || createBot(LOCAL_BOT_ID),
                     },
+                },
+                [TEMPORARY_BOT_PARTITION_ID]: {
+                    type: 'memory',
+                    initialState: {},
                 },
             };
         }

--- a/src/aux-vm/vm/AuxHelper.spec.ts
+++ b/src/aux-vm/vm/AuxHelper.spec.ts
@@ -147,6 +147,54 @@ describe('AuxHelper', () => {
                 }),
             ]);
         });
+
+        it('should support prefixes for bot IDs', async () => {
+            let mem = createMemoryPartition({
+                type: 'memory',
+                initialState: {},
+            });
+            helper = new AuxHelper({
+                '*': createMemoryPartition({
+                    type: 'memory',
+                    initialState: {},
+                }),
+                'TEST-*': mem,
+            });
+
+            await helper.createBot('TEST-abcdefghijklmnop');
+
+            expect(Object.keys(helper.botsState)).toEqual([
+                'TEST-abcdefghijklmnop',
+            ]);
+            expect(Object.keys(mem.state)).toEqual(['TEST-abcdefghijklmnop']);
+        });
+
+        it('should prevent partitions from overriding other partitions', async () => {
+            helper = new AuxHelper({
+                '*': createMemoryPartition({
+                    type: 'memory',
+                    initialState: {
+                        test: createBot('test', {
+                            abc: 'def',
+                        }),
+                    },
+                }),
+                'TEST-*': createMemoryPartition({
+                    type: 'memory',
+                    initialState: {
+                        test: createBot('test', {
+                            bad: 'thing',
+                        }),
+                    },
+                }),
+            });
+
+            expect(helper.botsState).toEqual({
+                test: createBot('test', {
+                    abc: 'def',
+                }),
+            });
+        });
     });
 
     describe('userBot', () => {


### PR DESCRIPTION
### Changes:
-   Added the ability to create temporary bots using the `createTemp()` function.
    -   This function behaves exactly the same as `create()` but the created bot is temporary, which means it won't be shared and will be deleted upon refresh.