### PR TITLE
Add a bunch of UX improvements for listener and formula tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
         -   On Chrome and Firefox, the text will be copied directly to the user's clipboard.
         -   On Safari and all iOS browsers, a popup will be triggered with a copy button allowing the user to copy the text to their clipboard.
     -   Tags that contain listeners will now display with a @ symbol in front of the tag name.
+    -   Removed the @ symbol from the first line in the code editor when editing a script.
 
 ## V0.11.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
     -   Removed the @ symbol from the first line in the code editor when editing a script.
     -   Added the ability to use an @ symbol while creating a new tag to prefill the editor with an @.
     -   Added the ability to use @ symbols in tags in `getTag()`, `setTag()`, `getBot()`, `getBots()`, `byTag()`, `shout()`, and `whisper()`.
+    -   Added tag filters for listener tags and formula tags to the bot table.
 
 ## V0.11.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
     -   Tags that contain formulas will now diwplay with a = sign after the tag name.
     -   Removed the @ symbol from the first line in the code editor when editing a script.
     -   Added the ability to use an @ symbol while creating a new tag to prefill the editor with an @.
+    -   Added the ability to use @ symbols in tags in `getTag()`, `setTag()`, `getBot()`, `getBots()`, `byTag()`, `shout()`, and `whisper()`.
 
 ## V0.11.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     -   Tags that contain listeners will now display with a @ symbol in front of the tag name.
     -   Tags that contain formulas will now diwplay with a = sign after the tag name.
     -   Removed the @ symbol from the first line in the code editor when editing a script.
+    -   Added the ability to use an @ symbol while creating a new tag to prefill the editor with an @.
 
 ## V0.11.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
         -   On Chrome and Firefox, the text will be copied directly to the user's clipboard.
         -   On Safari and all iOS browsers, a popup will be triggered with a copy button allowing the user to copy the text to their clipboard.
     -   Tags that contain listeners will now display with a @ symbol in front of the tag name.
-    -   Tags that contain formulas will now diwplay with a = sign after the tag name.
+    -   Tags that contain formulas will now display with a = sign after the tag name.
     -   Removed the @ symbol from the first line in the code editor when editing a script.
     -   Added the ability to use an @ symbol while creating a new tag to prefill the editor with an @.
     -   Added the ability to use @ symbols in tags in `getTag()`, `setTag()`, `getBot()`, `getBots()`, `byTag()`, `shout()`, and `whisper()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
         -   ex. `player.setClipboard("abc")` will set the user's clipboard to "abc".
         -   On Chrome and Firefox, the text will be copied directly to the user's clipboard.
         -   On Safari and all iOS browsers, a popup will be triggered with a copy button allowing the user to copy the text to their clipboard.
+    -   Tags that contain listeners will now display with a @ symbol in front of the tag name.
 
 ## V0.11.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
         -   On Chrome and Firefox, the text will be copied directly to the user's clipboard.
         -   On Safari and all iOS browsers, a popup will be triggered with a copy button allowing the user to copy the text to their clipboard.
     -   Tags that contain listeners will now display with a @ symbol in front of the tag name.
+    -   Tags that contain formulas will now diwplay with a = sign after the tag name.
     -   Removed the @ symbol from the first line in the code editor when editing a script.
 
 ## V0.11.15

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1052,7 +1052,7 @@ export function calculateStateDiff(
  * Trims the leading # symbol off the given tag.
  */
 export function trimTag(tag: string): string {
-    if (tag.indexOf('#') === 0) {
+    if (tag.startsWith('#') || tag.startsWith('@')) {
         return tag.substring(1);
     }
     return tag;

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -1985,6 +1985,8 @@ export function botActionsTests(
             ['parenthesis', 'sayHello()'],
             ['hashtag', '#sayHello'],
             ['hashtag and parenthesis', '#sayHello()'],
+            ['@ symbol', '@sayHello'],
+            ['@ symbol and parenthesis', '@sayHello()'],
         ];
 
         describe('shout()', () => {

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -1337,6 +1337,46 @@ export function botCalculationContextTests(
                     expect(unwrapped).toEqual(botA);
                 });
 
+                it('should allow using @ symbols when getting bots by tags', () => {
+                    const botA = createBot('a', {
+                        name: 'bob',
+                        formula: '=getBot("@name")',
+                    });
+                    const botB = createBot('b', {
+                        name: 'bob',
+                    });
+
+                    // specify the UUID to use next
+                    uuidMock.mockReturnValue('uuid-0');
+                    const context = createCalculationContext([botA, botB]);
+                    const result = calculateBotValue(context, botA, 'formula');
+                    const unwrapped = context.sandbox.interface.unwrapBot(
+                        result
+                    );
+
+                    expect(unwrapped).toEqual(botA);
+                });
+
+                it('should remove the first @ symbol but not the second', () => {
+                    const botA = createBot('a', {
+                        '@name': 'bob',
+                        formula: '=getBot("@@name")',
+                    });
+                    const botB = createBot('b', {
+                        '@name': 'bob',
+                    });
+
+                    // specify the UUID to use next
+                    uuidMock.mockReturnValue('uuid-0');
+                    const context = createCalculationContext([botA, botB]);
+                    const result = calculateBotValue(context, botA, 'formula');
+                    const unwrapped = context.sandbox.interface.unwrapBot(
+                        result
+                    );
+
+                    expect(unwrapped).toEqual(botA);
+                });
+
                 it('should get the first bot matching the given filter function', () => {
                     const botA = createBot('a', {
                         name: 'bob',
@@ -1489,6 +1529,30 @@ export function botCalculationContextTests(
                     expect(result).toEqual(['bob', 'alice', 'bob']);
                 });
 
+                it('should support using an @ symbol at the beginning of a tag', () => {
+                    const botA = createBot('a', {
+                        name: 'bob',
+                        formula: '=getBotTagValues("@name")',
+                    });
+                    const botB = createBot('b', {
+                        name: 'alice',
+                    });
+                    const botC = createBot('c', {
+                        name: 'bob',
+                    });
+
+                    // specify the UUID to use next
+                    uuidMock.mockReturnValue('uuid-0');
+                    const context = createCalculationContext([
+                        botB,
+                        botA,
+                        botC,
+                    ]);
+                    const result = calculateBotValue(context, botA, 'formula');
+
+                    expect(result).toEqual(['bob', 'alice', 'bob']);
+                });
+
                 it('should get the list of bots with the given tag matching the given value', () => {
                     const botA = createBot('a', {
                         name: 'bob',
@@ -1543,6 +1607,20 @@ export function botCalculationContextTests(
                     const botA = createBot('a', {
                         name: 'bob',
                         formula: '=getTag(this, "#name")',
+                    });
+
+                    // specify the UUID to use next
+                    uuidMock.mockReturnValue('uuid-0');
+                    const context = createCalculationContext([botA]);
+                    const result = calculateBotValue(context, botA, 'formula');
+
+                    expect(result).toEqual('bob');
+                });
+
+                it('should support using an @ symbol at the beginning of a tag', () => {
+                    const botA = createBot('a', {
+                        name: 'bob',
+                        formula: '=getTag(this, "@name")',
                     });
 
                     // specify the UUID to use next
@@ -1628,6 +1706,44 @@ export function botCalculationContextTests(
                             expect(value(bot2)).toBe(expected);
                         }
                     );
+
+                    it('should support using a hashtag at the beginning of a tag', () => {
+                        const bot = createBot('test', {
+                            formula: '=byTag("#red")',
+                        });
+
+                        const context = createCalculationContext([bot]);
+                        const value = calculateBotValue(
+                            context,
+                            bot,
+                            'formula'
+                        );
+
+                        const bot2 = createBot('test', {
+                            red: 'abc',
+                        });
+
+                        expect(value(bot2)).toBe(true);
+                    });
+
+                    it('should support using a @ symbol at the beginning of a tag', () => {
+                        const bot = createBot('test', {
+                            formula: '=byTag("@red")',
+                        });
+
+                        const context = createCalculationContext([bot]);
+                        const value = calculateBotValue(
+                            context,
+                            bot,
+                            'formula'
+                        );
+
+                        const bot2 = createBot('test', {
+                            red: 'abc',
+                        });
+
+                        expect(value(bot2)).toBe(true);
+                    });
                 });
 
                 describe('tag + value', () => {

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -22,6 +22,7 @@ import {
     DEFAULT_WORKSPACE_SCALE,
     AuxBot,
     PrecalculatedBot,
+    isScript,
 } from '@casual-simulation/aux-common';
 import { EventBus } from '../../shared/EventBus';
 
@@ -163,6 +164,12 @@ export default class BotTable extends Vue {
 
     isBotReadOnly(bot: Bot): boolean {
         return this.editableMap.get(bot.id) === false;
+    }
+
+    isTagOnlyScripts(tag: string) {
+        return this.bots.every(
+            b => !hasValue(b.tags[tag]) || isScript(b.tags[tag])
+        );
     }
 
     get botTableGridStyle() {

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -23,6 +23,7 @@ import {
     AuxBot,
     PrecalculatedBot,
     isScript,
+    parseScript,
 } from '@casual-simulation/aux-common';
 import { EventBus } from '../../shared/EventBus';
 
@@ -418,6 +419,9 @@ export default class BotTable extends Vue {
         }
 
         if (this.isMakingNewTag) {
+            const { tag, isScript } = this._formatNewTag(this.newTag);
+            this.newTag = tag;
+
             this.dropDownUsed = true;
             this.newTagOpen = true;
 
@@ -475,6 +479,10 @@ export default class BotTable extends Vue {
                 for (let tag of tags) {
                     if (tag.tag === addedTag) {
                         tag.$el.focus();
+                        // This is a super hacky way to pre-fill the first bot's tag with an @ symbol
+                        if (isScript) {
+                            tag.setInitialValue('@');
+                        }
                         break;
                     }
                 }
@@ -483,6 +491,13 @@ export default class BotTable extends Vue {
             this.newTag = '';
             this.newTagPlacement = placement;
         }
+    }
+
+    private _formatNewTag(newTag: string) {
+        return {
+            tag: parseScript(newTag),
+            isScript: isScript(newTag),
+        };
     }
 
     openNewTag(placement: NewTagPlacement = 'top') {
@@ -496,7 +511,8 @@ export default class BotTable extends Vue {
             return;
         }
 
-        this.newTag = inputTag;
+        const { tag, isScript } = this._formatNewTag(inputTag);
+        this.newTag = tag;
         this.newTagPlacement = 'bottom';
 
         this.dropDownUsed = true;
@@ -553,7 +569,10 @@ export default class BotTable extends Vue {
             for (let tag of tags) {
                 if (tag.tag === addedTag) {
                     tag.$el.focus();
-
+                    // This is a super hacky way to pre-fill the first bot's tag with an @ symbol
+                    if (isScript) {
+                        tag.setInitialValue('@');
+                    }
                     break;
                 }
             }

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -46,6 +46,7 @@ import Bowser from 'bowser';
 import BotTagMini from '../BotTagMini/BotTagMini';
 import TagValueEditor from '../../shared/vue-components/TagValueEditor/TagValueEditor';
 import { first } from 'rxjs/operators';
+import sumBy from 'lodash/sumBy';
 
 @Component({
     components: {
@@ -167,9 +168,13 @@ export default class BotTable extends Vue {
     }
 
     isTagOnlyScripts(tag: string) {
-        return this.bots.every(
-            b => !hasValue(b.tags[tag]) || isScript(b.tags[tag])
+        const numScripts = sumBy(this.bots, b =>
+            isScript(b.tags[tag]) ? 1 : 0
         );
+        const emptyScripts = sumBy(this.bots, b =>
+            !hasValue(b.tags[tag]) ? 1 : 0
+        );
+        return numScripts > 0 && this.bots.length === numScripts + emptyScripts;
     }
 
     get botTableGridStyle() {

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -141,7 +141,7 @@ export default class BotTable extends Vue {
     }
 
     isSpecialTag(tag: string): boolean {
-        if (tag === '@' || tag === 'hidden') {
+        if (tag === '@' || tag === 'hidden' || tag === '=') {
             return true;
         } else {
             return false;
@@ -827,6 +827,7 @@ export default class BotTable extends Vue {
         let hiddenList: (string | boolean)[] = [];
         let generalList: (string | boolean)[] = [];
         let listenerList: (string | boolean)[] = [];
+        let formulaList: (string | boolean)[] = [];
 
         for (let i = sortedArray.length - 1; i >= 0; i--) {
             const tag = sortedArray[i];
@@ -840,6 +841,13 @@ export default class BotTable extends Vue {
             }
             if (this.isTagOnlyScripts(tag)) {
                 listenerList.push(tag);
+                if (!removed) {
+                    sortedArray.splice(i, 1);
+                    removed = true;
+                }
+            }
+            if (this.isTagOnlyFormulas(tag)) {
+                formulaList.push(tag);
                 if (!removed) {
                     sortedArray.splice(i, 1);
                     removed = true;
@@ -939,6 +947,22 @@ export default class BotTable extends Vue {
             listenerList.unshift(activeCheck);
             listenerList.unshift('@');
             blacklist.unshift(listenerList);
+        }
+
+        if (formulaList.length > 0) {
+            let activeCheck = false;
+
+            if (this.tagBlacklist.length > 0) {
+                this.tagBlacklist.forEach(element => {
+                    if (element[0] === '@') {
+                        activeCheck = <boolean>element[1];
+                    }
+                });
+            }
+
+            formulaList.unshift(activeCheck);
+            formulaList.unshift('=');
+            blacklist.unshift(formulaList);
         }
 
         if (sortedArray.length > 0) {

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -171,10 +171,20 @@ export default class BotTable extends Vue {
         const numScripts = sumBy(this.bots, b =>
             isScript(b.tags[tag]) ? 1 : 0
         );
-        const emptyScripts = sumBy(this.bots, b =>
+        const emptyTags = sumBy(this.bots, b =>
             !hasValue(b.tags[tag]) ? 1 : 0
         );
-        return numScripts > 0 && this.bots.length === numScripts + emptyScripts;
+        return numScripts > 0 && this.bots.length === numScripts + emptyTags;
+    }
+
+    isTagOnlyFormulas(tag: string) {
+        const numFormulas = sumBy(this.bots, b =>
+            isFormula(b.tags[tag]) ? 1 : 0
+        );
+        const emptyTags = sumBy(this.bots, b =>
+            !hasValue(b.tags[tag]) ? 1 : 0
+        );
+        return numFormulas > 0 && this.bots.length === numFormulas + emptyTags;
     }
 
     get botTableGridStyle() {

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -141,7 +141,7 @@ export default class BotTable extends Vue {
     }
 
     isSpecialTag(tag: string): boolean {
-        if (tag === 'actions()' || tag === 'hidden') {
+        if (tag === '@' || tag === 'hidden') {
             return true;
         } else {
             return false;
@@ -826,11 +826,24 @@ export default class BotTable extends Vue {
 
         let hiddenList: (string | boolean)[] = [];
         let generalList: (string | boolean)[] = [];
+        let listenerList: (string | boolean)[] = [];
 
         for (let i = sortedArray.length - 1; i >= 0; i--) {
-            if (isHiddenTag(sortedArray[i])) {
-                hiddenList.push(sortedArray[i]);
-                sortedArray.splice(i, 1);
+            const tag = sortedArray[i];
+            let removed = false;
+            if (isHiddenTag(tag)) {
+                hiddenList.push(tag);
+                if (!removed) {
+                    sortedArray.splice(i, 1);
+                    removed = true;
+                }
+            }
+            if (this.isTagOnlyScripts(tag)) {
+                listenerList.push(tag);
+                if (!removed) {
+                    sortedArray.splice(i, 1);
+                    removed = true;
+                }
             }
         }
 
@@ -910,6 +923,22 @@ export default class BotTable extends Vue {
             hiddenList.forEach(hiddenTags => {
                 sortedArray.push(<string>hiddenTags);
             });
+        }
+
+        if (listenerList.length > 0) {
+            let activeCheck = false;
+
+            if (this.tagBlacklist.length > 0) {
+                this.tagBlacklist.forEach(element => {
+                    if (element[0] === '@') {
+                        activeCheck = <boolean>element[1];
+                    }
+                });
+            }
+
+            listenerList.unshift(activeCheck);
+            listenerList.unshift('@');
+            blacklist.unshift(listenerList);
         }
 
         if (sortedArray.length > 0) {

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -130,6 +130,7 @@
                             ref="tags"
                             :tag="tag"
                             :isScript="isTagOnlyScripts(tag)"
+                            :isFormula="isTagOnlyFormulas(tag)"
                             :allowCloning="bots.length === 1"
                         ></bot-tag>
 

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -126,7 +126,12 @@
                         class="bot-cell header"
                         @click="searchForTag(tag)"
                     >
-                        <bot-tag ref="tags" :tag="tag" :allowCloning="bots.length === 1"></bot-tag>
+                        <bot-tag
+                            ref="tags"
+                            :tag="tag"
+                            :isScript="isTagOnlyScripts(tag)"
+                            :allowCloning="bots.length === 1"
+                        ></bot-tag>
 
                         <!-- Show X button for tags that don't have values or tags that are hidden -->
                         <md-button

--- a/src/aux-server/aux-web/aux-projector/BotValue/BotValue.ts
+++ b/src/aux-server/aux-web/aux-projector/BotValue/BotValue.ts
@@ -7,6 +7,7 @@ import {
     isFormula,
     isAssignment,
     merge,
+    hasValue,
 } from '@casual-simulation/aux-common';
 import assign from 'lodash/assign';
 import { appManager } from '../../shared/AppManager';
@@ -43,6 +44,14 @@ export default class BotRow extends Vue {
     @Watch('tag')
     tagChanged() {
         this._updateValue();
+    }
+
+    setInitialValue(value: string) {
+        if (!hasValue(this.value)) {
+            this.value = value;
+            this.$emit('tagChanged', this.bot, this.tag, value);
+            this.getBotManager().editBot(this.bot, this.tag, value);
+        }
     }
 
     valueChanged(bot: Bot, tag: string, value: string) {

--- a/src/aux-server/aux-web/aux-projector/TagEditor/TagEditor.ts
+++ b/src/aux-server/aux-web/aux-projector/TagEditor/TagEditor.ts
@@ -3,7 +3,6 @@ import Component from 'vue-class-component';
 import { Inject, Prop, Watch } from 'vue-property-decorator';
 import { validateTag, value, KNOWN_TAGS } from '@casual-simulation/aux-common';
 import { appManager } from '../../shared/AppManager';
-import CombineIcon from '../../shared/public/icons/combine_icon.svg';
 import { EventBus } from '../../shared/EventBus';
 
 /**
@@ -11,15 +10,11 @@ import { EventBus } from '../../shared/EventBus';
  * Used for new tags and potentially for allowing users to change tag names.
  */
 @Component({
-    components: {
-        'combine-icon': CombineIcon,
-    },
+    components: {},
 })
 export default class TagEditor extends Vue {
     @Prop() value: string;
     @Prop() tagExists: boolean;
-    @Prop({ default: false })
-    isAction: boolean;
     @Prop({ default: false })
     useMaterialInput: boolean;
 
@@ -58,11 +53,7 @@ export default class TagEditor extends Vue {
     }
 
     get placeholder() {
-        if (this.isAction) {
-            return '(#tag:"value")';
-        } else {
-            return 'newTag';
-        }
+        return 'newTag';
     }
 
     get errorMessage() {
@@ -71,13 +62,7 @@ export default class TagEditor extends Vue {
             if (errors['tag.required']) {
                 return 'You must provide a value.';
             } else if (errors['tag.invalidChar']) {
-                if (this.isAction && errors['tag.invalidChar'].char === '#') {
-                    return 'Actions must start with (';
-                } else {
-                    return `Tags cannot contain ${
-                        errors['tag.invalidChar'].char
-                    }.`;
-                }
+                return `Tags cannot contain ${errors['tag.invalidChar'].char}.`;
             }
         }
         if (this.tagExists) {
@@ -88,11 +73,7 @@ export default class TagEditor extends Vue {
     }
 
     get editorValue() {
-        if (this.isAction) {
-            return this.value.slice(1) || '';
-        } else {
-            return this.value || '';
-        }
+        return this.value || '';
     }
 
     onInput(event: any) {
@@ -167,6 +148,6 @@ export default class TagEditor extends Vue {
     }
 
     private _convertToFinalValue(value: string) {
-        return this.isAction ? `+${value}` : value;
+        return value;
     }
 }

--- a/src/aux-server/aux-web/aux-projector/TagEditor/TagEditor.vue
+++ b/src/aux-server/aux-web/aux-projector/TagEditor/TagEditor.vue
@@ -1,11 +1,6 @@
 <template>
     <md-menu class="tag-editor" md-size="medium" md-align-trigger :md-active="showMenu">
         <span v-if="!useMaterialInput">
-            <!-- If you're wondering why this syntax is not -->
-            <!-- formatted very well, it's because spacing in HTML is significant -->
-            <!-- and we need the space to be ignored -->
-            <!-- See also: https://stackoverflow.com/a/2629446 -->
-            <span v-if="!isAction" class="hashtag">#</span><span v-else class="event-name">+</span
             ><input
                 ref="inputBox"
                 :value="editorValue"
@@ -18,10 +13,6 @@
         </span>
         <span v-else>
             <md-field ref="mdField">
-                <span v-if="!isAction" class="hashtag md-prefix">#</span>
-                <span v-else class="event-name-svg-container md-prefix"
-                    ><combine-icon class="event-name-svg"
-                /></span>
                 <input
                     class="md-input"
                     ref="inputBox"
@@ -33,16 +24,6 @@
                     autocapitalize="none"
                     autocorrect="off"
                 />
-
-                <!-- <md-input 
-                ref="inputBox"
-                :value="editorValue" 
-                :placeholder="placeholder"
-                @input="onInput($event)"
-                @focus.stop="onFocus"
-                @blur.stop="onBlur"
-                autocapitalize="none"
-                autocorrect="off"></md-input> -->
             </md-field>
         </span>
 

--- a/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.css
+++ b/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.css
@@ -11,6 +11,10 @@
     color: #fe6a2f;
 }
 
+.equals-sign {
+    color: #b22ffe;
+}
+
 .tag-name {
     font-weight: 700;
 }

--- a/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.css
+++ b/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.css
@@ -7,6 +7,10 @@
     color: #2f8dfe;
 }
 
+.at-symbol {
+    color: #fe6a2f;
+}
+
 .tag-name {
     font-weight: 700;
 }

--- a/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.ts
@@ -16,6 +16,7 @@ export default class BotTag extends Vue {
     @Prop() tag: string;
 
     @Prop({ default: false }) isScript: boolean;
+    @Prop({ default: false }) isFormula: boolean;
 
     /**
      * Whether the tag is allowed to be dragged from the bot table into the world.

--- a/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.ts
@@ -15,6 +15,8 @@ import TagColor from '../TagColor/TagColor';
 export default class BotTag extends Vue {
     @Prop() tag: string;
 
+    @Prop({ default: false }) isScript: boolean;
+
     /**
      * Whether the tag is allowed to be dragged from the bot table into the world.
      */

--- a/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.vue
@@ -2,22 +2,12 @@
     <span class="tag bot-tag" :class="{ clonable: allowCloning }">
         <tag-color :tag="tag"></tag-color>
         <span v-if="!isScript">
-            <span class="hashtag">#</span><span class="tag-name">{{ tag }}</span>
+            <span class="hashtag">#</span><span class="tag-name">{{ tag }}</span
+            ><span v-if="isFormula" class="equals-sign">=</span>
         </span>
         <span v-else>
             <span class="at-symbol">@</span><span class="tag-name">{{ tag }}</span>
         </span>
-        <!-- <span v-else class="filter">
-            <span v-if="!isCombine" class="event-name">{{ filterData.eventName }}</span>
-            <span v-else class="event-name-svg-container"
-                ><combine-icon class="event-name-svg"
-            /></span>
-            <span v-if="filterData.filter" class="filter-condition">
-                <span class="hashtag">#</span
-                ><span class="tag-name">{{ filterData.filter.tag }}</span
-                >:<span class="tag-value">{{ filterData.filter.value }}</span>
-            </span>
-        </span> -->
     </span>
 </template>
 <script src="./BotTag.ts"></script>

--- a/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.vue
@@ -1,8 +1,11 @@
 <template>
     <span class="tag bot-tag" :class="{ clonable: allowCloning }">
         <tag-color :tag="tag"></tag-color>
-        <span v-if="!isCombine">
+        <span v-if="!isScript">
             <span class="hashtag">#</span><span class="tag-name">{{ tag }}</span>
+        </span>
+        <span v-else>
+            <span class="at-symbol">@</span><span class="tag-name">{{ tag }}</span>
         </span>
         <!-- <span v-else class="filter">
             <span v-if="!isCombine" class="event-name">{{ filterData.eventName }}</span>

--- a/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditorUnscoped.css
@@ -5,11 +5,3 @@
 .formula-marker {
     text-align: right;
 }
-
-.script-marker::before {
-    content: '@';
-}
-
-.script-marker {
-    text-align: right;
-}

--- a/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditorUnscoped.css
@@ -1,7 +1,0 @@
-.formula-marker::before {
-    content: '=';
-}
-
-.formula-marker {
-    text-align: right;
-}

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop, Watch } from 'vue-property-decorator';
-import { Bot } from '@casual-simulation/aux-common';
+import { Bot, isScript } from '@casual-simulation/aux-common';
 import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
 import { SubscriptionLike } from 'rxjs';
 import { appManager } from '../../AppManager';
@@ -41,6 +41,13 @@ export default class MonacoTagEditor extends Vue {
     @Watch('bot')
     botChanged() {
         this._updateModel();
+    }
+
+    get isScript() {
+        if (this.bot && this.tag) {
+            return isScript(this.bot.tags[this.tag]);
+        }
+        return false;
     }
 
     created() {

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop, Watch } from 'vue-property-decorator';
-import { Bot, isScript } from '@casual-simulation/aux-common';
+import { Bot, isScript, isFormula } from '@casual-simulation/aux-common';
 import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
 import { SubscriptionLike } from 'rxjs';
 import { appManager } from '../../AppManager';
@@ -46,6 +46,13 @@ export default class MonacoTagEditor extends Vue {
     get isScript() {
         if (this.bot && this.tag) {
             return isScript(this.bot.tags[this.tag]);
+        }
+        return false;
+    }
+
+    get isFormula() {
+        if (this.bot && this.tag) {
+            return isFormula(this.bot.tags[this.tag]);
         }
         return false;
     }

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="editor-wrapper">
         <div class="editor-breadcrumbs">
-            <bot-tag :tag="tag"></bot-tag>
+            <bot-tag :tag="tag" :isScript="isScript"></bot-tag>
         </div>
         <div class="code-editor-wrapper">
             <monaco-editor ref="editor" @focus="editorFocused" @blur="editorBlured"></monaco-editor>

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="editor-wrapper">
         <div class="editor-breadcrumbs">
-            <bot-tag :tag="tag" :isScript="isScript"></bot-tag>
+            <bot-tag :tag="tag" :isScript="isScript" :isFormula="isFormula"></bot-tag>
         </div>
         <div class="code-editor-wrapper">
             <monaco-editor ref="editor" @focus="editorFocused" @blur="editorBlured"></monaco-editor>


### PR DESCRIPTION
### Changes

-   Tags that contain listeners will now display with a @ symbol in front of the tag name.
-   Tags that contain formulas will now diwplay with a = sign after the tag name.
-   Removed the @ symbol from the first line in the code editor when editing a script.
-   Added the ability to use an @ symbol while creating a new tag to prefill the editor with an @.
-   Added the ability to use @ symbols in tags in `getTag()`, `setTag()`, `getBot()`, `getBots()`, `byTag()`, `shout()`, and `whisper()`.
-   Added tag filters for listener tags and formula tags to the bot table.