### PR TITLE
Channel Designer sheet updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Improvements
     -   Showing hidden tags in the bot table will now also show the `shared` tag.
     -   Removed the multi-select button from the bot table.
+    -   Removed the create context button from the bot table.
     -   Hid all other buttons when a mod is selected in the bot table.
 
 ## V0.11.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     -   Showing hidden tags in the bot table will now also show the `shared` tag.
     -   Removed the multi-select button from the bot table.
     -   Removed the create context button from the bot table.
+    -   Removed the clear search button from the bot table.
     -   Hid all other buttons when a mod is selected in the bot table.
 
 ## V0.11.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 -   Improvements
     -   Showing hidden tags in the bot table will now also show the `shared` tag.
+    -   Removed the multi-select button from the bot table.
+    -   Hid all other buttons when a mod is selected in the bot table.
 
 ## V0.11.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
     -   Removed the multi-select button from the bot table.
     -   Removed the create context button from the bot table.
     -   Removed the clear search button from the bot table.
+    -   Removed the "create mod from selection" button from the bot table.
+    -   Added the ability to click/tap on a bot preview in the bot table to select a mod of it.
+    -   Added the ability to drag a bot preview in the bot table to drag a mod of it.
+    -   Hid the ID tag when a mod is selected.
     -   Hid all other buttons when a mod is selected in the bot table.
 
 ## V0.11.17

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -215,7 +215,7 @@ export function botTags(
     currentTags: string[],
     extraTags: string[],
     includeHidden: boolean = false,
-    tagBlacklist: (string | boolean)[][] = []
+    tagWhitelist: (string | boolean)[][] = []
 ) {
     const botTags = flatMap(bots, f => keys(f.tags));
     // Only keep tags that don't start with an underscore (_)
@@ -228,22 +228,22 @@ export function botTags(
     let allInactive = true;
 
     // if there is a blacklist index and the  first index [all] is not selected
-    if (tagBlacklist != undefined && tagBlacklist.length > 0) {
+    if (tagWhitelist != undefined && tagWhitelist.length > 0) {
         let filteredTags: string[] = [];
 
-        for (let i = tagBlacklist.length - 1; i >= 0; i--) {
-            if (tagBlacklist[i][1]) {
+        for (let i = tagWhitelist.length - 1; i >= 0; i--) {
+            if (tagWhitelist[i][1]) {
                 allInactive = false;
             }
         }
 
         if (!allInactive) {
-            for (let i = tagBlacklist.length - 1; i >= 0; i--) {
-                if (!tagBlacklist[i][1]) {
-                    for (let j = 2; j < tagBlacklist[i].length; j++) {
+            for (let i = tagWhitelist.length - 1; i >= 0; i--) {
+                if (!tagWhitelist[i][1]) {
+                    for (let j = 2; j < tagWhitelist[i].length; j++) {
                         for (let k = onlyTagsToKeep.length - 1; k >= 0; k--) {
                             if (
-                                onlyTagsToKeep[k] === <string>tagBlacklist[i][j]
+                                onlyTagsToKeep[k] === <string>tagWhitelist[i][j]
                             ) {
                                 onlyTagsToKeep.splice(k, 1);
                                 break;

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -105,9 +105,7 @@ export default class BotTable extends Vue {
     viewMode: 'rows' | 'columns' = 'columns';
     showHidden: boolean = false;
 
-    tagBlacklist: (string | boolean)[][] = [];
-    blacklistIndex: boolean[] = [];
-    blacklistCount: number[] = [];
+    tagWhitelist: (string | boolean)[][] = [];
     editableMap: Map<string, boolean>;
 
     showCreateWorksurfaceDialog: boolean = false;
@@ -160,17 +158,17 @@ export default class BotTable extends Vue {
         EventBus.$emit('toggleSheetSize');
     }
 
-    isBlacklistTagActive(index: number | string): boolean {
+    isWhitelistTagActive(index: number | string): boolean {
         if (typeof index === 'number') {
-            return <boolean>this.tagBlacklist[index][1];
+            return <boolean>this.tagWhitelist[index][1];
         } else {
-            const idx = this.tagBlacklist.findIndex(bl => bl[0] === index);
-            return this.isBlacklistTagActive(idx);
+            const idx = this.tagWhitelist.findIndex(bl => bl[0] === index);
+            return this.isWhitelistTagActive(idx);
         }
     }
 
-    getBlacklistCount(index: number): number {
-        return this.tagBlacklist[index].length - 2;
+    getWhitelistCount(index: number): number {
+        return this.tagWhitelist[index].length - 2;
     }
 
     isBotReadOnly(bot: Bot): boolean {
@@ -263,7 +261,7 @@ export default class BotTable extends Vue {
 
         this.lastSelectionCount = this.bots.length;
 
-        this.setTagBlacklist();
+        this.setTagWhitelist();
         this._updateTags();
         this.numBotsSelected = this.bots.length;
         if (this.focusedBot) {
@@ -705,7 +703,7 @@ export default class BotTable extends Vue {
 
     toggleHidden() {
         this.showHidden = !this.showHidden;
-        this.setTagBlacklist();
+        this.setTagWhitelist();
         this._updateTags();
     }
 
@@ -723,7 +721,7 @@ export default class BotTable extends Vue {
             this.addedTags.splice(index, 1);
         }
 
-        this.setTagBlacklist();
+        this.setTagWhitelist();
         this._updateTags();
     }
 
@@ -782,7 +780,7 @@ export default class BotTable extends Vue {
             return [];
         });
 
-        this.setTagBlacklist();
+        this.setTagWhitelist();
         this._updateTags();
         this.numBotsSelected = this.bots.length;
         this._updateEditable();
@@ -804,10 +802,10 @@ export default class BotTable extends Vue {
             this.tags,
             allExtraTags,
             true,
-            this.tagBlacklist
+            this.tagWhitelist
         ).sort();
 
-        const isHiddenActive = this.isBlacklistTagActive('hidden');
+        const isHiddenActive = this.isWhitelistTagActive('hidden');
         if (isHiddenActive) {
             this.readOnlyTags = [BOT_SPACE_TAG];
         } else {
@@ -815,12 +813,12 @@ export default class BotTable extends Vue {
         }
     }
 
-    toggleBlacklistIndex(index: number) {
-        this.tagBlacklist[index][1] = !this.tagBlacklist[index][1];
+    toggleWhitelistIndex(index: number) {
+        this.tagWhitelist[index][1] = !this.tagWhitelist[index][1];
         this._updateTags();
     }
 
-    setTagBlacklist() {
+    setTagWhitelist() {
         let sortedArray: string[] = getAllBotTags(this.bots, true).sort();
 
         // remove any duplicates from the array to fix multiple bots adding in duplicate tags
@@ -828,7 +826,7 @@ export default class BotTable extends Vue {
             return index === self.indexOf(elem);
         });
 
-        let blacklist: (string | boolean)[][] = [];
+        let whitelist: (string | boolean)[][] = [];
 
         let hiddenList: (string | boolean)[] = [];
         let generalList: (string | boolean)[] = [];
@@ -871,10 +869,10 @@ export default class BotTable extends Vue {
                 sortedArray[i].split(camelCaseRegex)[0]
             ) {
                 if (tempArray.length > 0) {
-                    if (blacklist.length === 0) {
-                        blacklist = [tempArray];
+                    if (whitelist.length === 0) {
+                        whitelist = [tempArray];
                     } else {
-                        blacklist.push(tempArray);
+                        whitelist.push(tempArray);
                     }
                 }
 
@@ -891,8 +889,8 @@ export default class BotTable extends Vue {
 
                 let activeCheck = false;
                 // add the section visibility in slot 1
-                if (this.tagBlacklist.length > 0) {
-                    this.tagBlacklist.forEach(element => {
+                if (this.tagWhitelist.length > 0) {
+                    this.tagWhitelist.forEach(element => {
                         if (element[0] === tempArray[0]) {
                             activeCheck = <boolean>element[1];
                         }
@@ -910,20 +908,20 @@ export default class BotTable extends Vue {
             }
         }
 
-        // makes sure if the loop ends on an array it will add in the temp array correctly to the blacklist
+        // makes sure if the loop ends on an array it will add in the temp array correctly to the whitelist
         if (tempArray.length > 0) {
-            if (blacklist.length === 0) {
-                blacklist = [tempArray];
+            if (whitelist.length === 0) {
+                whitelist = [tempArray];
             } else {
-                blacklist.push(tempArray);
+                whitelist.push(tempArray);
             }
         }
 
         if (hiddenList.length > 0) {
             let activeCheck = false;
 
-            if (this.tagBlacklist.length > 0) {
-                this.tagBlacklist.forEach(element => {
+            if (this.tagWhitelist.length > 0) {
+                this.tagWhitelist.forEach(element => {
                     if (element[0] === 'hidden') {
                         activeCheck = <boolean>element[1];
                     }
@@ -932,7 +930,7 @@ export default class BotTable extends Vue {
 
             hiddenList.unshift(activeCheck);
             hiddenList.unshift('hidden');
-            blacklist.unshift(hiddenList);
+            whitelist.unshift(hiddenList);
         } else {
             hiddenList.forEach(hiddenTags => {
                 sortedArray.push(<string>hiddenTags);
@@ -942,8 +940,8 @@ export default class BotTable extends Vue {
         if (listenerList.length > 0) {
             let activeCheck = false;
 
-            if (this.tagBlacklist.length > 0) {
-                this.tagBlacklist.forEach(element => {
+            if (this.tagWhitelist.length > 0) {
+                this.tagWhitelist.forEach(element => {
                     if (element[0] === '@') {
                         activeCheck = <boolean>element[1];
                     }
@@ -952,14 +950,14 @@ export default class BotTable extends Vue {
 
             listenerList.unshift(activeCheck);
             listenerList.unshift('@');
-            blacklist.unshift(listenerList);
+            whitelist.unshift(listenerList);
         }
 
         if (formulaList.length > 0) {
             let activeCheck = false;
 
-            if (this.tagBlacklist.length > 0) {
-                this.tagBlacklist.forEach(element => {
+            if (this.tagWhitelist.length > 0) {
+                this.tagWhitelist.forEach(element => {
                     if (element[0] === '@') {
                         activeCheck = <boolean>element[1];
                     }
@@ -968,14 +966,14 @@ export default class BotTable extends Vue {
 
             formulaList.unshift(activeCheck);
             formulaList.unshift('=');
-            blacklist.unshift(formulaList);
+            whitelist.unshift(formulaList);
         }
 
         if (sortedArray.length > 0) {
             let activeCheck = true;
 
-            if (this.tagBlacklist.length > 0) {
-                this.tagBlacklist.forEach(element => {
+            if (this.tagWhitelist.length > 0) {
+                this.tagWhitelist.forEach(element => {
                     if (element[0] === '#') {
                         activeCheck = <boolean>element[1];
                     }
@@ -989,34 +987,34 @@ export default class BotTable extends Vue {
                 generalList.push(<string>generalTags);
             });
 
-            blacklist.unshift(generalList);
+            whitelist.unshift(generalList);
         }
 
-        this.tagBlacklist = blacklist;
+        this.tagWhitelist = whitelist;
     }
 
-    getTagBlacklist(): string[] {
+    getTagWhitelist(): string[] {
         let tagList: string[] = [];
 
-        this.tagBlacklist.forEach(element => {
+        this.tagWhitelist.forEach(element => {
             tagList.push(<string>element[0]);
         });
 
         return tagList;
     }
 
-    getVisualTagBlacklist(index: number): string {
-        let newBlacklist: string;
+    getVisualTagWhitelist(index: number): string {
+        let newWhitelist: string;
 
-        if ((<string>this.tagBlacklist[index][0]).length > 15) {
-            newBlacklist =
-                (<string>this.tagBlacklist[index][0]).substring(0, 15) + '..';
+        if ((<string>this.tagWhitelist[index][0]).length > 15) {
+            newWhitelist =
+                (<string>this.tagWhitelist[index][0]).substring(0, 15) + '..';
         } else {
-            newBlacklist =
-                (<string>this.tagBlacklist[index][0]).substring(0, 15) + '*';
+            newWhitelist =
+                (<string>this.tagWhitelist[index][0]).substring(0, 15) + '*';
         }
 
-        return '#' + newBlacklist;
+        return '#' + newWhitelist;
     }
 
     private _updateEditable() {

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -605,10 +605,6 @@ export default class BotTable extends Vue {
         appManager.simulationManager.primary.botPanel.isOpen = true;
     }
 
-    async multiSelect() {
-        await this.getBotManager().selection.setSelectedBots(this.bots);
-    }
-
     async downloadBots() {
         if (this.hasBots) {
             const stored = await this.getBotManager().exportBots(

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -193,18 +193,24 @@ export default class BotTable extends Vue {
         return numFormulas > 0 && this.bots.length === numFormulas + emptyTags;
     }
 
+    get showID() {
+        return !this.diffSelected;
+    }
+
     get botTableGridStyle() {
         const sizeType = this.viewMode === 'rows' ? 'columns' : 'rows';
 
+        const idTemplate = this.showID ? 'auto' : '';
+
         if (this.tags.length === 0) {
             return {
-                [`grid-template-${sizeType}`]: `auto auto auto`,
+                [`grid-template-${sizeType}`]: `auto ${idTemplate} auto`,
             };
         }
 
         return {
-            [`grid-template-${sizeType}`]: `auto auto repeat(${this.tags
-                .length + this.readOnlyTags.length}, auto) auto`,
+            [`grid-template-${sizeType}`]: `auto ${idTemplate} repeat(${this
+                .tags.length + this.readOnlyTags.length}, auto) auto`,
         };
     }
 

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -27,7 +27,6 @@ import {
     BOT_SPACE_TAG,
     getBotSpace,
     getBotTag,
-    calculateBotValue,
 } from '@casual-simulation/aux-common';
 import { EventBus } from '../../shared/EventBus';
 
@@ -225,19 +224,6 @@ export default class BotTable extends Vue {
         return this.tagExists(this.newTag);
     }
 
-    get hasContextSelected() {
-        return this.bots.some(b => 'auxContext' in b.tags);
-    }
-
-    getSelectedContext() {
-        const bot = this.bots.find(b => 'auxContext' in b.tags);
-        if (bot) {
-            const calc = appManager.simulationManager.primary.helper.createContext();
-            return calculateBotValue(calc, bot, 'auxContext');
-        }
-        return '<none>';
-    }
-
     isEmptyDiff(): boolean {
         if (this.diffSelected) {
             if (this.bots[0].id === 'empty' && this.addedTags.length === 0) {
@@ -399,12 +385,7 @@ export default class BotTable extends Vue {
     }
 
     async createBot() {
-        const tags = this.hasContextSelected
-            ? {
-                  [this.getSelectedContext()]: true,
-              }
-            : undefined;
-        const id = await this.getBotManager().helper.createBot(undefined, tags);
+        const id = await this.getBotManager().helper.createBot();
 
         this.getBotManager()
             .watcher.botChanged(id)

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -27,6 +27,7 @@ import {
     BOT_SPACE_TAG,
     getBotSpace,
     getBotTag,
+    calculateBotValue,
 } from '@casual-simulation/aux-common';
 import { EventBus } from '../../shared/EventBus';
 
@@ -224,6 +225,19 @@ export default class BotTable extends Vue {
         return this.tagExists(this.newTag);
     }
 
+    get hasContextSelected() {
+        return this.bots.some(b => 'auxContext' in b.tags);
+    }
+
+    getSelectedContext() {
+        const bot = this.bots.find(b => 'auxContext' in b.tags);
+        if (bot) {
+            const calc = appManager.simulationManager.primary.helper.createContext();
+            return calculateBotValue(calc, bot, 'auxContext');
+        }
+        return '<none>';
+    }
+
     isEmptyDiff(): boolean {
         if (this.diffSelected) {
             if (this.bots[0].id === 'empty' && this.addedTags.length === 0) {
@@ -385,7 +399,12 @@ export default class BotTable extends Vue {
     }
 
     async createBot() {
-        const id = await this.getBotManager().helper.createBot();
+        const tags = this.hasContextSelected
+            ? {
+                  [this.getSelectedContext()]: true,
+              }
+            : undefined;
+        const id = await this.getBotManager().helper.createBot(undefined, tags);
 
         this.getBotManager()
             .watcher.botChanged(id)

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -160,6 +160,9 @@ export default class BotTable extends Vue {
 
     isWhitelistTagActive(index: number | string): boolean {
         if (typeof index === 'number') {
+            if (index < 0) {
+                return false;
+            }
             return <boolean>this.tagWhitelist[index][1];
         } else {
             const idx = this.tagWhitelist.findIndex(bl => bl[0] === index);

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -587,15 +587,19 @@ export default class BotTable extends Vue {
     }
 
     async clearSelection() {
+        await this.selectMod(this.bots[0]);
+    }
+
+    async selectMod(bot: Bot) {
         this.addedTags = [];
 
         await this.getBotManager().selection.selectBot(
-            <AuxBot>this.bots[0],
+            <AuxBot>bot,
             false,
             this.getBotManager().botPanel
         );
 
-        this.getBotManager().recent.addBotDiff(this.bots[0], true);
+        this.getBotManager().recent.addBotDiff(bot, true);
         await this.getBotManager().selection.clearSelection();
         appManager.simulationManager.primary.botPanel.isOpen = true;
     }

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.ts
@@ -108,11 +108,6 @@ export default class BotTable extends Vue {
     tagWhitelist: (string | boolean)[][] = [];
     editableMap: Map<string, boolean>;
 
-    showCreateWorksurfaceDialog: boolean = false;
-    worksurfaceContext: string = '';
-    worksurfaceAllowPlayer: boolean = false;
-    showSurface: boolean = true;
-
     private _simulation: BrowserSimulation;
     private _isMobile: boolean;
 
@@ -612,69 +607,6 @@ export default class BotTable extends Vue {
             );
             downloadAuxState(stored, `selection-${Date.now()}`);
         }
-    }
-
-    public createSurface(): void {
-        this.worksurfaceContext = createContextId();
-        this.showSurface = true;
-        this.worksurfaceAllowPlayer = false;
-        this.showCreateWorksurfaceDialog = true;
-    }
-
-    /**
-     * Confirm event from the create worksurface dialog.
-     */
-    async onConfirmCreateWorksurface() {
-        this.showCreateWorksurfaceDialog = false;
-
-        const nextPosition = nextAvailableWorkspacePosition(
-            this.getBotManager().helper.createContext()
-        );
-        const finalPosition = gridPosToRealPos(
-            nextPosition,
-            DEFAULT_WORKSPACE_SCALE * 1.1
-        );
-        const workspace = await this.getBotManager().helper.createWorkspace(
-            undefined,
-            this.worksurfaceContext,
-            this.worksurfaceAllowPlayer,
-            this.showSurface,
-            finalPosition.x,
-            finalPosition.y
-        );
-
-        if (!this.diffSelected) {
-            const calc = this.getBotManager().helper.createContext();
-            for (let i = 0; i < this.bots.length; i++) {
-                const bot = this.bots[i];
-                await this.getBotManager().helper.updateBot(bot, {
-                    tags: {
-                        ...addToContextDiff(
-                            calc,
-                            this.worksurfaceContext,
-                            0,
-                            0,
-                            i
-                        ),
-                    },
-                });
-            }
-        }
-
-        this.resetCreateWorksurfaceDialog();
-    }
-
-    /**
-     * Cancel event from the create worksurface dialog.
-     */
-    onCancelCreateWorksurface() {
-        this.resetCreateWorksurfaceDialog();
-    }
-
-    resetCreateWorksurfaceDialog() {
-        this.showCreateWorksurfaceDialog = false;
-        this.worksurfaceAllowPlayer = false;
-        this.showSurface = true;
     }
 
     onTagChanged(bot: Bot, tag: string, value: string) {

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -12,17 +12,20 @@
                         <md-tooltip>Add Tag</md-tooltip>
                     </md-button>
                     <md-button
-                        v-if="!isSearch"
+                        v-if="!isSearch && !diffSelected"
                         class="md-icon-button create-bot"
                         @click="createBot()"
                     >
                         <cube-icon></cube-icon>
                         <md-tooltip>Create Empty Bot</md-tooltip>
                     </md-button>
-                    <md-button class="md-icon-button create-surface" @click="createSurface()">
+                    <md-button
+                        class="md-icon-button create-surface"
+                        v-if="!diffSelected"
+                        @click="createSurface()"
+                    >
                         <hex-icon></hex-icon>
-                        <md-tooltip v-if="diffSelected">Create Context</md-tooltip>
-                        <md-tooltip v-else>Create Context from Selection</md-tooltip>
+                        <md-tooltip>Create Context from Selection</md-tooltip>
                     </md-button>
 
                     <md-button
@@ -62,7 +65,7 @@
                             </div>
                         </form>
                     </div>
-                    <div v-else-if="hasBots">
+                    <div v-else-if="hasBots && !diffSelected">
                         <md-button
                             v-if="!isSearch && selectionMode != 'multi'"
                             class="md-icon-button create-surface"

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -12,12 +12,12 @@
                         <md-tooltip>Add Tag</md-tooltip>
                     </md-button>
                     <md-button
-                        v-if="!isSearch && !diffSelected"
+                        v-if="!isSearch && !diffSelected && hasContextSelected"
                         class="md-icon-button create-bot"
                         @click="createBot()"
                     >
                         <cube-icon></cube-icon>
-                        <md-tooltip>Create Empty Bot</md-tooltip>
+                        <md-tooltip>Create Empty Bot in {{ getSelectedContext() }}</md-tooltip>
                     </md-button>
 
                     <md-button

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -147,7 +147,14 @@
                     <template v-for="bot in bots">
                         <!-- deselect button -->
                         <div :key="`${bot.id}-remove`" class="bot-cell remove-item">
-                            <mini-bot :bots="bot" ref="tags" :allowCloning="true"> </mini-bot>
+                            <mini-bot
+                                :bots="bot"
+                                ref="tags"
+                                :allowCloning="true"
+                                :createMod="true"
+                                @click="selectMod(bot)"
+                            >
+                            </mini-bot>
                         </div>
 
                         <!-- Bot ID -->

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -67,15 +67,6 @@
                     </div>
                     <div v-else-if="hasBots && !diffSelected">
                         <md-button
-                            v-if="!isSearch && selectionMode != 'multi'"
-                            class="md-icon-button create-surface"
-                            @click="multiSelect()"
-                        >
-                            <multi-icon></multi-icon>
-                            <md-tooltip>Multiselect Bots</md-tooltip>
-                        </md-button>
-
-                        <md-button
                             v-if="!isMobile()"
                             class="md-icon-button create-surface"
                             @click="toggleSheet()"

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -12,12 +12,12 @@
                         <md-tooltip>Add Tag</md-tooltip>
                     </md-button>
                     <md-button
-                        v-if="!isSearch && !diffSelected && hasContextSelected"
+                        v-if="!isSearch && !diffSelected"
                         class="md-icon-button create-bot"
                         @click="createBot()"
                     >
                         <cube-icon></cube-icon>
-                        <md-tooltip>Create Empty Bot in {{ getSelectedContext() }}</md-tooltip>
+                        <md-tooltip>Create Empty Bot</md-tooltip>
                     </md-button>
 
                     <md-button

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -98,7 +98,7 @@
                     </div>
 
                     <!-- ID tag -->
-                    <div class="bot-cell header" @click="searchForTag('id')">
+                    <div v-if="showID" class="bot-cell header" @click="searchForTag('id')">
                         <bot-tag tag="id" :allowCloning="false"></bot-tag>
                     </div>
 
@@ -160,6 +160,7 @@
                         <!-- Bot ID -->
                         <bot-id
                             ref="tags"
+                            v-if="showID"
                             :key="bot.id"
                             :bots="bot"
                             :allowCloning="true"

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -19,19 +19,6 @@
                         <cube-icon></cube-icon>
                         <md-tooltip>Create Empty Bot</md-tooltip>
                     </md-button>
-
-                    <md-button
-                        v-if="selectionMode === 'single' && !diffSelected && bots.length === 1"
-                        class="md-icon-button create-surface"
-                        @click="clearSelection()"
-                    >
-                        <picture>
-                            <source srcset="../public/icons/make-merge.webp" type="image/webp" />
-                            <source srcset="../public/icons/make-merge.png" type="image/png" />
-                            <img alt="Make Merge" src="../public/icons/make-merge.png" />
-                        </picture>
-                        <md-tooltip>Create Mod From Selection</md-tooltip>
-                    </md-button>
                 </div>
                 <div class="bot-table-actions">
                     <div v-if="isMakingNewTag">

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -89,10 +89,7 @@
                 >
                     <!-- Remove all button -->
                     <div class="bot-cell remove-item" v-if="!diffSelected">
-                        <md-button v-if="isSearch" class="md-dense" @click="clearSearch()">
-                            Clear Search
-                        </md-button>
-                        <div v-else-if="selectionMode === 'multi'">
+                        <div v-if="selectionMode === 'multi'">
                             <!-- keep place here so it shows up as empty-->
                         </div>
                     </div>

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -228,36 +228,36 @@
                         </div>
                     </template>
                 </div>
-                <div class="bot-section-holder-outer" v-if="getTagBlacklist().length > 0">
+                <div class="bot-section-holder-outer" v-if="getTagWhitelist().length > 0">
                     <div class="bot-section-holder-inner">
                         <div
-                            v-for="(tagBlacklist, index) in getTagBlacklist()"
+                            v-for="(tagWhitelist, index) in getTagWhitelist()"
                             :key="index"
                             class="bot-section"
                         >
                             <md-button
-                                v-if="isBlacklistTagActive(index)"
+                                v-if="isWhitelistTagActive(index)"
                                 class="bot-section active"
-                                @click="toggleBlacklistIndex(index)"
+                                @click="toggleWhitelistIndex(index)"
                             >
-                                <span v-if="isAllTag(tagBlacklist)"> {{ tagBlacklist }}</span>
-                                <span v-else-if="isSpecialTag(tagBlacklist)">
-                                    {{ tagBlacklist }}</span
+                                <span v-if="isAllTag(tagWhitelist)"> {{ tagWhitelist }}</span>
+                                <span v-else-if="isSpecialTag(tagWhitelist)">
+                                    {{ tagWhitelist }}</span
                                 >
-                                <span v-else>{{ getVisualTagBlacklist(index) }}</span>
+                                <span v-else>{{ getVisualTagWhitelist(index) }}</span>
                             </md-button>
                             <md-button
                                 v-else
                                 class="bot-section inactive"
-                                @click="toggleBlacklistIndex(index)"
+                                @click="toggleWhitelistIndex(index)"
                             >
-                                <span v-if="isAllTag(tagBlacklist)"> {{ tagBlacklist }}</span>
-                                <span v-else-if="isSpecialTag(tagBlacklist)">
-                                    {{ tagBlacklist }} {{ getBlacklistCount(index) }}</span
+                                <span v-if="isAllTag(tagWhitelist)"> {{ tagWhitelist }}</span>
+                                <span v-else-if="isSpecialTag(tagWhitelist)">
+                                    {{ tagWhitelist }} {{ getWhitelistCount(index) }}</span
                                 >
                                 <span v-else
-                                    >{{ getVisualTagBlacklist(index) }}
-                                    {{ getBlacklistCount(index) }}</span
+                                    >{{ getVisualTagWhitelist(index) }}
+                                    {{ getWhitelistCount(index) }}</span
                                 >
                             </md-button>
                         </div>

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -19,14 +19,6 @@
                         <cube-icon></cube-icon>
                         <md-tooltip>Create Empty Bot</md-tooltip>
                     </md-button>
-                    <md-button
-                        class="md-icon-button create-surface"
-                        v-if="!diffSelected"
-                        @click="createSurface()"
-                    >
-                        <hex-icon></hex-icon>
-                        <md-tooltip>Create Context from Selection</md-tooltip>
-                    </md-button>
 
                     <md-button
                         v-if="selectionMode === 'single' && !diffSelected && bots.length === 1"
@@ -276,31 +268,6 @@
                 ></tag-value-editor>
             </div>
         </div>
-
-        <md-dialog :md-active.sync="showCreateWorksurfaceDialog">
-            <md-dialog-title v-if="diffSelected">Create Context</md-dialog-title>
-            <md-dialog-title v-else>Create Context from Selection</md-dialog-title>
-
-            <md-dialog-content>
-                <md-field>
-                    <label>Context</label>
-                    <md-input
-                        ref="input"
-                        v-model="worksurfaceContext"
-                        maxlength="40"
-                        @keydown.enter.native="onConfirmCreateWorksurface"
-                    />
-                </md-field>
-
-                <md-checkbox v-model="showSurface">Show Surface</md-checkbox>
-                <md-checkbox v-model="worksurfaceAllowPlayer">Lock Context</md-checkbox>
-            </md-dialog-content>
-
-            <md-dialog-actions>
-                <md-button class="md-primary" @click="onCancelCreateWorksurface">Cancel</md-button>
-                <md-button class="md-primary" @click="onConfirmCreateWorksurface">Save</md-button>
-            </md-dialog-actions>
-        </md-dialog>
 
         <md-snackbar md-position="center" :md-duration="6000" :md-active.sync="showBotDestroyed">
             <span>Destroyed {{ deletedBotId }}</span>

--- a/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTable/BotTable.vue
@@ -253,12 +253,11 @@
                             >
                                 <span v-if="isAllTag(tagBlacklist)"> {{ tagBlacklist }}</span>
                                 <span v-else-if="isSpecialTag(tagBlacklist)">
-                                    {{ tagBlacklist }} [{{ getBlacklistCount(index) }}]</span
+                                    {{ tagBlacklist }} {{ getBlacklistCount(index) }}</span
                                 >
                                 <span v-else
-                                    >{{ getVisualTagBlacklist(index) }} [{{
-                                        getBlacklistCount(index)
-                                    }}]</span
+                                    >{{ getVisualTagBlacklist(index) }}
+                                    {{ getBlacklistCount(index) }}</span
                                 >
                             </md-button>
                         </div>

--- a/src/aux-server/aux-web/aux-projector/BotTagMini/BotTagMini.ts
+++ b/src/aux-server/aux-web/aux-projector/BotTagMini/BotTagMini.ts
@@ -18,8 +18,18 @@ export default class BotTagMini extends Vue {
     @Prop({ default: true })
     allowCloning: boolean;
 
+    /**
+     * Whether the tag should create a mod when dragged.
+     */
+    @Prop({ default: false })
+    createMod: boolean;
+
     @Prop()
     bots: AuxBot;
+
+    click() {
+        this.$emit('click');
+    }
 
     constructor() {
         super();

--- a/src/aux-server/aux-web/aux-projector/BotTagMini/BotTagMini.vue
+++ b/src/aux-server/aux-web/aux-projector/BotTagMini/BotTagMini.vue
@@ -7,6 +7,8 @@
             ref="mini"
             :isSearch="true"
             class="bot-tag-mini"
+            :createMod="createMod"
+            @click="click()"
         ></mini-bot>
     </span>
 </template>

--- a/src/aux-server/aux-web/aux-projector/MiniBot/MiniBot.ts
+++ b/src/aux-server/aux-web/aux-projector/MiniBot/MiniBot.ts
@@ -32,6 +32,12 @@ export default class MiniBot extends Vue {
     @Prop({ default: false })
     isSearch: boolean;
 
+    /**
+     * Whether the bot should create a mod when dragged.
+     */
+    @Prop({ default: false })
+    createMod: boolean;
+
     image: string = '';
     label: string = '';
     labelColor: string = '#000';

--- a/src/aux-server/aux-web/aux-projector/interaction/BuilderInteractionManager.ts
+++ b/src/aux-server/aux-web/aux-projector/interaction/BuilderInteractionManager.ts
@@ -207,6 +207,15 @@ export class BuilderInteractionManager extends BaseInteractionManager {
             const table = vueElement.$parent.$parent;
             const bot = vueElement.bot;
 
+            if (vueElement.createMod) {
+                return new BuilderModClickOperation(
+                    this._game.simulation3D,
+                    this,
+                    bot.tags,
+                    vrController
+                );
+            }
+
             if (state[bot.id]) {
                 return new BuilderBotIDClickOperation(
                     this._game.simulation3D,

--- a/src/aux-server/aux-web/aux-projector/interaction/ClickOperation/BuilderBotClickOperation.ts
+++ b/src/aux-server/aux-web/aux-projector/interaction/ClickOperation/BuilderBotClickOperation.ts
@@ -55,6 +55,7 @@ export class BuilderBotClickOperation extends BaseBotClickOperation {
         calc: BotCalculationContext,
         fromCoord?: Vector2
     ): BaseBotDragOperation {
+        this._interaction.hideContextMenu();
         if (
             this.game.getInput().getKeyHeld('Meta') ||
             this.game.getInput().getKeyHeld('Ctrl') ||
@@ -133,7 +134,7 @@ export class BuilderBotClickOperation extends BaseBotClickOperation {
 
             // If we're clicking on a workspace show the context menu for it.
         } else if (workspace) {
-            this._interaction.showContextMenu(calc);
+            this._interaction.toggleContextMenu(calc);
         }
     }
 

--- a/src/aux-server/aux-web/aux-projector/interaction/ClickOperation/BuilderEmptyClickOperation.ts
+++ b/src/aux-server/aux-web/aux-projector/interaction/ClickOperation/BuilderEmptyClickOperation.ts
@@ -25,8 +25,6 @@ export class BuilderEmptyClickOperation extends BaseEmptyClickOperation {
         appManager.simulationManager.primary.botPanel.restrictVisible(false);
 
         this.removeSelected();
-
-        this._game.gameView.$emit('onContextMenuHide');
     }
 
     async removeSelected() {

--- a/src/aux-server/aux-web/aux-projector/interaction/ClickOperation/BuilderModClickOperation.ts
+++ b/src/aux-server/aux-web/aux-projector/interaction/ClickOperation/BuilderModClickOperation.ts
@@ -25,16 +25,25 @@ export class BuilderModClickOperation extends BaseModClickOperation {
     // This overrides the base class Simulation3D
     protected _simulation3D: BuilderSimulation3D;
 
+    // protected _allowSelection: boolean;
+
     constructor(
         simulation: BuilderSimulation3D,
         interaction: BuilderInteractionManager,
         mod: BotTags,
         vrController: VRController3D | null
+        // allowSelection: boolean = false
     ) {
         super(simulation, interaction, mod, vrController);
+        // this._allowSelection = allowSelection;
     }
 
     protected _performClick(calc: BotCalculationContext): void {
+        // if (this._allowSelection) {
+        //     this._simulation3D.simulation.recent.addBotDiff(this._mod, true);
+        //     this._simulation3D.simulation.selection.clearSelection();
+        //     this._simulation3D.simulation.botPanel.isOpen = true;
+        // }
         // Do nothing by default
     }
 

--- a/src/aux-server/aux-web/shared/interaction/BaseInteractionManager.ts
+++ b/src/aux-server/aux-web/shared/interaction/BaseInteractionManager.ts
@@ -73,6 +73,7 @@ export abstract class BaseInteractionManager {
     private _operations: IOperation[];
     private _overHtmlMixerIFrame: boolean;
     private _pressedBot: AuxBot3D;
+    private _contextMenuOpen: boolean = false;
 
     constructor(game: Game) {
         this._draggableGroupsDirty = true;
@@ -246,6 +247,10 @@ export abstract class BaseInteractionManager {
                 // Always allow the iframes to recieve input when no inputs are being held.
                 const webglCanvas = this._game.getRenderer().domElement;
                 webglCanvas.style.pointerEvents = 'none';
+            }
+
+            if (!noMouseInput) {
+                this.hideContextMenu();
             }
 
             if (this._operations.length === 0) {
@@ -590,6 +595,14 @@ export abstract class BaseInteractionManager {
         }
     }
 
+    toggleContextMenu(calc: BotCalculationContext) {
+        if (this._contextMenuOpen) {
+            this.hideContextMenu();
+        } else {
+            this.showContextMenu(calc);
+        }
+    }
+
     showContextMenu(calc: BotCalculationContext) {
         if (WebVRDisplays.isPresenting()) {
             // Context menu does nothing in VR yet...
@@ -605,6 +618,7 @@ export abstract class BaseInteractionManager {
         const actions = this._contextMenuActions(calc, gameObject, hit.point);
 
         if (actions) {
+            this._contextMenuOpen = true;
             this.setCameraControlsEnabled(false);
 
             // Now send the actual context menu event.
@@ -614,6 +628,11 @@ export abstract class BaseInteractionManager {
             };
             this._game.gameView.$emit('onContextMenu', menuEvent);
         }
+    }
+
+    hideContextMenu() {
+        this._contextMenuOpen = false;
+        this._game.gameView.$emit('onContextMenuHide');
     }
 
     async selectBot(bot: AuxBot3D) {

--- a/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseClickOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseClickOperation.ts
@@ -107,6 +107,8 @@ export abstract class BaseClickOperation implements IOperation {
                       );
 
                 if (dragThresholdPassed) {
+                    this._interaction.hideContextMenu();
+
                     // Attempt to start dragging now that we've crossed the threshold.
                     this._triedDragging = true;
 

--- a/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseEmptyClickOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseEmptyClickOperation.ts
@@ -46,6 +46,8 @@ export abstract class BaseEmptyClickOperation implements IOperation {
             // Store the screen position of the input when the click occured.
             this._startScreenPos = this._game.getInput().getMouseScreenPos();
         }
+
+        this._interaction.hideContextMenu();
     }
 
     public update(calc: BotCalculationContext): void {


### PR DESCRIPTION
### Changes:

-   Improvements
    -   Showing hidden tags in the bot table will now also show the `shared` tag.
    -   Removed the multi-select button from the bot table.
    -   Removed the create context button from the bot table.
    -   Removed the clear search button from the bot table.
    -   Removed the "create mod from selection" button from the bot table.
    -   Added the ability to click/tap on a bot preview in the bot table to select a mod of it.
    -   Added the ability to drag a bot preview in the bot table to drag a mod of it.
    -   Hid the ID tag when a mod is selected.
    -   Hid all other buttons when a mod is selected in the bot table.