### PR TITLE
Make create() automatically set auxCreator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # AUX Changelog
 
+## V0.11.11
+
+### Date: TBD
+
+### Changes:
+
+-   **Breaking Changes**
+    -   Changed `create()` and `createTemp()` to automatically set `auxCreator` to the current `this` bot.
+        -   `create()` no longer takes a bot/bot ID as the first parameter. Instead, you need to use the `from()` function to set the creator ID.
+        -   e.g. `create(from(bot))`.
+
 ## V0.11.10
 
 ### Date: 12/9/2019

--- a/src/aux-common/Formulas/formula-lib-globals.ts
+++ b/src/aux-common/Formulas/formula-lib-globals.ts
@@ -1,10 +1,11 @@
-import { BotsState } from '../bots/Bot';
+import { BotsState, Bot } from '../bots/Bot';
 import { BotAction } from '../bots/BotEvents';
 import { BotSandboxContext } from '../bots/BotCalculationContext';
 
 let actions: BotAction[] = [];
 let state: BotsState = null;
 let calc: BotSandboxContext = null;
+let currentBot: Bot = null;
 let currentEnergy: number = 0;
 
 export function setActions(value: BotAction[]) {
@@ -51,4 +52,12 @@ export function getEnergy(): number {
 
 export function setEnergy(energy: number) {
     currentEnergy = energy;
+}
+
+export function getCurrentBot() {
+    return currentBot;
+}
+
+export function setCurrentBot(bot: Bot) {
+    currentBot = bot;
 }

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -77,6 +77,7 @@ import {
     getEnergy,
     setEnergy,
     addAction,
+    getCurrentBot,
 } from './formula-lib-globals';
 import {
     remote as calcRemote,
@@ -660,7 +661,7 @@ function createFromMods(idFactory: () => string, ...mods: (Mod | Mod[])[]) {
             }
 
             variants = newVariants;
-        } else {
+        } else if (typeof diff === 'object') {
             for (let b = 0; b < variants.length; b++) {
                 variants[b].push(diff);
             }
@@ -711,18 +712,16 @@ function getBotId(bot: Bot | string): string {
     }
 }
 
-function createBase(
-    idFactory: () => string,
-    parent: Bot | string,
-    ...datas: Mod[]
-) {
-    let parentId = getBotId(parent);
-    let parentDiff = parentId
-        ? {
-              auxCreator: parentId,
-          }
-        : {};
-    return createFromMods(idFactory, ...datas, parentDiff);
+function createBase(idFactory: () => string, ...datas: Mod[]) {
+    // let parentId = getBotId(parent);
+    // let parentDiff = parentId
+    //     ? {
+    //           auxCreator: parentId,
+    //       }
+    //     : {};
+    let parent = getCurrentBot();
+    let parentDiff = parent ? from(parent) : {};
+    return createFromMods(idFactory, parentDiff, ...datas);
 }
 
 /**
@@ -743,8 +742,8 @@ function createBase(
  * ]);
  *
  */
-function create(parent: Bot | string, ...mods: Mod[]) {
-    return createBase(() => uuid(), parent, ...mods);
+function create(...mods: Mod[]) {
+    return createBase(() => uuid(), ...mods);
 }
 
 /**
@@ -765,8 +764,24 @@ function create(parent: Bot | string, ...mods: Mod[]) {
  * ]);
  *
  */
-function createTemp(parent: Bot | string, ...mods: Mod[]) {
-    return createBase(() => `T-${uuid()}`, parent, ...mods);
+function createTemp(...mods: Mod[]) {
+    return createBase(() => `T-${uuid()}`, ...mods);
+}
+
+/**
+ * Creates a mod that sets the auxCreator of a bot to the given bot.
+ * @param creator The bot or Bot ID of the creator.
+ */
+function from(creator: Bot | string): Mod {
+    let parentId = getBotId(creator);
+    let parentDiff = parentId
+        ? {
+              auxCreator: parentId,
+          }
+        : {
+              auxCreator: null,
+          };
+    return parentDiff;
 }
 
 /**
@@ -2224,6 +2239,7 @@ export default {
     whisper,
     remote,
     webhook,
+    from,
 
     getBot,
     getBots,

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -53,6 +53,8 @@ import {
     getActions,
     getEnergy,
     setEnergy,
+    getCurrentBot,
+    setCurrentBot,
 } from '../Formulas/formula-lib-globals';
 import { PartialBot } from '../bots';
 import { merge, shortUuid } from '../utils';
@@ -2585,15 +2587,18 @@ export function calculateFormulaValue(
 ) {
     const prevCalc = getCalculationContext();
     const prevEnergy = getEnergy();
+    const prevBot = getCurrentBot();
     setCalculationContext(context);
 
     // TODO: Allow configuring energy per formula
     setEnergy(DEFAULT_ENERGY);
+    setCurrentBot(null);
 
     const result = context.sandbox.run(formula, extras, context);
 
     setCalculationContext(prevCalc);
     setEnergy(prevEnergy);
+    setCurrentBot(prevBot);
     return result;
 }
 
@@ -2795,7 +2800,9 @@ function _calculateFormulaValue(
     energy?: number
 ) {
     const prevCalc = getCalculationContext();
+    const prevBot = getCurrentBot();
     setCalculationContext(context);
+    setCurrentBot(object);
 
     let vars = {
         bot: object,
@@ -2816,5 +2823,6 @@ function _calculateFormulaValue(
     );
 
     setCalculationContext(prevCalc);
+    setCurrentBot(prevBot);
     return result;
 }

--- a/src/aux-common/bots/BotsChannel.ts
+++ b/src/aux-common/bots/BotsChannel.ts
@@ -25,6 +25,8 @@ import {
     setCalculationContext,
     getEnergy,
     setEnergy,
+    getCurrentBot,
+    setCurrentBot,
 } from '../Formulas/formula-lib-globals';
 import sortBy from 'lodash/sortBy';
 
@@ -219,6 +221,7 @@ export function formulaActions(
     let prevState = getBotState();
     let prevUserId = getUserId();
     let prevEnergy = getEnergy();
+    let prevBot = getCurrentBot();
     let actions: BotAction[] = [];
     let vars: {
         [key: string]: any;
@@ -229,6 +232,7 @@ export function formulaActions(
 
     // TODO: Allow configuring energy per action
     setEnergy(DEFAULT_ENERGY);
+    setCurrentBot(thisObject);
 
     vars['that'] = arg;
     vars['bot'] = thisObject;
@@ -246,5 +250,6 @@ export function formulaActions(
     setBotState(prevState);
     setCalculationContext(prevContext);
     setEnergy(prevEnergy);
+    setCurrentBot(prevBot);
     return [actions, results];
 }


### PR DESCRIPTION
### Changes:

-   **Breaking Changes**
    -   Changed `create()` and `createTemp()` to automatically set `auxCreator` to the current `this` bot.
        -   `create()` no longer takes a bot/bot ID as the first parameter. Instead, you need to use the `from()` function to set the creator ID.
        -   e.g. `create(from(bot))`.