### PR TITLE
Add the `server.setupChannel()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@
 
 -   Improvements
     -   Added the `server.setupChannel(channel, botOrMod)` function.
-        -   This creates a channel if it doesn't already exist and places a clone of the given bot or mod in it.
+        -   This sends a `setup_channel` action to the server which, if executed using `action.perform()`, will create a channel if it doesn't already exist and place a clone of the given bot or mod in it.
         -   Takes 2 parameters:
             -   `channel` - The channel that should be created.
             -   `botOrMod` - (Optional) The bot or mod that should be cloned and placed inside the new channel. `onCreate()` is triggered after the bot or mod is created so you can use that to script custom setup logic.
+        -   As mentioned above, you have to receive the `device` action in `onAnyAction()` and do an `action.perform(that.action.event)` to allow channels to be setup via this function.
 
 ## V0.11.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # AUX Changelog
 
+## V0.11.6
+
+### Date: 11/6/2019
+
+### Changes:
+
+-   Improvements
+    -   Added the `server.setupChannel(channel, botOrMod)` function.
+        -   This creates a channel if it doesn't already exist and places a clone of the given bot or mod in it.
+        -   Takes 2 parameters:
+            -   `channel` - The channel that should be created.
+            -   `botOrMod` - (Optional) The bot or mod that should be cloned and placed inside the new channel. `onCreate()` is triggered after the bot or mod is created so you can use that to script custom setup logic.
+
 ## V0.11.5
 
 ### Date: 10/31/2019

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -37,6 +37,7 @@ import {
     loadFile as calcLoadFile,
     saveFile as calcSaveFile,
     replaceDragBot as calcReplaceDragBot,
+    setupChannel as calcSetupChannel,
 } from '../bots/BotEvents';
 import { calculateActionResultsUsingContext } from '../bots/BotsChannel';
 import uuid from 'uuid/v4';
@@ -2016,6 +2017,15 @@ function echo(message: string) {
 }
 
 /**
+ * Sends an event to the server to setup a new channel if it does not exist.
+ * @param channel The channel.
+ * @param botOrMod The bot or mod that should be cloned into the new channel.
+ */
+function setupChannel(channel: string, botOrMod?: Mod) {
+    return remote(calcSetupChannel(channel, botOrMod));
+}
+
+/**
  * Executes the given shell script on the server.
  * @param script The shell script  that should be executed.
  */
@@ -2145,6 +2155,7 @@ const server = {
 
     loadFile: serverLoadFile,
     saveFile: serverSaveFile,
+    setupChannel,
 };
 
 /**

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -67,7 +67,8 @@ export type ExtraActions =
     | CheckoutSubmittedAction
     | FinishCheckoutAction
     | PasteStateAction
-    | ReplaceDragBotAction;
+    | ReplaceDragBotAction
+    | SetupChannelAction;
 
 /**
  * Defines a bot event that indicates a bot was added to the state.
@@ -883,6 +884,23 @@ export interface RejectAction {
 }
 
 /**
+ * Defines an event that creates a channel if it doesn't exist.
+ */
+export interface SetupChannelAction {
+    type: 'setup_channel';
+
+    /**
+     * The channel that should be created.
+     */
+    channel: string;
+
+    /**
+     * The bot or mod that should be cloned into the new channel.
+     */
+    botOrMod?: Bot | BotTags;
+}
+
+/**
  * Creates a new AddBotAction.
  * @param bot The bot that was added.
  */
@@ -1440,5 +1458,21 @@ export function replaceDragBot(bot: Bot | BotTags): ReplaceDragBotAction {
     return {
         type: 'replace_drag_bot',
         bot,
+    };
+}
+
+/**
+ * Creates a channel if it doesn't exist and places the given bot in it.
+ * @param channel The ID of the channel to setup.
+ * @param botOrMod The bot that should be cloned into the new channel.
+ */
+export function setupChannel(
+    channel: string,
+    botOrMod?: Bot | BotTags
+): SetupChannelAction {
+    return {
+        type: 'setup_channel',
+        channel,
+        botOrMod,
     };
 }

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -31,6 +31,7 @@ import {
     loadFile,
     saveFile,
     replaceDragBot,
+    setupChannel,
 } from '../BotEvents';
 import {
     COMBINE_ACTION_NAME,
@@ -2860,41 +2861,6 @@ export function botActionsTests(
             });
         });
 
-        describe('server.saveFile()', () => {
-            it('should issue a SaveFileAction in a remote event', () => {
-                const state: BotsState = {
-                    thisBot: {
-                        id: 'thisBot',
-                        tags: {
-                            abc: true,
-                            'test()':
-                                'server.saveFile("path", mod.export({ abc: true }))',
-                        },
-                    },
-                };
-
-                // specify the UUID to use next
-                uuidMock.mockReturnValue('uuid-0');
-                const botAction = action('test', ['thisBot']);
-                const result = calculateActionEvents(
-                    state,
-                    botAction,
-                    createSandbox
-                );
-
-                expect(result.hasUserDefinedEvents).toBe(true);
-
-                expect(result.events).toEqual([
-                    remote(
-                        saveFile({
-                            path: 'path',
-                            data: JSON.stringify({ abc: true }),
-                        })
-                    ),
-                ]);
-            });
-        });
-
         describe('addToContextDiff()', () => {
             it('should add the bot to the given context', () => {
                 const state: BotsState = {
@@ -4654,6 +4620,48 @@ export function botActionsTests(
                 expect(result.hasUserDefinedEvents).toBe(true);
 
                 expect(result.events).toEqual([remote(sayHello())]);
+            });
+        });
+
+        describe('server.setupChannel()', () => {
+            it('should send a SetupChannelAction in a RemoteAction', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            'test()': 'server.setupChannel("channel", this)',
+                        },
+                    },
+                    userBot: {
+                        id: 'userBot',
+                        tags: {
+                            'aux._user': 'testUser',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot'], 'userBot');
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    remote(
+                        setupChannel(
+                            'channel',
+                            createBot('thisBot', {
+                                'test()':
+                                    'server.setupChannel("channel", this)',
+                            })
+                        )
+                    ),
+                ]);
             });
         });
 

--- a/src/aux-server/server/modules/SetupChannelModule.spec.ts
+++ b/src/aux-server/server/modules/SetupChannelModule.spec.ts
@@ -1,0 +1,262 @@
+import {
+    NodeAuxChannel,
+    AuxLoadedChannel,
+} from '@casual-simulation/aux-vm-node';
+import {
+    botAdded,
+    createBot,
+    AuxCausalTree,
+    webhook,
+    setupChannel,
+    createPrecalculatedBot,
+} from '@casual-simulation/aux-common';
+import {
+    DeviceInfo,
+    RealtimeChannelInfo,
+    storedTree,
+    site,
+    USERNAME_CLAIM,
+    DEVICE_ID_CLAIM,
+    SESSION_ID_CLAIM,
+    SERVER_ROLE,
+} from '@casual-simulation/causal-trees';
+import { SetupChannelModule } from './SetupChannelModule';
+import { AuxUser, AuxConfig } from '@casual-simulation/aux-vm';
+import { Subscription } from 'rxjs';
+import { waitAsync } from '@casual-simulation/aux-vm/test/TestHelpers';
+import { TestChannelManager, createChannel } from './test/TestChannelManager';
+import uuid from 'uuid/v4';
+
+const uuidMock: jest.Mock = <any>uuid;
+jest.mock('uuid/v4');
+console.log = jest.fn();
+
+describe('SetupChannelModule', () => {
+    let tree: AuxCausalTree;
+    let channel: NodeAuxChannel;
+    let user: AuxUser;
+    let device: DeviceInfo;
+    let serverDevice: DeviceInfo;
+    let config: AuxConfig;
+    let subject: SetupChannelModule;
+    let sub: Subscription;
+    let info: RealtimeChannelInfo;
+    let manager: TestChannelManager;
+    let auxChannel: AuxLoadedChannel;
+
+    beforeEach(async () => {
+        tree = new AuxCausalTree(storedTree(site(1)));
+        await tree.root();
+
+        user = {
+            id: 'userId',
+            isGuest: false,
+            name: 'User Name',
+            username: 'username',
+            token: 'token',
+        };
+        config = {
+            config: {
+                isBuilder: false,
+                isPlayer: false,
+            },
+            partitions: {
+                '*': {
+                    type: 'causal_tree',
+                    tree: tree,
+                    id: 'id',
+                },
+            },
+        };
+        device = {
+            claims: {
+                [USERNAME_CLAIM]: 'username',
+                [DEVICE_ID_CLAIM]: 'deviceId',
+                [SESSION_ID_CLAIM]: 'sessionId',
+            },
+            roles: [],
+        };
+        serverDevice = {
+            claims: {
+                [USERNAME_CLAIM]: 'server',
+                [DEVICE_ID_CLAIM]: 'deviceId',
+                [SESSION_ID_CLAIM]: 'sessionId',
+            },
+            roles: [SERVER_ROLE],
+        };
+        info = {
+            id: 'aux-test',
+            type: 'aux',
+        };
+
+        auxChannel = await createChannel(info, user, device, config);
+
+        channel = auxChannel.channel;
+
+        manager = new TestChannelManager();
+        manager.setChannelFactory(async info => {
+            return await createChannel(info, user, device, config);
+        });
+        manager.addChannel(info, auxChannel);
+
+        subject = new SetupChannelModule();
+        subject.setChannelManager(<any>manager);
+        sub = await subject.setup(info, channel);
+    });
+
+    afterEach(() => {
+        if (sub) {
+            sub.unsubscribe();
+            sub = null;
+        }
+    });
+
+    describe('events', () => {
+        describe('setup_channel', () => {
+            it('should create non-existant channels', async () => {
+                expect.assertions(1);
+
+                await channel.sendEvents([setupChannel('newChannel')]);
+
+                await waitAsync();
+
+                await expect(
+                    manager.hasChannel({
+                        id: 'newChannel',
+                        type: 'aux',
+                    })
+                ).resolves.toBe(true);
+            });
+
+            it('should clone the given bot into the new channel', async () => {
+                expect.assertions(2);
+
+                uuidMock.mockReturnValueOnce('newBot');
+
+                await channel.sendEvents([
+                    setupChannel(
+                        'newChannel',
+                        createBot('test', {
+                            abc: 'def',
+                        })
+                    ),
+                ]);
+
+                await waitAsync();
+
+                await expect(
+                    manager.hasChannel({
+                        id: 'newChannel',
+                        type: 'aux',
+                    })
+                ).resolves.toBe(true);
+
+                const newChannel = await manager.loadChannel({
+                    id: 'newChannel',
+                    type: 'aux',
+                });
+
+                const newBot = newChannel.simulation.helper.botsState['newBot'];
+                expect(newBot).toEqual(
+                    createPrecalculatedBot('newBot', {
+                        abc: 'def',
+                    })
+                );
+            });
+
+            it('should clone the given mod into the new channel', async () => {
+                expect.assertions(2);
+
+                uuidMock.mockReturnValueOnce('newBot');
+
+                await channel.sendEvents([
+                    setupChannel('newChannel', {
+                        abc: 'def',
+                    }),
+                ]);
+
+                await waitAsync();
+
+                await expect(
+                    manager.hasChannel({
+                        id: 'newChannel',
+                        type: 'aux',
+                    })
+                ).resolves.toBe(true);
+
+                const newChannel = await manager.loadChannel({
+                    id: 'newChannel',
+                    type: 'aux',
+                });
+
+                const newBot = newChannel.simulation.helper.botsState['newBot'];
+                expect(newBot).toEqual(
+                    createPrecalculatedBot('newBot', {
+                        abc: 'def',
+                    })
+                );
+            });
+
+            it('should call onCreate() on the new bot', async () => {
+                expect.assertions(2);
+
+                uuidMock.mockReturnValueOnce('newBot');
+
+                await channel.sendEvents([
+                    setupChannel('newChannel', {
+                        'onCreate()': 'setTag(this, "created", true)',
+                    }),
+                ]);
+
+                await waitAsync();
+
+                await expect(
+                    manager.hasChannel({
+                        id: 'newChannel',
+                        type: 'aux',
+                    })
+                ).resolves.toBe(true);
+
+                const newChannel = await manager.loadChannel({
+                    id: 'newChannel',
+                    type: 'aux',
+                });
+
+                const newBot = newChannel.simulation.helper.botsState['newBot'];
+                expect(newBot).toEqual(
+                    createPrecalculatedBot('newBot', {
+                        'onCreate()': 'setTag(this, "created", true)',
+                        created: true,
+                    })
+                );
+            });
+
+            it('should not add the new bot if the channel already exists', async () => {
+                expect.assertions(1);
+
+                // Creates the new channel
+                await manager.loadChannel({
+                    id: 'newChannel',
+                    type: 'aux',
+                });
+
+                uuidMock.mockReturnValueOnce('newBot');
+                await channel.sendEvents([
+                    setupChannel('newChannel', {
+                        test: 'abc',
+                    }),
+                ]);
+
+                await waitAsync();
+
+                const newChannel = await manager.loadChannel({
+                    id: 'newChannel',
+                    type: 'aux',
+                });
+
+                const newBot = newChannel.simulation.helper.botsState['newBot'];
+                expect(newBot).toBeUndefined();
+            });
+        });
+    });
+});

--- a/src/aux-server/server/modules/SetupChannelModule.spec.ts
+++ b/src/aux-server/server/modules/SetupChannelModule.spec.ts
@@ -122,7 +122,7 @@ describe('SetupChannelModule', () => {
 
                 await expect(
                     manager.hasChannel({
-                        id: 'newChannel',
+                        id: 'aux-newChannel',
                         type: 'aux',
                     })
                 ).resolves.toBe(true);
@@ -146,13 +146,13 @@ describe('SetupChannelModule', () => {
 
                 await expect(
                     manager.hasChannel({
-                        id: 'newChannel',
+                        id: 'aux-newChannel',
                         type: 'aux',
                     })
                 ).resolves.toBe(true);
 
                 const newChannel = await manager.loadChannel({
-                    id: 'newChannel',
+                    id: 'aux-newChannel',
                     type: 'aux',
                 });
 
@@ -179,13 +179,13 @@ describe('SetupChannelModule', () => {
 
                 await expect(
                     manager.hasChannel({
-                        id: 'newChannel',
+                        id: 'aux-newChannel',
                         type: 'aux',
                     })
                 ).resolves.toBe(true);
 
                 const newChannel = await manager.loadChannel({
-                    id: 'newChannel',
+                    id: 'aux-newChannel',
                     type: 'aux',
                 });
 
@@ -212,13 +212,13 @@ describe('SetupChannelModule', () => {
 
                 await expect(
                     manager.hasChannel({
-                        id: 'newChannel',
+                        id: 'aux-newChannel',
                         type: 'aux',
                     })
                 ).resolves.toBe(true);
 
                 const newChannel = await manager.loadChannel({
-                    id: 'newChannel',
+                    id: 'aux-newChannel',
                     type: 'aux',
                 });
 
@@ -236,7 +236,7 @@ describe('SetupChannelModule', () => {
 
                 // Creates the new channel
                 await manager.loadChannel({
-                    id: 'newChannel',
+                    id: 'aux-newChannel',
                     type: 'aux',
                 });
 
@@ -250,7 +250,7 @@ describe('SetupChannelModule', () => {
                 await waitAsync();
 
                 const newChannel = await manager.loadChannel({
-                    id: 'newChannel',
+                    id: 'aux-newChannel',
                     type: 'aux',
                 });
 

--- a/src/aux-server/server/modules/SetupChannelModule.ts
+++ b/src/aux-server/server/modules/SetupChannelModule.ts
@@ -1,0 +1,114 @@
+import { AuxModule, AuxChannel } from '@casual-simulation/aux-vm';
+import {
+    USERNAME_CLAIM,
+    RealtimeChannelInfo,
+    DeviceInfo,
+    remote,
+    SESSION_ID_CLAIM,
+    GUEST_ROLE,
+} from '@casual-simulation/causal-trees';
+import { Subscription } from 'rxjs';
+import { flatMap, tap } from 'rxjs/operators';
+import {
+    calculateBotValue,
+    getBotRoles,
+    getUserAccountBot,
+    getTokensForUserAccount,
+    findMatchingToken,
+    AuxBot,
+    ShellAction,
+    getChannelBotById,
+    LocalActions,
+    EchoAction,
+    action,
+    SendWebhookAction,
+    BotAction,
+    SetupChannelAction,
+    isBot,
+    createBot,
+    CREATE_ACTION_NAME,
+} from '@casual-simulation/aux-common';
+import {
+    NodeAuxChannel,
+    AuxChannelManager,
+} from '@casual-simulation/aux-vm-node';
+import { sendWebhook } from '../../shared/WebhookUtils';
+
+/**
+ * Defines an AuxModule that adds setup channel functionality.
+ */
+export class SetupChannelModule implements AuxModule {
+    private _channelManager: AuxChannelManager;
+
+    constructor() {}
+
+    setChannelManager(manager: AuxChannelManager) {
+        this._channelManager = manager;
+    }
+
+    async setup(
+        info: RealtimeChannelInfo,
+        channel: NodeAuxChannel
+    ): Promise<Subscription> {
+        let sub = new Subscription();
+
+        sub.add(
+            channel.onLocalEvents
+                .pipe(
+                    flatMap(e => e),
+                    flatMap(async event => {
+                        if (event.type === 'setup_channel') {
+                            await this._setupChannel(info, event);
+                        }
+                    })
+                )
+                .subscribe()
+        );
+
+        return sub;
+    }
+
+    async deviceConnected(
+        info: RealtimeChannelInfo,
+        channel: NodeAuxChannel,
+        device: DeviceInfo
+    ): Promise<void> {}
+
+    async deviceDisconnected(
+        info: RealtimeChannelInfo,
+        channel: NodeAuxChannel,
+        device: DeviceInfo
+    ): Promise<void> {}
+
+    private async _setupChannel(
+        info: RealtimeChannelInfo,
+        event: SetupChannelAction
+    ) {
+        const newChannelInfo = {
+            id: event.channel,
+            type: 'aux',
+        };
+        const hasChannel = await this._channelManager.hasChannel(
+            newChannelInfo
+        );
+        if (!hasChannel) {
+            console.log(
+                `[SetupChannelModule] Setting up new channel ${event.channel}`
+            );
+            const channel = await this._channelManager.loadChannel(
+                newChannelInfo
+            );
+
+            if (event.botOrMod) {
+                const botId = await channel.simulation.helper.createBot(
+                    undefined,
+                    isBot(event.botOrMod) ? event.botOrMod.tags : event.botOrMod
+                );
+                const newBot = channel.simulation.helper.botsState[botId];
+                await channel.simulation.helper.action(CREATE_ACTION_NAME, [
+                    newBot,
+                ]);
+            }
+        }
+    }
+}

--- a/src/aux-server/server/modules/test/TestChannelManager.ts
+++ b/src/aux-server/server/modules/test/TestChannelManager.ts
@@ -16,6 +16,15 @@ import { AuxConfig, AuxUser } from '@casual-simulation/aux-vm';
 
 export class TestChannelManager {
     private _map: Map<string, AuxLoadedChannel> = new Map();
+    private _channelFactory: (
+        info: RealtimeChannelInfo
+    ) => Promise<AuxLoadedChannel>;
+
+    setChannelFactory(
+        factory: (info: RealtimeChannelInfo) => Promise<AuxLoadedChannel>
+    ) {
+        this._channelFactory = factory;
+    }
 
     addChannel(info: RealtimeChannelInfo, channel: AuxLoadedChannel) {
         this._map.set(info.id, channel);
@@ -26,7 +35,14 @@ export class TestChannelManager {
     }
 
     async loadChannel(info: RealtimeChannelInfo): Promise<AuxLoadedChannel> {
-        return this._map.get(info.id);
+        let channel = this._map.get(info.id);
+
+        if (!channel && this._channelFactory) {
+            channel = await this._channelFactory(info);
+            this._map.set(info.id, channel);
+        }
+
+        return channel;
     }
 }
 

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -69,6 +69,7 @@ import Stripe from 'stripe';
 import csp from 'helmet-csp';
 import { CspOptions } from 'helmet-csp/dist/lib/types';
 import { FilesModule } from './modules/FilesModule';
+import { SetupChannelModule } from './modules/SetupChannelModule';
 
 const connect = pify(MongoClient.connect);
 
@@ -738,6 +739,7 @@ export class Server {
 
         const checkout = new CheckoutModule(key => new Stripe(key));
         const webhook = new WebhooksModule();
+        const setupChannel = new SetupChannelModule();
         this._channelManager = new AuxChannelManagerImpl(
             serverUser,
             serverDevice,
@@ -750,11 +752,13 @@ export class Server {
                 new FilesModule(this._config.drives),
                 checkout,
                 webhook,
+                setupChannel,
             ]
         );
 
         checkout.setChannelManager(this._channelManager);
         webhook.setChannelManager(this._channelManager);
+        setupChannel.setChannelManager(this._channelManager);
 
         const authenticator = new NullDeviceAuthenticator();
         const authorizer = new NullChannelAuthorizer();


### PR DESCRIPTION
### Changes:

-   Added the `server.setupChannel(channel, botOrMod)` function.
    -   This sends a `setup_channel` action to the server which, if executed using `action.perform()`, will create a channel if it doesn't already exist and place a clone of the given bot or mod in it.
    -   Takes 2 parameters:
        -   `channel` - The channel that should be created.
        -   `botOrMod` - (Optional) The bot or mod that should be cloned and placed inside the new channel. `onCreate()` is triggered after the bot or mod is created so you can use that to script custom setup logic.
    -   As mentioned above, you have to receive the `device` action in `onAnyAction()` and do an `action.perform(that.action.event)` to allow channels to be setup via this function.