### PR TITLE
Update drop event arguments and add additional script features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # AUX Changelog
 
+## V0.11.17
+
+### Date: TBD
+
+### Changes:
+
+-   **Breaking Changes**
+    -   Changed `@onDrop`, `@onDropEnter`, and `@onDropExit` to use the same parameters.
+        -   `that` is an object with the following properties:
+            -   `dragBot` - The bot that is being dragged.
+            -   `to` - an object with the following properties:
+                -   `context` - The context the bot is being dragged into.
+                -   `x` - The X grid position the bot is being dragged to.
+                -   `y` - The Y grid position the bot is being dragged to.
+                -   `bot` - The bot that the `dragBot` is being dragged onto.
+            -   `from` - an object with the following properties:
+                -   `context` The context the bot is being dragged from.
+                -   `x` - The X grid position the bot is being dragged from.
+                -   `y` - The Y grid position the bot is being dragged from.
+
 ## V0.11.16
 
 ### Date: 12/19/2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
                 -   `context` The context the bot is being dragged from.
                 -   `x` - The X grid position the bot is being dragged from.
                 -   `y` - The Y grid position the bot is being dragged from.
+-   Improvements
+    -   `create()` will now automatically set the `auxCreator` tag to `null` if it references a bot that is in a different space from the created bot.
+    -   Also `create()` will not set the `auxCreator` tag to `null` if it references a non-existent bot.
 
 ## V0.11.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
 -   Improvements
     -   `create()` will now automatically set the `auxCreator` tag to `null` if it references a bot that is in a different space from the created bot.
     -   Also `create()` will not set the `auxCreator` tag to `null` if it references a non-existent bot.
+    -   Added the `changeState(bot, stateName, groupName)` function to help with building state machines.
+        -   Sets the `[groupName]` tag to `[stateName]` on `bot` and sends "on enter" and "on exit" whispers to the bot that was updated.
+        -   `groupName` defaults to `"state"` if not specified.
+        -   If the state has changed, then a `@[groupName][previousStateName]OnExit()` and `@[groupName][stateName]OnEnter()` whispers are sent to the updated bot.
+            -   `that` is a object with the following properties:
+                -   `from` - The previous state name.
+                -   `to` - The next state name.
+        -   Example: Running `changeState(bot, "Running")` will set the `state` tag to `"Running"` and will send a `@stateRunningOnEnter()` whisper to the bot.
 
 ## V0.11.16
 

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -2044,6 +2044,29 @@ function isConnected(): boolean {
     return false;
 }
 
+/**
+ * Changes the state that the given bot is in.
+ * @param bot The bot to change.
+ * @param stateName The state that the bot should move to.
+ * @param groupName The group of states that the bot's state should change in. (Defaults to "state")
+ */
+function changeState(bot: Bot, stateName: string, groupName: string = 'state') {
+    const previousState = getTag(bot, groupName);
+    if (previousState === stateName) {
+        return;
+    }
+    setTag(bot, groupName, stateName);
+
+    const arg = {
+        to: stateName,
+        from: previousState,
+    };
+    if (hasValue(previousState)) {
+        whisper(bot, `${groupName}${previousState}OnExit`, arg);
+    }
+    whisper(bot, `${groupName}${stateName}OnEnter`, arg);
+}
+
 function __energyCheck() {
     let current = getEnergy();
     current -= 1;
@@ -2150,6 +2173,7 @@ export default {
     webhook,
     getID,
     getJSON,
+    changeState,
 
     // Mod functions
     applyMod,

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -68,6 +68,7 @@ import {
     hasValue,
     createBot,
     isScriptBot,
+    getBotSpace,
 } from '../bots/BotCalculations';
 
 import '../polyfill/Array.first.polyfill';
@@ -683,6 +684,26 @@ function createFromMods(idFactory: () => string, ...mods: (Mod | Mod[])[]) {
             }
         }
         applyMod(bot.tags, ...v);
+
+        if ('auxCreator' in bot.tags) {
+            const creatorId = bot.tags['auxCreator'];
+            const creator = getBot('id', creatorId);
+            let clearCreator = false;
+            if (!creator) {
+                clearCreator = true;
+            } else {
+                const creatorSpace = getBotSpace(creator);
+                const currentSpace = getBotSpace(bot);
+                if (creatorSpace !== currentSpace) {
+                    clearCreator = true;
+                }
+            }
+
+            if (clearCreator) {
+                applyMod(bot.tags, { auxCreator: null });
+            }
+        }
+
         return bot;
     });
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -767,33 +767,33 @@ export const KNOWN_TAGS: string[] = [
     'onChannelAction',
 ];
 
-export function onDropEnterArg(
-    draggedBot: Bot,
-    otherBot: Bot,
-    context: string
-) {
-    return {
-        draggedBot,
-        otherBot,
-        context,
-    };
-}
+// export function onDropEnterArg(
+//     draggedBot: Bot,
+//     otherBot: Bot,
+//     context: string
+// ) {
+//     return {
+//         draggedBot,
+//         otherBot,
+//         context,
+//     };
+// }
 
-export function onDropExitArg(draggedBot: Bot, otherBot: Bot, context: string) {
-    return {
-        draggedBot,
-        otherBot,
-        context,
-    };
-}
+// export function onDropExitArg(draggedBot: Bot, otherBot: Bot, context: string) {
+//     return {
+//         draggedBot,
+//         otherBot,
+//         context,
+//     };
+// }
 
 export function onDropArg(
-    bot: Bot,
-    to: BotDropDestination,
+    dragBot: Bot,
+    to: BotDropToDestination,
     from: BotDropDestination
 ) {
     return {
-        bot,
+        dragBot,
         to,
         from,
     };
@@ -803,4 +803,8 @@ export interface BotDropDestination {
     x: number;
     y: number;
     context: string;
+}
+
+export interface BotDropToDestination extends BotDropDestination {
+    bot: Bot;
 }

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -3040,6 +3040,166 @@ export function botActionsTests(
             });
         });
 
+        describe('changeState()', () => {
+            it('should set the state tag to the given value', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: '@changeState(this, "abc")',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            state: 'abc',
+                        },
+                    }),
+                ]);
+            });
+
+            it('should send an @onEnter whisper to the bot', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            state: 'Xyz',
+                            test: '@changeState(this, "Abc")',
+                            stateAbcOnEnter:
+                                '@tags.enter = that.from + "-" + that.to',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            state: 'Abc',
+                            enter: 'Xyz-Abc',
+                        },
+                    }),
+                ]);
+            });
+
+            it('should send an @onExit whisper to the bot', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            state: 'Xyz',
+                            test: '@changeState(this, "Abc")',
+                            stateXyzOnExit:
+                                '@tags.exit = that.from + "-" + that.to',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            state: 'Abc',
+                            exit: 'Xyz-Abc',
+                        },
+                    }),
+                ]);
+            });
+
+            it('should use the given group name', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            fun: 'Xyz',
+                            test: '@changeState(this, "Abc", "fun")',
+                            funXyzOnExit:
+                                '@tags.exit = that.from + "-" + that.to',
+                            funAbcOnEnter:
+                                '@tags.enter = that.from + "-" + that.to',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            fun: 'Abc',
+                            enter: 'Xyz-Abc',
+                            exit: 'Xyz-Abc',
+                        },
+                    }),
+                ]);
+            });
+
+            it('should do nothing if the state does not change', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            state: 'Xyz',
+                            test: '@changeState(this, "Xyz")',
+                            funXyzOnExit:
+                                '@tags.exit = that.from + "-" + that.to',
+                            funXyzOnEnter:
+                                '@tags.enter = that.from + "-" + that.to',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(false);
+                expect(result.events).toEqual([]);
+            });
+        });
+
         describe('player.getBot()', () => {
             it('should get the current users bot', () => {
                 const state: BotsState = {

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -6516,7 +6516,7 @@ export function botActionsTests(
                         id: expectedId,
                         space: 'tempLocal',
                         tags: {
-                            auxCreator: 'thisBot',
+                            auxCreator: null,
                             test: true,
                             hello: true,
                         },
@@ -6713,6 +6713,70 @@ export function botActionsTests(
                             id: expectedId,
                             tags: {
                                 abc: 'def',
+                                auxCreator: null,
+                            },
+                        }),
+                    ]);
+                });
+
+                it('should set auxCreator to null if it references a bot in a different space', () => {
+                    const state: BotsState = {
+                        thisBot: {
+                            id: 'thisBot',
+                            tags: {
+                                test: `@${name}({ auxCreator: "otherBot" }, { space: "def" })`,
+                            },
+                        },
+                        otherBot: {
+                            id: 'otherBot',
+                            space: 'shared',
+                            tags: {
+                                other: true,
+                            },
+                        },
+                    };
+                    // specify the UUID to use next
+                    uuidMock.mockReturnValue(id);
+                    const botAction = action('test', ['thisBot']);
+                    const result = calculateActionEvents(
+                        state,
+                        botAction,
+                        createSandbox
+                    );
+                    expect(result.hasUserDefinedEvents).toBe(true);
+                    expect(result.events).toEqual([
+                        botAdded({
+                            id: expectedId,
+                            space: <any>'def',
+                            tags: {
+                                auxCreator: null,
+                            },
+                        }),
+                    ]);
+                });
+
+                it('should set auxCreator to null if it references a bot that does not exist', () => {
+                    const state: BotsState = {
+                        thisBot: {
+                            id: 'thisBot',
+                            tags: {
+                                test: `@${name}({ auxCreator: "otherBot" })`,
+                            },
+                        },
+                    };
+                    // specify the UUID to use next
+                    uuidMock.mockReturnValue(id);
+                    const botAction = action('test', ['thisBot']);
+                    const result = calculateActionEvents(
+                        state,
+                        botAction,
+                        createSandbox
+                    );
+                    expect(result.hasUserDefinedEvents).toBe(true);
+                    expect(result.events).toEqual([
+                        botAdded({
+                            id: expectedId,
+                            tags: {
                                 auxCreator: null,
                             },
                         }),


### PR DESCRIPTION
### Changes:

-   **Breaking Changes**
    -   Changed `@onDrop`, `@onDropEnter`, and `@onDropExit` to use the same parameters.
        -   `that` is an object with the following properties:
            -   `dragBot` - The bot that is being dragged.
            -   `to` - an object with the following properties:
                -   `context` - The context the bot is being dragged into.
                -   `x` - The X grid position the bot is being dragged to.
                -   `y` - The Y grid position the bot is being dragged to.
                -   `bot` - The bot that the `dragBot` is being dragged onto.
            -   `from` - an object with the following properties:
                -   `context` The context the bot is being dragged from.
                -   `x` - The X grid position the bot is being dragged from.
                -   `y` - The Y grid position the bot is being dragged from.
-   Improvements
    -   `create()` will now automatically set the `auxCreator` tag to `null` if it references a bot that is in a different space from the created bot.
    -   Also `create()` will not set the `auxCreator` tag to `null` if it references a non-existent bot.
    -   Added the `changeState(bot, stateName, groupName)` function to help with building state machines.
        -   Sets the `[groupName]` tag to `[stateName]` on `bot` and sends "on enter" and "on exit" whispers to the bot that was updated.
        -   `groupName` defaults to `"state"` if not specified.
        -   If the state has changed, then a `@[groupName][previousStateName]OnExit()` and `@[groupName][stateName]OnEnter()` whispers are sent to the updated bot.
            -   `that` is a object with the following properties:
                -   `from` - The previous state name.
                -   `to` - The next state name.
        -   Example: Running `changeState(bot, "Running")` will set the `state` tag to `"Running"` and will send a `@stateRunningOnEnter()` whisper to the bot.