### PR TITLE
Fixed bugs 7886 and 7763 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # AUX Changelog
 
+## V0.11.8
+
+### Date: TBD
+
+### Changes:
+
+-   Bug Fixes
+    -   Tag values that are objects are displayed as JSON.Stringified text. ie `{ field: "myValue" }`
+        -   Known Issue: Modifying these displayed strings will convert the tag value to a string
+    -   When Moving the camera via `player.MoveTo()`, the pan distance is now set correctly so pan limits are absolute.
+
 ## V0.11.7
 
 ### Date: TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # AUX Changelog
 
-## V0.11.8
-
-### Date: TBD
-
-### Changes:
-
--   Bug Fixes
-    -   Tag values that are objects are displayed as JSON.Stringified text. ie `{ field: "myValue" }`
-        -   Known Issue: Modifying these displayed strings will convert the tag value to a string
-    -   When Moving the camera via `player.MoveTo()`, the pan distance is now set correctly so pan limits are absolute.
-
 ## V0.11.7
 
 ### Date: TBD
@@ -19,6 +8,9 @@
 
 -   Bug Fixes
     -   Resolved issue of player inventory resizing showing a reset on each change.
+    -   Tag values that are objects are displayed as JSON.Stringified text. ie `{ field: "myValue" }`
+        -   Known Issue: Modifying these displayed strings will convert the tag value to a string
+    -   When Moving the camera via `player.MoveTo()`, the pan distance is now set correctly so pan limits are absolute.
 
 ## V0.11.6
 

--- a/src/aux-server/aux-web/aux-projector/BotValue/BotValue.ts
+++ b/src/aux-server/aux-web/aux-projector/BotValue/BotValue.ts
@@ -98,6 +98,8 @@ export default class BotRow extends Vue {
                 this.value = assignment.editing
                     ? assignment.formula
                     : assignment.value;
+            } else if (typeof val === 'object') {
+                this.value = JSON.stringify(val);
             } else {
                 this.value = val;
             }

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -433,6 +433,9 @@ export function getScript(bot: Bot, tag: string) {
     let val = bot.tags[tag];
     if (typeof val !== 'undefined' && val !== null) {
         let str = val.toString();
+        if (typeof val === 'object') {
+            str = JSON.stringify(val);
+        }
         if (isFormula(str)) {
             return transpiler.replaceMacros(str);
         } else {

--- a/src/aux-server/aux-web/shared/interaction/CameraControls.ts
+++ b/src/aux-server/aux-web/shared/interaction/CameraControls.ts
@@ -870,6 +870,10 @@ export class CameraControls {
         // move target to panned location
         this.target.add(this.panOffset);
         this.target.add(this.cameraOffset);
+        if (this.cameraOffset.length() > 0) {
+            this.currentDistX = this.target.x;
+            this.currentDistY = this.target.y;
+        }
 
         if (this.resetRot === true) {
             this.resetRotation();


### PR DESCRIPTION
Fixed  [7763](https://favro.com/organization/be53ac939ef0ec4b260f4823/0a73c24336ea02e1f6b1f2c5?card=yet-7763). When calling `player.MoveTo()`, the pan distance was not being updated. Now, the pan distance will correctly be set to the new location. Warning: Moving the camera outside the pan distance will likely lock panning. 

Fixed [7886](https://favro.com/organization/be53ac939ef0ec4b260f4823/0a73c24336ea02e1f6b1f2c5?card=yet-7886). When tag values are set to objects (for instance, with `setTag(this, 'tag', anObject)`), the tag value is now displayed as a JSON.Stringified string rather than `[Object object]`. Warning: editing this text will convert the tag value to a string. You should use the tag value as just a view this way, as text will not be converted to an object.