### PR TITLE
Add the "tags" function and formula variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@
     -   Added the `tags` variable to all functions and formulas.
         -   This is a quick shortcut for `let tags = getMod(bot)` at the beginning of a script/formula.
         -   The `tags` variable has some caveats when used in formulas. Namely that the formulas won't be automatically updated when another tag referenced from the formula is updated. (Use `getTag()` for full support)
+        -   Supports autocomplete for all tags.
 
 ## V0.11.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,14 @@
         -   Usage: `renameTagsFromDotCaseToCamelCase(bot)`
     -   Added the `bot` variable to all functions and formulas.
         -   Replacement for `this`.
+    -   Added the `getMod()` function to be able to get all the tags on a bot.
+        -   Returns a mod containing all the tag values on the bot.
+        -   The returned mod is always up to date with the bot's current values.
+        -   Calling `mod.export()` on the returned mod will save the tag code to JSON.
+            -   For example, if you have a formula `=123`, then `mod.export(getMod(bot))` will return JSON containing `tag: "=123"` instead of `tag: 123`.
+    -   Added the `tags` variable to all functions and formulas.
+        -   This is a quick shortcut for `let tags = getMod(bot)` at the beginning of a script/formula.
+        -   The `tags` variable has some caveats when used in formulas. Namely that the formulas won't be automatically updated when another tag referenced from the formula is updated. (Use `getTag()` for full support)
 
 ## V0.11.8
 

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -63,6 +63,7 @@ import {
     trimEvent,
     hasValue,
     createBot,
+    getBotValues,
 } from '../bots/BotCalculations';
 
 import '../polyfill/Array.first.polyfill';
@@ -1677,6 +1678,14 @@ function exportMod(bot: any): string {
 }
 
 /**
+ * Gets a mod of the tags from the given bot.
+ * @param bot The bot.
+ */
+function getMod(bot: Bot): Mod {
+    return getBotValues(getCalculationContext(), bot);
+}
+
+/**
  * Applies the given diff to the given bot.
  * @param bot The bot.
  * @param diff The diff to apply.
@@ -2218,6 +2227,7 @@ export default {
 
     getBot,
     getBots,
+    getMod,
     getBotTagValues,
     byTag,
     byMod,

--- a/src/aux-common/bots/BotActions.ts
+++ b/src/aux-common/bots/BotActions.ts
@@ -155,7 +155,7 @@ export function calculateFormulaEvents(
         sandboxFactory
     );
 
-    let [botEvents] = formulaActions(state, context, [], null, [formula]);
+    let [botEvents] = formulaActions(state, context, null, null, [formula]);
 
     return [...botEvents, ...context.sandbox.interface.getBotUpdates()];
 }

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1453,6 +1453,9 @@ export function getBotValues(
     calc: BotSandboxContext,
     bot: Bot
 ): PrecalculatedTags {
+    if (!bot) {
+        return null;
+    }
     if (isPrecalculated(bot)) {
         return bot.values;
     }

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1445,6 +1445,46 @@ export function getBotShape(calc: BotCalculationContext, bot: Bot): BotShape {
 }
 
 /**
+ * Gets a mod for the bot.
+ * @param calc The sandbox calculation context.
+ * @param bot The bot to get the values of.
+ */
+export function getBotValues(
+    calc: BotSandboxContext,
+    bot: Bot
+): PrecalculatedTags {
+    if (isPrecalculated(bot)) {
+        return bot.values;
+    }
+
+    const o = {
+        ...bot.tags,
+    };
+    const p = new Proxy(o, {
+        get(target, key, proxy) {
+            if (key === 'toJSON') {
+                return Reflect.get(target, key, proxy);
+            }
+            return calc.sandbox.interface.getTag(bot, key as string);
+        },
+        set(target, key, proxy) {
+            return false;
+        },
+    });
+
+    // Define a toJSON() function but
+    // make it not enumerable so it is not included
+    // in Object.keys() and for..in expressions.
+    Object.defineProperty(p, 'toJSON', {
+        value: () => bot.tags,
+        writable: false,
+        enumerable: false,
+    });
+
+    return p;
+}
+
+/**
  * Gets the anchor position for the bot's label.
  * @param calc The calculation context to use.
  * @param bot The bot.
@@ -2753,6 +2793,7 @@ function _calculateFormulaValue(
 
     let vars = {
         bot: object,
+        tags: getBotValues(context, object),
     };
 
     // NOTE: The energy should not get reset

--- a/src/aux-common/bots/BotsChannel.ts
+++ b/src/aux-common/bots/BotsChannel.ts
@@ -13,6 +13,7 @@ import {
     ON_SHOUT_ACTION_NAME,
     FilterParseResult,
     filtersOnBot,
+    getBotValues,
 } from './BotCalculations';
 import {
     getActions,
@@ -209,7 +210,7 @@ function eventActions(
 export function formulaActions(
     state: BotsState,
     context: BotSandboxContext,
-    thisObject: any,
+    thisObject: Bot,
     arg: any,
     scripts: string[]
 ): [BotAction[], any[]] {
@@ -231,6 +232,7 @@ export function formulaActions(
 
     vars['that'] = arg;
     vars['bot'] = thisObject;
+    vars['tags'] = getBotValues(context, thisObject);
 
     let results: any[] = [];
     for (let script of scripts) {

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -141,6 +141,84 @@ export function botActionsTests(
             ]);
         });
 
+        it('should pass in a tags variable which equals getMod(this)', () => {
+            const state: BotsState = {
+                thisBot: {
+                    id: 'thisBot',
+                    tags: {
+                        auxColor: 'red',
+                        'test()': 'setTag(this, "other", tags.auxColor)',
+                    },
+                },
+                thatBot: {
+                    id: 'thatBot',
+                    tags: {
+                        name: 'Joe',
+                    },
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const botAction = action('test', ['thisBot']);
+            const result = calculateActionEvents(
+                state,
+                botAction,
+                createSandbox
+            );
+
+            expect(result.hasUserDefinedEvents).toBe(true);
+
+            expect(result.events).toEqual([
+                botUpdated('thisBot', {
+                    tags: {
+                        other: 'red',
+                    },
+                }),
+            ]);
+        });
+
+        it('should update the tags variable when setTag() is called', () => {
+            const state: BotsState = {
+                thisBot: {
+                    id: 'thisBot',
+                    tags: {
+                        auxColor: 'red',
+                        'test()': `
+                            setTag(this, "other", tags.auxColor);
+                            setTag(this, "final", tags.other);
+                        `,
+                    },
+                },
+                thatBot: {
+                    id: 'thatBot',
+                    tags: {
+                        name: 'Joe',
+                    },
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const botAction = action('test', ['thisBot']);
+            const result = calculateActionEvents(
+                state,
+                botAction,
+                createSandbox
+            );
+
+            expect(result.hasUserDefinedEvents).toBe(true);
+
+            expect(result.events).toEqual([
+                botUpdated('thisBot', {
+                    tags: {
+                        other: 'red',
+                        final: 'red',
+                    },
+                }),
+            ]);
+        });
+
         it('should preserve formulas when copying', () => {
             const state: BotsState = {
                 thisBot: {

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -2974,6 +2974,12 @@ export function botCalculationContextTests(
     });
 
     describe('getBotValues()', () => {
+        it('should return null if given null', () => {
+            const calc = createCalculationContext([]);
+            const tags = getBotValues(calc, null);
+            expect(tags).toBe(null);
+        });
+
         it('should return an object of tag values from the bot', () => {
             const bot = createBot('bot', {
                 auxColor: 'red',

--- a/src/aux-server/aux-web/shared/CompletionHelpers.spec.ts
+++ b/src/aux-server/aux-web/shared/CompletionHelpers.spec.ts
@@ -1,0 +1,18 @@
+import { propertyInsertText } from './CompletionHelpers';
+
+describe('CompletionHelpers', () => {
+    describe('propertyInsertText()', () => {
+        it('should return the property if it is alphanumeric', () => {
+            expect(propertyInsertText('abc')).toEqual('.abc');
+            expect(propertyInsertText('a123')).toEqual('.a123');
+            expect(propertyInsertText('a_b_c')).toEqual('.a_b_c');
+            expect(propertyInsertText('_1')).toEqual('._1');
+        });
+
+        it('should return the property with brackets if it is not alphanumeric', () => {
+            expect(propertyInsertText('1abc')).toEqual('["1abc"]');
+            expect(propertyInsertText('test.tag')).toEqual('["test.tag"]');
+            expect(propertyInsertText('@fun')).toEqual('["@fun"]');
+        });
+    });
+});

--- a/src/aux-server/aux-web/shared/CompletionHelpers.ts
+++ b/src/aux-server/aux-web/shared/CompletionHelpers.ts
@@ -1,0 +1,7 @@
+export function propertyInsertText(property: string): string {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(property)) {
+        return `.${property}`;
+    } else {
+        return `["${property}"]`;
+    }
+}

--- a/src/aux-server/aux-web/shared/FormulaHelpers.ts
+++ b/src/aux-server/aux-web/shared/FormulaHelpers.ts
@@ -24,6 +24,7 @@ export function calculateFormulaDefinitions(options?: FormulaLibraryOptions) {
             'declare global {',
             ...Object.keys(formulaLib).map(k => `  const ${k}: _${k};`),
             `  const bot: Bot;`,
+            `  const tags: BotTags;`,
             '}',
         ].join('\n');
 


### PR DESCRIPTION
-   Added the `getMod()` function to be able to get all the tags on a bot.
    -   Returns a mod containing all the tag values on the bot.
    -   The returned mod is always up to date with the bot's current values.
    -   Calling `mod.export()` on the returned mod will save the tag code to JSON.
        -   For example, if you have a formula `=123`, then `mod.export(getMod(bot))` will return JSON containing `tag: "=123"` instead of `tag: 123`.
-   Added the `tags` variable to all functions and formulas.
    -   This is a quick shortcut for `let tags = getMod(bot)` at the beginning of a script/formula.
    -   The `tags` variable has some caveats when used in formulas. Namely that the formulas won't be automatically updated when another tag referenced from the formula is updated. (Use `getTag()` for full support)
    -   Supports autocomplete for all tags.