### PR TITLE
Add the ability to query and restore history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # AUX Changelog
 
+## V0.11.22
+
+### Date: TBD
+
+### Changes:
+
+-   **Breaking Changes**
+    -   Changed player bots to use the `tempLocal` space.
+        -   This means that refreshing the page won't pollute the universe with a ton of extra bots.
+    -   `player.loadUniverse()` will now create bots in the `tempLocal` space.
+        -   Previously they were created in the `shared` space.
+-   Improvements
+    -   Added the ability to create, load, and restore version marks.
+        -   The `player.markHistory(options)` function creates a history mark for the current version.
+            -   `options` is an object with the following properties:
+                -   `message` - The message that the new mark should have.
+        -   The `player.browseHistory()` function loads the `history` space with all the marks that the universe has.
+        -   The `player.restoreHistoryMark(mark)` function restores the state in the given mark to the universe.
+            -   `mark` - The bot or bot ID of the mark that should be restored.
+        -   The `player.restoreHistoryMarkToUniverse(mark, universe)` function restores the state in the given mark to the given universe.
+            -   `mark` - The bot or bot ID of the mark that should be restored.
+            -   `universe` - The universe that the mark should be restored to.
+
 ## V0.11.21
 
 ### Date: 1/14/2020

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -758,4 +758,24 @@ Each mark is a bot that is placed in the `#auxHistory` dimension.
 server.browseHistory();
 ```
 
+### `server.markHistory(options)`
+
+<FunctionCode name='markHistory'/>
+
+Marks the current state as a save point in history. This save point can be restored by using the <ActionLink action='server.restoreHistoryMark(mark)'/> action.
+Note that this only saves bots in the `shared` space. `local` and `tempLocal` bots are unaffected.
+
+The **first parameter** are the options that should be used to mark the history point.
+It should be an object with the following properties:
+- `message` - The message that the new mark should have. Use this as a way to communicate what was special about this save point.
+
+#### Examples:
+
+1. Save the current state of the `shared` space.
+```typescript
+server.markHistory({
+    message: 'First Version of my AUX'
+});
+```
+
 [listen-tag]: docs/listen-tags

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -743,4 +743,19 @@ server.setupUniverse("test", {
 });
 ```
 
+### `server.browseHistory()`
+
+<FunctionCode name='browseHistory'/>
+
+Loads the `history` space into the current universe.
+The `history` space is read-only and contains all the marks that have been created for the universe.
+Each mark is a bot that is placed in the `#auxHistory` dimension.
+
+#### Examples:
+
+1. Load the `history` space.
+```typescript
+server.browseHistory();
+```
+
 [listen-tag]: docs/listen-tags

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -778,4 +778,24 @@ server.markHistory({
 });
 ```
 
+### `server.restoreHistoryMark(mark)`
+
+<FunctionCode name='restoreHistoryMark'/>
+
+Restores the current state to the state that was saved by the given mark.
+This will create a new mark with any unsaved changes and another mark with the state that was saved by the given mark.
+
+The **first parameter** is the bot or bot ID of the mark that should be restored. You can find available marks in the current universe by using the <ActionLink action='server.browseHistory()'/> action.
+
+#### Examples:
+
+1. Restore the state to a given mark.
+```typescript
+// Find a random mark that was loaded by server.browseHistory()
+let mark = getBot(byTag("#auxHistory", true));
+
+// Restore the current state to the given mark.
+server.restoreHistoryMark(mark);
+```
+
 [listen-tag]: docs/listen-tags

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -798,4 +798,26 @@ let mark = getBot(byTag("#auxHistory", true));
 server.restoreHistoryMark(mark);
 ```
 
+### `server.restoreHistoryMarkToUniverse(mark, universe)`
+
+<FunctionCode name='restoreHistoryMarkToUniverse'/>
+
+Restores the state in the given universe to the state that was saved by the given mark.
+This will create a new mark with any unsaved changes in the universe and another mark with the state that was saved by the given mark.
+
+The **first parameter** is the bot or bot ID of the mark that should be restored. You can find available marks in the current universe by using the <ActionLink action='server.browseHistory()'/> action.
+
+The **second parameter** is the universe that the state should be restored to. If `null` or an empty string, then the current universe will be restored.
+
+#### Examples:
+
+1. Restore the state of the `test` universe to a given mark.
+```typescript
+// Find a random mark that was loaded by server.browseHistory()
+let mark = getBot(byTag("#auxHistory", true));
+
+// Restore the current state to the given mark.
+server.restoreHistoryMarkToUniverse(mark, "test");
+```
+
 [listen-tag]: docs/listen-tags

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -103,6 +103,8 @@ export const VideoBadge = ({url}) => (<Badge type='info'><a href={url} target='_
 
 export const UserBotBadge = ({url}) => (<Badge type='primary'>Player Bot</Badge>);
 
+export const HistoryBotBadge = ({url}) => (<Badge type='primary'>History Bot</Badge>);
+
 export const Alert = ({type, children}) => (
     <div className={`alert alert--${type}`} role='alert'>
         {children}

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -16,9 +16,11 @@ import {
   LabelAnchorValues,
   AnyColorValues,
   Alert,
+  ActionLink,
   TagLink,
   NormalCode,
   UserBotBadge,
+  HistoryBotBadge,
 } from './components.mdx';
 
 AUX has many tags.
@@ -58,6 +60,12 @@ Every bot is stored in a space that specifies how long the bot lives and if it i
   <PossibleValueCode value='tempLocal'>
     The bot is not saved and is not shared with other sessions.
     When the current session is closed (by refreshing or closing the tab), the bot is destroyed.
+  </PossibleValueCode>
+  <PossibleValueCode value='history'>
+    The bot represents a mark (save point).
+    The history space is not available by default.
+    You need to use the <ActionLink action='server.browseHistory()'/> function to load it.
+    Additionally, the history space is read-only. This means that bots cannot be added or removed from it and they also cannot be edited.
   </PossibleValueCode>
 </PossibleValuesTable>
 
@@ -1069,6 +1077,43 @@ Combines with <TagLink tag='auxIframeSizeX'/> and <TagLink tag='auxIframeSizeY'/
     Specifies the scale of the iframe. (Default is 1)
   </PossibleValue>
 </PossibleValuesTable>
+
+## History Tags
+
+History tags are tags that are automatically applied to bots in the `history` space.
+
+### `auxHistory`
+
+<Badges>
+  <HistoryBotBadge/>
+</Badges>
+
+Whether the bot is in the `auxHistory` dimension.
+
+### `auxMarkHash`
+
+<Badges>
+  <HistoryBotBadge/>
+</Badges>
+
+The [SHA-256](https://en.wikipedia.org/wiki/SHA-2) hash that the mark represents.
+
+### `auxPreviousMarkHash`
+
+<Badges>
+  <HistoryBotBadge/>
+</Badges>
+
+The <TagLink tag='auxMarkHash'/> of the mark that was created before this mark.
+You can use this tag as a way to find previous marks from a mark.
+
+### `auxMarkTime`
+
+<Badges>
+  <HistoryBotBadge/>
+</Badges>
+
+The time that the mark was created.
 
 ## Hidden Tags
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "start": "node ./src/aux-server/server/dist/main.js",
         "bootstrap": "lerna bootstrap --hoist",
         "watch": "npm run build:libs && concurrently --names \"Libs,Server\" \"npm run watch:libs\" \"npm run watch:server\"",
+        "watch:docs": "cd docs && npm start",
         "watch:player": "npm run build:libs && concurrently \"npm run watch:libs\" \"npm run watch:server:player\"",
         "watch:server": "lerna exec --no-prefix --scope @casual-simulation/aux-server -- npm run watch",
         "watch:server:player": "lerna exec --no-prefix --scope @casual-simulation/aux-server -- npm run watch:player",

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -57,6 +57,7 @@ import {
     download,
     showUploadAuxFile as calcShowUploadAuxFile,
     markHistory as calcMarkHistory,
+    browseHistory as calcBrowseHistory,
 } from '../bots/BotEvents';
 import { calculateActionResultsUsingContext } from '../bots/BotsChannel';
 import uuid from 'uuid/v4';
@@ -365,9 +366,9 @@ interface Bot {
 }
 
 /**
- * The possible bot types.
+ * The possible bot spaces.
  */
-type BotType = 'shared' | 'local' | 'tempLocal';
+type BotType = 'shared' | 'local' | 'tempLocal' | 'history';
 
 /**
  * Defines a tag filter. It can be either a function that accepts a tag value and returns true/false or it can be the value that the tag value has to match.
@@ -1159,6 +1160,13 @@ function finishCheckout(options: FinishCheckoutOptions) {
  */
 function markHistory(options: MarkHistoryOptions) {
     return remote(calcMarkHistory(options));
+}
+
+/**
+ * Loads the "history" space into the universe.
+ */
+function browseHistory() {
+    return remote(calcBrowseHistory());
 }
 
 /**
@@ -2227,6 +2235,7 @@ const server = {
     backupAsDownload,
     finishCheckout,
     markHistory,
+    browseHistory,
 
     loadFile: serverLoadFile,
     saveFile: serverSaveFile,

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -56,6 +56,7 @@ import {
     runScript,
     download,
     showUploadAuxFile as calcShowUploadAuxFile,
+    markHistory as calcMarkHistory,
 } from '../bots/BotEvents';
 import { calculateActionResultsUsingContext } from '../bots/BotsChannel';
 import uuid from 'uuid/v4';
@@ -249,6 +250,16 @@ interface FinishCheckoutOptions {
      * Any extra info that should be included in the onPaymentSuccessful() or onPaymentFailed() events for this checkout.
      */
     extra: any;
+}
+
+/**
+ * Defines an interface for options that mark a specific time in history.
+ */
+interface MarkHistoryOptions {
+    /**
+     * The message that the mark should contain.
+     */
+    message: string;
 }
 
 /**
@@ -1134,6 +1145,20 @@ function finishCheckout(options: FinishCheckoutOptions) {
         options.extra
     );
     return addAction(event);
+}
+
+/**
+ * Saves the current state as a history mark.
+ * @param options The options that describe what information the mark should contain.
+ *
+ * @example
+ * // Bookmark the current state with a message
+ * server.markHistory({
+ *   message: "Save recent changes"
+ * });
+ */
+function markHistory(options: MarkHistoryOptions) {
+    return remote(calcMarkHistory(options));
 }
 
 /**
@@ -2201,6 +2226,7 @@ const server = {
     backupToGithub,
     backupAsDownload,
     finishCheckout,
+    markHistory,
 
     loadFile: serverLoadFile,
     saveFile: serverSaveFile,

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -1180,6 +1180,16 @@ function restoreHistoryMark(mark: Bot | string) {
 }
 
 /**
+ * Restores the current state to the given mark.
+ * @param mark The bot or bot ID that represents the mark that should be restored.
+ * @param universe The universe that the mark should be restored to.
+ */
+function restoreHistoryMarkToUniverse(mark: Bot | string, universe: string) {
+    const id = getID(mark);
+    return remote(calcRestoreHistoryMark(id, universe));
+}
+
+/**
  * Derermines whether the player is in the given dimension.
  * @param dimension The dimension.
  */
@@ -2247,6 +2257,7 @@ const server = {
     markHistory,
     browseHistory,
     restoreHistoryMark,
+    restoreHistoryMarkToUniverse,
 
     loadFile: serverLoadFile,
     saveFile: serverSaveFile,

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -58,6 +58,7 @@ import {
     showUploadAuxFile as calcShowUploadAuxFile,
     markHistory as calcMarkHistory,
     browseHistory as calcBrowseHistory,
+    restoreHistoryMark as calcRestoreHistoryMark,
 } from '../bots/BotEvents';
 import { calculateActionResultsUsingContext } from '../bots/BotsChannel';
 import uuid from 'uuid/v4';
@@ -1170,6 +1171,15 @@ function browseHistory() {
 }
 
 /**
+ * Restores the current state to the given mark.
+ * @param mark The bot or bot ID that represents the mark that should be restored.
+ */
+function restoreHistoryMark(mark: Bot | string) {
+    const id = getID(mark);
+    return remote(calcRestoreHistoryMark(id));
+}
+
+/**
  * Derermines whether the player is in the given dimension.
  * @param dimension The dimension.
  */
@@ -2236,6 +2246,7 @@ const server = {
     finishCheckout,
     markHistory,
     browseHistory,
+    restoreHistoryMark,
 
     loadFile: serverLoadFile,
     saveFile: serverSaveFile,

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -53,8 +53,9 @@ export interface Bot {
  * - "shared" means that the bot is a normal bot.
  * - "local" means that the bot is stored in the local storage partition.
  * - "tempLocal" means that the bot is stored in the temporary partition.
+ * - "history" means that the bot represents a version of another space.
  */
-export type BotSpace = 'shared' | 'local' | 'tempLocal';
+export type BotSpace = 'shared' | 'local' | 'tempLocal' | 'history';
 
 /**
  * Defines an interface for a bot in a script/formula.

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -1,4 +1,4 @@
-import { PartialBot, BotsState, Bot, BotTags } from './Bot';
+import { PartialBot, BotsState, Bot, BotTags, BotSpace } from './Bot';
 import {
     Action,
     DeviceAction,
@@ -74,7 +74,9 @@ export type ExtraActions =
     | ShowChatBarAction
     | RunScriptAction
     | ShowUploadAuxFileAction
-    | MarkHistoryAction;
+    | MarkHistoryAction
+    | BrowseHistoryAction
+    | LoadSpaceAction;
 
 /**
  * Defines a bot event that indicates a bot was added to the state.
@@ -979,6 +981,30 @@ export interface MarkHistoryAction {
     message: string;
 }
 
+/**
+ * Defines an event that loads the history into the universe.
+ */
+export interface BrowseHistoryAction {
+    type: 'browse_history';
+}
+
+/**
+ * Defines an event that loads a space into the universe.
+ */
+export interface LoadSpaceAction {
+    type: 'load_space';
+
+    /**
+     * The space that should be loaded.
+     */
+    space: BotSpace;
+
+    /**
+     * The config that should be used to load the space.
+     */
+    config: any;
+}
+
 /**z
  * Creates a new AddBotAction.
  * @param bot The bot that was added.
@@ -1639,4 +1665,26 @@ export function markHistory(options: MarkHistoryOptions): MarkHistoryAction {
 
 export interface MarkHistoryOptions {
     message: string;
+}
+
+/**
+ * Creates a BrowseHistoryAction.
+ */
+export function browseHistory(): BrowseHistoryAction {
+    return {
+        type: 'browse_history',
+    };
+}
+
+/**
+ * Loads a space into the universe.
+ * @param space The space to load.
+ * @param config The config which specifies how the space should be loaded.
+ */
+export function loadSpace(space: BotSpace, config: any): LoadSpaceAction {
+    return {
+        type: 'load_space',
+        space,
+        config,
+    };
 }

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -73,7 +73,8 @@ export type ExtraActions =
     | SetClipboardAction
     | ShowChatBarAction
     | RunScriptAction
-    | ShowUploadAuxFileAction;
+    | ShowUploadAuxFileAction
+    | MarkHistoryAction;
 
 /**
  * Defines a bot event that indicates a bot was added to the state.
@@ -966,6 +967,18 @@ export interface ShowUploadAuxFileAction {
     type: 'show_upload_aux_file';
 }
 
+/**
+ * Defines an event that marks a specific point in history.
+ */
+export interface MarkHistoryAction {
+    type: 'mark_history';
+
+    /**
+     * The message that the mark should contain.
+     */
+    message: string;
+}
+
 /**z
  * Creates a new AddBotAction.
  * @param bot The bot that was added.
@@ -1611,4 +1624,19 @@ export function showUploadAuxFile(): ShowUploadAuxFileAction {
     return {
         type: 'show_upload_aux_file',
     };
+}
+
+/**
+ * Creates a MarkHistoryAction.
+ * @param options The options to use.
+ */
+export function markHistory(options: MarkHistoryOptions): MarkHistoryAction {
+    return {
+        type: 'mark_history',
+        ...options,
+    };
+}
+
+export interface MarkHistoryOptions {
+    message: string;
 }

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -76,6 +76,7 @@ export type ExtraActions =
     | ShowUploadAuxFileAction
     | MarkHistoryAction
     | BrowseHistoryAction
+    | RestoreHistoryMarkAction
     | LoadSpaceAction;
 
 /**
@@ -989,6 +990,18 @@ export interface BrowseHistoryAction {
 }
 
 /**
+ * Defines an event that restores the current state to a specific bookmark.
+ */
+export interface RestoreHistoryMarkAction {
+    type: 'restore_history_mark';
+
+    /**
+     * The ID of the mark that should be restored.
+     */
+    mark: string;
+}
+
+/**
  * Defines an event that loads a space into the universe.
  */
 export interface LoadSpaceAction {
@@ -1673,6 +1686,17 @@ export interface MarkHistoryOptions {
 export function browseHistory(): BrowseHistoryAction {
     return {
         type: 'browse_history',
+    };
+}
+
+/**
+ * Creates a RestoreHistoryMarkAction.
+ * @param mark The ID of the mark that history should be restored to.
+ */
+export function restoreHistoryMark(mark: string): RestoreHistoryMarkAction {
+    return {
+        type: 'restore_history_mark',
+        mark,
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -999,6 +999,12 @@ export interface RestoreHistoryMarkAction {
      * The ID of the mark that should be restored.
      */
     mark: string;
+
+    /**
+     * The universe that the mark should be restored to.
+     * If not specified, then the current universe will be used.
+     */
+    universe?: string;
 }
 
 /**
@@ -1692,12 +1698,24 @@ export function browseHistory(): BrowseHistoryAction {
 /**
  * Creates a RestoreHistoryMarkAction.
  * @param mark The ID of the mark that history should be restored to.
+ * @param universe The universe that the mark should be restored to. If not specified, then the current universe will be used.
  */
-export function restoreHistoryMark(mark: string): RestoreHistoryMarkAction {
-    return {
-        type: 'restore_history_mark',
-        mark,
-    };
+export function restoreHistoryMark(
+    mark: string,
+    universe?: string
+): RestoreHistoryMarkAction {
+    if (!universe) {
+        return {
+            type: 'restore_history_mark',
+            mark,
+        };
+    } else {
+        return {
+            type: 'restore_history_mark',
+            mark,
+            universe,
+        };
+    }
 }
 
 /**

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -41,6 +41,7 @@ import {
     download,
     showUploadAuxFile,
     markHistory,
+    browseHistory,
 } from '../BotEvents';
 import { createBot, getActiveObjects } from '../BotCalculations';
 import { getBotsForAction } from '../BotsChannel';
@@ -5836,6 +5837,32 @@ export function botActionsTests(
                         })
                     ),
                 ]);
+            });
+        });
+
+        describe('server.browseHistory()', () => {
+            it('should emit a browse_history event', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: `@server.browseHistory()`,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot'], 'userBot');
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([remote(browseHistory())]);
             });
         });
 

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -43,6 +43,7 @@ import {
     markHistory,
     browseHistory,
     restoreHistoryMark,
+    RestoreHistoryMarkAction,
 } from '../BotEvents';
 import { createBot, getActiveObjects } from '../BotCalculations';
 import { getBotsForAction } from '../BotsChannel';
@@ -5891,6 +5892,38 @@ export function botActionsTests(
 
                 expect(result.events).toEqual([
                     remote(restoreHistoryMark('mark')),
+                ]);
+            });
+        });
+
+        describe('server.restoreHistoryMarkToUniverse()', () => {
+            it('should emit a restore_history_mark event', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: `@server.restoreHistoryMarkToUniverse("mark", "universe")`,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot'], 'userBot');
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    remote(<RestoreHistoryMarkAction>{
+                        type: 'restore_history_mark',
+                        mark: 'mark',
+                        universe: 'universe',
+                    }),
                 ]);
             });
         });

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -40,6 +40,7 @@ import {
     runScript,
     download,
     showUploadAuxFile,
+    markHistory,
 } from '../BotEvents';
 import { createBot, getActiveObjects } from '../BotCalculations';
 import { getBotsForAction } from '../BotsChannel';
@@ -5800,6 +5801,40 @@ export function botActionsTests(
                     finishCheckout('token1', 100, 'usd', 'Test', {
                         abc: 'def',
                     }),
+                ]);
+            });
+        });
+
+        describe('server.markHistory()', () => {
+            it('should emit a mark_history event', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: `@server.markHistory({
+                                message: 'testMark'
+                            })`,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot'], 'userBot');
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    remote(
+                        markHistory({
+                            message: 'testMark',
+                        })
+                    ),
                 ]);
             });
         });

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -42,6 +42,7 @@ import {
     showUploadAuxFile,
     markHistory,
     browseHistory,
+    restoreHistoryMark,
 } from '../BotEvents';
 import { createBot, getActiveObjects } from '../BotCalculations';
 import { getBotsForAction } from '../BotsChannel';
@@ -5863,6 +5864,34 @@ export function botActionsTests(
                 expect(result.hasUserDefinedEvents).toBe(true);
 
                 expect(result.events).toEqual([remote(browseHistory())]);
+            });
+        });
+
+        describe('server.restoreHistoryMark()', () => {
+            it('should emit a restore_history_mark event', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: `@server.restoreHistoryMark("mark")`,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot'], 'userBot');
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    remote(restoreHistoryMark('mark')),
+                ]);
             });
         });
 

--- a/src/aux-server/aux-web/aux-player/scene/InventorySimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/InventorySimulation3D.ts
@@ -9,7 +9,7 @@ import {
     BrowserSimulation,
     userBotChanged,
 } from '@casual-simulation/aux-vm-browser';
-import { tap } from 'rxjs/operators';
+import { tap, filter } from 'rxjs/operators';
 import { InventoryContextGroup3D as InventoryDimensionGroup3D } from './InventoryContextGroup3D';
 import { CameraRig } from '../../shared/scene/CameraRigFactory';
 import { Game } from '../../shared/scene/Game';
@@ -45,6 +45,7 @@ export class InventorySimulation3D extends Simulation3D {
         this._subs.push(
             userBotChanged(this.simulation)
                 .pipe(
+                    filter(bot => !!bot),
                     tap(bot => {
                         const userInventoryDimensionValue =
                             bot.values['_auxUserInventoryDimension'];

--- a/src/aux-server/aux-web/aux-player/scene/PlayerSimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerSimulation3D.ts
@@ -17,7 +17,7 @@ import {
     BrowserSimulation,
     userBotChanged,
 } from '@casual-simulation/aux-vm-browser';
-import { tap } from 'rxjs/operators';
+import { tap, filter } from 'rxjs/operators';
 import { DimensionGroup3D } from '../../shared/scene/DimensionGroup3D';
 import { doesBotDefinePlayerDimension } from '../PlayerUtils';
 import {
@@ -686,6 +686,7 @@ export class PlayerSimulation3D extends Simulation3D {
             this.simulation.watcher
                 .botChanged(bot.id)
                 .pipe(
+                    filter(bot => !!bot),
                     tap(update => {
                         const bot = update;
                         let userBackgroundColor = calculateBotValue(

--- a/src/aux-vm-browser/partitions/LocalStoragePartition.ts
+++ b/src/aux-vm-browser/partitions/LocalStoragePartition.ts
@@ -17,7 +17,11 @@ import {
     tagsOnBot,
     hasValue,
 } from '@casual-simulation/aux-common';
-import { DeviceAction, StatusUpdate } from '@casual-simulation/causal-trees';
+import {
+    DeviceAction,
+    StatusUpdate,
+    Action,
+} from '@casual-simulation/causal-trees';
 import {
     LocalStoragePartition,
     LocalStoragePartitionConfig,
@@ -34,7 +38,7 @@ export class LocalStoragePartitionImpl implements LocalStoragePartition {
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
 
     protected _onError = new Subject<any>();
-    protected _onEvents = new Subject<DeviceAction[]>();
+    protected _onEvents = new Subject<Action[]>();
     protected _onStatusUpdated = new Subject<StatusUpdate>();
     protected _hasRegisteredSubs = false;
     private _state: BotsState = {};
@@ -56,7 +60,7 @@ export class LocalStoragePartitionImpl implements LocalStoragePartition {
         return this._onError;
     }
 
-    get onEvents(): Observable<DeviceAction[]> {
+    get onEvents(): Observable<Action[]> {
         return this._onEvents;
     }
 

--- a/src/aux-vm-browser/partitions/ProxyClientPartition.ts
+++ b/src/aux-vm-browser/partitions/ProxyClientPartition.ts
@@ -4,7 +4,11 @@ import {
     UpdatedBot,
     merge,
 } from '@casual-simulation/aux-common';
-import { DeviceAction, StatusUpdate } from '@casual-simulation/causal-trees';
+import {
+    DeviceAction,
+    StatusUpdate,
+    Action,
+} from '@casual-simulation/causal-trees';
 import { Observable, Subject, Subscription } from 'rxjs';
 import {
     ProxyBridgePartition,
@@ -37,7 +41,7 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
     private _onBotsRemoved: Subject<string[]>;
     private _onBotsUpdated: Subject<UpdatedBot[]>;
     private _onError: Subject<any>;
-    private _onEvents: Subject<DeviceAction[]>;
+    private _onEvents: Subject<Action[]>;
     private _onStatusUpdated: Subject<StatusUpdate>;
     private _proxies: readonly any[];
     private _sub: Subscription;
@@ -58,7 +62,7 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
     get onError(): Observable<any> {
         return this._onError;
     }
-    get onEvents(): Observable<DeviceAction[]> {
+    get onEvents(): Observable<Action[]> {
         return this._onEvents;
     }
     get onStatusUpdated(): Observable<StatusUpdate> {
@@ -77,7 +81,7 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
         this._onBotsRemoved = new Subject<string[]>();
         this._onBotsUpdated = new Subject<UpdatedBot[]>();
         this._onError = new Subject<any>();
-        this._onEvents = new Subject<DeviceAction[]>();
+        this._onEvents = new Subject<Action[]>();
         this._onStatusUpdated = new Subject<StatusUpdate>();
     }
 
@@ -87,7 +91,7 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
             proxy((bots: string[]) => this._handleOnBotsRemoved(bots)),
             proxy((bots: UpdatedBot[]) => this._handleOnBotsUpdated(bots)),
             proxy((error: any) => this._onError.next(error)),
-            proxy((events: DeviceAction[]) => this._onEvents.next(events)),
+            proxy((events: Action[]) => this._onEvents.next(events)),
             proxy((status: StatusUpdate) => this._onStatusUpdated.next(status)),
         ] as const;
 

--- a/src/aux-vm-browser/vm/BrowserAuxChannel.ts
+++ b/src/aux-vm-browser/vm/BrowserAuxChannel.ts
@@ -59,8 +59,8 @@ export class BrowserAuxChannel extends RemoteAuxChannel {
 
     // TODO: Move this logic to an AuxModule
     // Overridden to automatically execute events from the server.
-    protected async _handleServerEvents(events: DeviceAction[]) {
-        await super._handleServerEvents(events);
+    protected async _handlePartitionEvents(events: DeviceAction[]) {
+        await super._handlePartitionEvents(events);
         let filtered = events.filter(
             e => e.device.roles.indexOf(SERVER_ROLE) >= 0
         );

--- a/src/aux-vm-browser/vm/BrowserAuxChannel.ts
+++ b/src/aux-vm-browser/vm/BrowserAuxChannel.ts
@@ -17,6 +17,7 @@ import {
     RemoteAction,
     SERVER_ROLE,
     DeviceAction,
+    Action,
 } from '@casual-simulation/causal-trees';
 import {
     AuxConfig,
@@ -59,11 +60,11 @@ export class BrowserAuxChannel extends RemoteAuxChannel {
 
     // TODO: Move this logic to an AuxModule
     // Overridden to automatically execute events from the server.
-    protected async _handlePartitionEvents(events: DeviceAction[]) {
+    protected async _handlePartitionEvents(events: BotAction[]) {
         await super._handlePartitionEvents(events);
         let filtered = events.filter(
-            e => e.device.roles.indexOf(SERVER_ROLE) >= 0
-        );
+            e => e.type === 'device' && e.device.roles.indexOf(SERVER_ROLE) >= 0
+        ) as DeviceAction[];
         let mapped = <BotAction[]>filtered.map(e => e.event);
         if (filtered.length > 0) {
             await this.sendEvents(mapped);

--- a/src/aux-vm-client/vm/RemoteAuxChannel.ts
+++ b/src/aux-vm-client/vm/RemoteAuxChannel.ts
@@ -25,6 +25,7 @@ import {
     iteratePartitions,
     filterAtomFactory,
     createCausalRepoClientPartition,
+    createCausalRepoHistoryClientPartition,
 } from '@casual-simulation/aux-vm';
 import {
     SyncedRealtimeCausalTree,
@@ -85,7 +86,8 @@ export class RemoteAuxChannel extends BaseAuxChannel {
             createMemoryPartition,
             config => createCausalRepoPartition(config, this.user),
             config => createRemoteCausalRepoPartition(config, this.user),
-            config => createCausalRepoClientPartition(config, this.user)
+            config => createCausalRepoClientPartition(config, this.user),
+            config => createCausalRepoHistoryClientPartition(config, this.user)
         );
     }
 

--- a/src/aux-vm/managers/BotHelper.spec.ts
+++ b/src/aux-vm/managers/BotHelper.spec.ts
@@ -97,30 +97,46 @@ describe('BotHelper', () => {
 
             expect(vm.events).toEqual([
                 botAdded(
-                    createBot('botId', {
-                        abc: true,
-                        auxUniverse: 'test',
-                    })
+                    createBot(
+                        'botId',
+                        {
+                            abc: true,
+                            auxUniverse: 'test',
+                        },
+                        'tempLocal'
+                    )
                 ),
                 action(CREATE_ACTION_NAME, ['botId'], 'user'),
                 action(CREATE_ANY_ACTION_NAME, null, 'user', {
-                    bot: createBot('botId', {
-                        abc: true,
-                        auxUniverse: 'test',
-                    }),
+                    bot: createBot(
+                        'botId',
+                        {
+                            abc: true,
+                            auxUniverse: 'test',
+                        },
+                        'tempLocal'
+                    ),
                 }),
                 botAdded(
-                    createBot('botId2', {
-                        abc: true,
-                        auxUniverse: 'test2',
-                    })
+                    createBot(
+                        'botId2',
+                        {
+                            abc: true,
+                            auxUniverse: 'test2',
+                        },
+                        'tempLocal'
+                    )
                 ),
                 action(CREATE_ACTION_NAME, ['botId2'], 'user'),
                 action(CREATE_ANY_ACTION_NAME, null, 'user', {
-                    bot: createBot('botId2', {
-                        abc: true,
-                        auxUniverse: 'test2',
-                    }),
+                    bot: createBot(
+                        'botId2',
+                        {
+                            abc: true,
+                            auxUniverse: 'test2',
+                        },
+                        'tempLocal'
+                    ),
                 }),
             ]);
         });

--- a/src/aux-vm/managers/BotHelper.ts
+++ b/src/aux-vm/managers/BotHelper.ts
@@ -26,6 +26,7 @@ import {
     createPrecalculatedContext,
     CREATE_ACTION_NAME,
     CREATE_ANY_ACTION_NAME,
+    BotSpace,
 } from '@casual-simulation/aux-common';
 import flatMap from 'lodash/flatMap';
 import { BaseHelper } from './BaseHelper';
@@ -93,17 +94,19 @@ export class BotHelper extends BaseHelper<PrecalculatedBot> {
      * @param id (Optional) The ID that the bot should have.
      * @param tags (Optional) The tags that the bot should have.
      * @param sendShouts Whether to send the onCreate() and onAnyCreate() shouts.
+     * @param space The space the bot should be stored in.
      */
     async createBot(
         id?: string,
         tags?: Bot['tags'],
-        sendShouts: boolean = true
+        sendShouts: boolean = true,
+        space?: BotSpace
     ): Promise<string> {
         if (BotHelper._debug) {
             console.log('[BotManager] Create Bot');
         }
 
-        const bot = createBot(id, tags);
+        const bot = createBot(id, tags, space);
 
         let events: BotAction[] = [botAdded(bot)];
 
@@ -175,10 +178,15 @@ export class BotHelper extends BaseHelper<PrecalculatedBot> {
         const simBots = this.getSimulationBots(id);
 
         if (simBots.length === 0) {
-            await this.createBot(botId, {
-                [this.userBot.tags['_auxUserUniversesDimension']]: true,
-                ['auxUniverse']: id,
-            });
+            await this.createBot(
+                botId,
+                {
+                    [this.userBot.tags['_auxUserUniversesDimension']]: true,
+                    ['auxUniverse']: id,
+                },
+                true,
+                'tempLocal'
+            );
         }
     }
 

--- a/src/aux-vm/partitions/AuxPartition.ts
+++ b/src/aux-vm/partitions/AuxPartition.ts
@@ -8,13 +8,12 @@ import {
 } from '@casual-simulation/aux-common';
 import {
     RealtimeCausalTree,
-    DeviceAction,
     StatusUpdate,
     RemoteAction,
     User,
+    Action,
 } from '@casual-simulation/causal-trees';
 import { Observable, SubscriptionLike } from 'rxjs';
-import { StoredAux } from '../StoredAux';
 
 /**
  * Defines an interface that maps Bot IDs to their corresponding partitions.
@@ -106,7 +105,7 @@ export interface AuxPartitionBase extends SubscriptionLike {
     /**
      * Gets the observable list of remote events from the partition.
      */
-    onEvents: Observable<DeviceAction[]>;
+    onEvents: Observable<Action[]>;
 
     /**
      * Gets the observable list of status updates from the partition.
@@ -123,7 +122,7 @@ export interface ProxyBridgePartition extends AuxPartitionBase {
         onBotsRemoved?: (bot: string[]) => void,
         onBotsUpdated?: (bots: UpdatedBot[]) => void,
         onError?: (error: any) => void,
-        onEvents?: (actions: DeviceAction[]) => void,
+        onEvents?: (actions: Action[]) => void,
         onStatusUpdated?: (status: StatusUpdate) => void
     ): Promise<void>;
 }

--- a/src/aux-vm/partitions/AuxPartitionConfig.ts
+++ b/src/aux-vm/partitions/AuxPartitionConfig.ts
@@ -21,6 +21,7 @@ export type PartitionConfig =
     | CausalTreePartitionConfig
     | CausalRepoPartitionConfig
     | RemoteCausalRepoPartitionConfig
+    | CausalRepoHistoryClientPartitionConfig
     | CausalRepoClientPartitionConfig
     | MemoryPartitionConfig
     | ProxyPartitionConfig
@@ -158,6 +159,24 @@ export interface RemoteCausalRepoPartitionConfig extends PartitionConfigBase {
      * Whether the partition should be loaded in read-only mode.
      */
     readOnly?: boolean;
+}
+
+/**
+ * Defines a causal repo partition that loads history for a branch.
+ */
+export interface CausalRepoHistoryClientPartitionConfig
+    extends PartitionConfigBase {
+    type: 'causal_repo_history_client';
+
+    /**
+     * The branch to load history from.
+     */
+    branch: string;
+
+    /**
+     * The client that should be used to load the history.
+     */
+    client: CausalRepoClient;
 }
 
 /**

--- a/src/aux-vm/partitions/CausalRepoPartition.ts
+++ b/src/aux-vm/partitions/CausalRepoPartition.ts
@@ -7,6 +7,7 @@ import {
     DEVICE_ID_CLAIM,
     SESSION_ID_CLAIM,
     USER_ROLE,
+    Action,
 } from '@casual-simulation/causal-trees';
 import {
     Weave,
@@ -70,7 +71,7 @@ export class CausalRepoPartitionImpl implements CausalRepoPartition {
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
 
     protected _onError = new Subject<any>();
-    protected _onEvents = new Subject<DeviceAction[]>();
+    protected _onEvents = new Subject<Action[]>();
     protected _onStatusUpdated = new Subject<StatusUpdate>();
     protected _hasRegisteredSubs = false;
     private _sub = new Subscription();
@@ -99,7 +100,7 @@ export class CausalRepoPartitionImpl implements CausalRepoPartition {
         return this._onError;
     }
 
-    get onEvents(): Observable<DeviceAction[]> {
+    get onEvents(): Observable<Action[]> {
         return this._onEvents;
     }
 

--- a/src/aux-vm/partitions/CausalTreePartition.ts
+++ b/src/aux-vm/partitions/CausalTreePartition.ts
@@ -7,6 +7,7 @@ import {
     StatusUpdate,
     DeviceAction,
     LocalRealtimeCausalTree,
+    Action,
 } from '@casual-simulation/causal-trees';
 import {
     auxCausalTreeFactory,
@@ -36,7 +37,7 @@ export abstract class CausalTreePartitionImpl implements CausalTreePartition {
         botsUpdated: Observable<UpdatedBot[]>;
     }>(null);
     protected _onError = new Subject<any>();
-    protected _onEvents = new Subject<DeviceAction[]>();
+    protected _onEvents = new Subject<Action[]>();
     protected _onStatusUpdated = new Subject<StatusUpdate>();
     protected _hasRegisteredSubs = false;
     private _sub = new Subscription();
@@ -77,7 +78,7 @@ export abstract class CausalTreePartitionImpl implements CausalTreePartition {
         return this._onError;
     }
 
-    get onEvents(): Observable<DeviceAction[]> {
+    get onEvents(): Observable<Action[]> {
         return this._onEvents;
     }
 

--- a/src/aux-vm/partitions/MemoryPartition.ts
+++ b/src/aux-vm/partitions/MemoryPartition.ts
@@ -23,6 +23,7 @@ import {
     DEVICE_ID_CLAIM,
     SESSION_ID_CLAIM,
     USER_ROLE,
+    Action,
 } from '@casual-simulation/causal-trees';
 import { startWith } from 'rxjs/operators';
 import flatMap from 'lodash/flatMap';
@@ -46,7 +47,7 @@ class MemoryPartitionImpl implements MemoryPartition {
     private _onBotsRemoved = new Subject<string[]>();
     private _onBotsUpdated = new Subject<UpdatedBot[]>();
     private _onError = new Subject<any>();
-    private _onEvents = new Subject<DeviceAction[]>();
+    private _onEvents = new Subject<Action[]>();
     private _onStatusUpdated = new Subject<StatusUpdate>();
 
     type = 'memory' as const;
@@ -69,7 +70,7 @@ class MemoryPartitionImpl implements MemoryPartition {
         return this._onError;
     }
 
-    get onEvents(): Observable<DeviceAction[]> {
+    get onEvents(): Observable<Action[]> {
         return this._onEvents;
     }
 

--- a/src/aux-vm/partitions/ProxyBridgePartition.ts
+++ b/src/aux-vm/partitions/ProxyBridgePartition.ts
@@ -4,6 +4,7 @@ import {
     DeviceAction,
     RemoteAction,
     StatusUpdate,
+    Action,
 } from '@casual-simulation/causal-trees';
 import { Bot, UpdatedBot, BotAction } from '@casual-simulation/aux-common';
 import { Observable, Subscription } from 'rxjs';
@@ -25,7 +26,7 @@ export class ProxyBridgePartitionImpl implements ProxyBridgePartition {
     get onError(): Observable<any> {
         return this._partition.onError;
     }
-    get onEvents(): Observable<DeviceAction[]> {
+    get onEvents(): Observable<Action[]> {
         return this._partition.onEvents;
     }
     get onStatusUpdated(): Observable<StatusUpdate> {
@@ -71,7 +72,7 @@ export class ProxyBridgePartitionImpl implements ProxyBridgePartition {
         onBotsRemoved?: (bot: string[]) => void,
         onBotsUpdated?: (bots: UpdatedBot[]) => void,
         onError?: (error: any) => void,
-        onEvents?: (actions: any[]) => void,
+        onEvents?: (actions: Action[]) => void,
         onStatusUpdated?: (status: StatusUpdate) => void
     ): Promise<void> {
         if (onBotsAdded) {

--- a/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.spec.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.spec.ts
@@ -1,0 +1,187 @@
+import { testPartitionImplementation } from './test/PartitionTests';
+import {
+    RemoteCausalRepoHistoryPartitionImpl,
+    COMMIT_ID_NAMESPACE,
+} from './RemoteCausalRepoHistoryPartition';
+import { BehaviorSubject, Subject, Subscription } from 'rxjs';
+import {
+    Atom,
+    atom,
+    atomId,
+    ADD_ATOMS,
+    AddAtomsEvent,
+    MemoryConnectionClient,
+    CausalRepoClient,
+    SEND_EVENT,
+    ReceiveDeviceActionEvent,
+    RECEIVE_EVENT,
+    COMMIT,
+    WATCH_COMMITS,
+    AddCommitsEvent,
+    ADD_COMMITS,
+    index,
+    commit,
+} from '@casual-simulation/causal-trees/core2';
+import {
+    remote,
+    DeviceAction,
+    device,
+    deviceInfo,
+    Action,
+} from '@casual-simulation/causal-trees';
+import flatMap from 'lodash/flatMap';
+import { waitAsync } from '../test/TestHelpers';
+import {
+    botAdded,
+    createBot,
+    botUpdated,
+    Bot,
+    UpdatedBot,
+} from '@casual-simulation/aux-common';
+import {
+    AuxOpType,
+    addAuxResults,
+    bot,
+    tag,
+    value,
+} from '@casual-simulation/aux-common/aux-format-2';
+import {
+    RemoteCausalRepoPartitionConfig,
+    CausalRepoHistoryClientPartitionConfig,
+} from './AuxPartitionConfig';
+import uuid from 'uuid/v5';
+
+console.log = jest.fn();
+
+describe('RemoteCausalRepoHistoryPartition', () => {
+    describe('connection', () => {
+        let connection: MemoryConnectionClient;
+        let client: CausalRepoClient;
+        let partition: RemoteCausalRepoHistoryPartitionImpl;
+        let receiveEvent: Subject<ReceiveDeviceActionEvent>;
+        let addAtoms: Subject<AddAtomsEvent>;
+        let added: Bot[];
+        let removed: string[];
+        let updated: UpdatedBot[];
+        let sub: Subscription;
+
+        beforeEach(async () => {
+            connection = new MemoryConnectionClient();
+            receiveEvent = new Subject<ReceiveDeviceActionEvent>();
+            addAtoms = new Subject<AddAtomsEvent>();
+            connection.events.set(RECEIVE_EVENT, receiveEvent);
+            connection.events.set(ADD_ATOMS, addAtoms);
+            client = new CausalRepoClient(connection);
+            connection.connect();
+            sub = new Subscription();
+
+            added = [];
+            removed = [];
+            updated = [];
+
+            setupPartition({
+                type: 'causal_repo_history_client',
+                branch: 'testBranch',
+                client: null,
+            });
+        });
+
+        afterEach(() => {
+            sub.unsubscribe();
+        });
+
+        describe('remote events', () => {
+            it('should not send the remote event to the server', async () => {
+                await partition.sendRemoteEvents([
+                    remote(
+                        {
+                            type: 'def',
+                        },
+                        {
+                            deviceId: 'device',
+                        }
+                    ),
+                ]);
+
+                expect(connection.sentMessages).toEqual([]);
+            });
+        });
+
+        it('should request commits', async () => {
+            partition.connect();
+
+            expect(connection.sentMessages).toEqual([
+                {
+                    name: WATCH_COMMITS,
+                    data: 'testBranch',
+                },
+            ]);
+        });
+
+        it('should convert commits into bots', async () => {
+            const addCommits = new Subject<AddCommitsEvent>();
+            connection.events.set(ADD_COMMITS, addCommits);
+
+            partition.connect();
+
+            await waitAsync();
+
+            const a1 = atom(atomId('a', 1), null, {});
+            const a2 = atom(atomId('a', 2), a1, {});
+            const idx1 = index(a1);
+            const idx2 = index(a1, a2);
+            const c1 = commit('commit1', new Date(1900, 1, 1), idx1, null);
+            const c2 = commit('commit2', new Date(1900, 1, 1), idx2, c1);
+
+            addCommits.next({
+                branch: 'testBranch',
+                commits: [c2, c1],
+            });
+
+            await waitAsync();
+
+            expect(partition.state).toEqual({
+                [uuid(c1.hash, COMMIT_ID_NAMESPACE)]: createBot(
+                    uuid(c1.hash, COMMIT_ID_NAMESPACE),
+                    {
+                        auxHistory: true,
+                        auxLabel: 'commit1',
+                        auxMarkHash: c1.hash,
+                        auxPreviousMarkHash: null,
+                        auxMarkTime: new Date(1900, 1, 1),
+                    }
+                ),
+                [uuid(c2.hash, COMMIT_ID_NAMESPACE)]: createBot(
+                    uuid(c2.hash, COMMIT_ID_NAMESPACE),
+                    {
+                        auxHistory: true,
+                        auxLabel: 'commit2',
+                        auxMarkHash: c2.hash,
+                        auxPreviousMarkHash: c1.hash,
+                        auxMarkTime: new Date(1900, 1, 1),
+                    }
+                ),
+            });
+        });
+
+        function setupPartition(
+            config: CausalRepoHistoryClientPartitionConfig
+        ) {
+            partition = new RemoteCausalRepoHistoryPartitionImpl(
+                {
+                    id: 'test',
+                    name: 'name',
+                    token: 'token',
+                    username: 'username',
+                },
+                client,
+                config
+            );
+
+            sub.add(partition);
+            sub.add(partition.onBotsAdded.subscribe(b => added.push(...b)));
+            sub.add(partition.onBotsRemoved.subscribe(b => removed.push(...b)));
+            sub.add(partition.onBotsUpdated.subscribe(b => updated.push(...b)));
+        }
+    });
+});

--- a/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.spec.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.spec.ts
@@ -22,6 +22,7 @@ import {
     index,
     commit,
     CHECKOUT,
+    RESTORE,
 } from '@casual-simulation/causal-trees/core2';
 import {
     remote,
@@ -109,7 +110,7 @@ describe('RemoteCausalRepoHistoryPartition', () => {
             });
 
             describe('restore_history_mark', () => {
-                it('should send a checkout event to the server', async () => {
+                it('should send a restore event to the server', async () => {
                     const addCommits = new Subject<AddCommitsEvent>();
                     connection.events.set(ADD_COMMITS, addCommits);
 
@@ -153,7 +154,7 @@ describe('RemoteCausalRepoHistoryPartition', () => {
 
                     expect(connection.sentMessages.slice(1)).toEqual([
                         {
-                            name: CHECKOUT,
+                            name: RESTORE,
                             data: {
                                 branch: 'testBranch',
                                 commit: c1.hash,
@@ -162,7 +163,7 @@ describe('RemoteCausalRepoHistoryPartition', () => {
                     ]);
                 });
 
-                it('should send a checkout event to the server with the universe if specified', async () => {
+                it('should send a restore event to the server with the universe if specified', async () => {
                     const addCommits = new Subject<AddCommitsEvent>();
                     connection.events.set(ADD_COMMITS, addCommits);
 
@@ -207,7 +208,7 @@ describe('RemoteCausalRepoHistoryPartition', () => {
 
                     expect(connection.sentMessages.slice(1)).toEqual([
                         {
-                            name: CHECKOUT,
+                            name: RESTORE,
                             data: {
                                 branch: 'universe',
                                 commit: c1.hash,

--- a/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.ts
@@ -55,6 +55,7 @@ import {
     loadSpace,
     BrowseHistoryAction,
     createBot,
+    RestoreHistoryMarkAction,
 } from '@casual-simulation/aux-common';
 import flatMap from 'lodash/flatMap';
 import {
@@ -169,6 +170,18 @@ export class RemoteCausalRepoHistoryPartitionImpl
     async sendRemoteEvents(events: RemoteAction[]): Promise<void> {
         if (this._readOnly) {
             return;
+        }
+
+        for (let event of events) {
+            if (event.event.type === 'restore_history_mark') {
+                const restoreMark = <RestoreHistoryMarkAction>event.event;
+                const bot = this.state[restoreMark.mark];
+                if (!bot) {
+                    continue;
+                }
+                const hash = bot.tags.auxMarkHash;
+                this._client.checkout(this._branch, hash);
+            }
         }
     }
 

--- a/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.ts
@@ -180,7 +180,10 @@ export class RemoteCausalRepoHistoryPartitionImpl
                     continue;
                 }
                 const hash = bot.tags.auxMarkHash;
-                this._client.checkout(this._branch, hash);
+                this._client.checkout(
+                    restoreMark.universe || this._branch,
+                    hash
+                );
             }
         }
     }

--- a/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoHistoryPartition.ts
@@ -180,7 +180,7 @@ export class RemoteCausalRepoHistoryPartitionImpl
                     continue;
                 }
                 const hash = bot.tags.auxMarkHash;
-                this._client.checkout(
+                this._client.restore(
                     restoreMark.universe || this._branch,
                     hash
                 );

--- a/src/aux-vm/partitions/RemoteCausalRepoPartition.spec.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoPartition.spec.ts
@@ -12,6 +12,7 @@ import {
     SEND_EVENT,
     ReceiveDeviceActionEvent,
     RECEIVE_EVENT,
+    COMMIT,
 } from '@casual-simulation/causal-trees/core2';
 import {
     remote,
@@ -176,6 +177,33 @@ describe('RemoteCausalRepoPartition', () => {
                 ]);
 
                 expect(connection.sentMessages).toEqual([]);
+            });
+
+            describe('mark_history', () => {
+                it(`should send a ${COMMIT} event to the server`, async () => {
+                    setupPartition({
+                        type: 'remote_causal_repo',
+                        branch: 'testBranch',
+                        host: 'testHost',
+                    });
+
+                    await partition.sendRemoteEvents([
+                        remote(<any>{
+                            type: 'mark_history',
+                            message: 'newCommit',
+                        }),
+                    ]);
+
+                    expect(connection.sentMessages).toEqual([
+                        {
+                            name: COMMIT,
+                            data: {
+                                branch: 'testBranch',
+                                message: 'newCommit',
+                            },
+                        },
+                    ]);
+                });
             });
         });
 

--- a/src/aux-vm/partitions/RemoteCausalRepoPartition.spec.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoPartition.spec.ts
@@ -13,6 +13,7 @@ import {
     ReceiveDeviceActionEvent,
     RECEIVE_EVENT,
     COMMIT,
+    WATCH_COMMITS,
 } from '@casual-simulation/causal-trees/core2';
 import {
     remote,
@@ -201,6 +202,37 @@ describe('RemoteCausalRepoPartition', () => {
                             data: {
                                 branch: 'testBranch',
                                 message: 'newCommit',
+                            },
+                        },
+                    ]);
+                });
+            });
+
+            describe('browse_history', () => {
+                it(`should send a load_space action`, async () => {
+                    setupPartition({
+                        type: 'remote_causal_repo',
+                        branch: 'testBranch',
+                        host: 'testHost',
+                    });
+
+                    let events = [] as Action[];
+                    partition.onEvents.subscribe(e => events.push(...e));
+
+                    await partition.sendRemoteEvents([
+                        remote(<any>{
+                            type: 'browse_history',
+                        }),
+                    ]);
+
+                    expect(events).toEqual([
+                        {
+                            type: 'load_space',
+                            space: 'history',
+                            config: {
+                                type: 'causal_repo_history_client',
+                                branch: 'testBranch',
+                                client: expect.anything(),
                             },
                         },
                     ]);

--- a/src/aux-vm/partitions/RemoteCausalRepoPartition.spec.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoPartition.spec.ts
@@ -19,6 +19,7 @@ import {
     DeviceAction,
     device,
     deviceInfo,
+    Action,
 } from '@casual-simulation/causal-trees';
 import flatMap from 'lodash/flatMap';
 import { waitAsync } from '../test/TestHelpers';
@@ -136,7 +137,7 @@ describe('RemoteCausalRepoPartition', () => {
             });
 
             it('should listen for device events from the connection', async () => {
-                let events = [] as DeviceAction[];
+                let events = [] as Action[];
                 partition.onEvents.subscribe(e => events.push(...e));
 
                 const action = device(

--- a/src/aux-vm/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoPartition.ts
@@ -163,7 +163,12 @@ export class RemoteCausalRepoPartitionImpl
             return;
         }
         for (let event of events) {
-            this._client.sendEvent(this._branch, event);
+            if (event.event.type === 'mark_history') {
+                const markHistory = <any>event.event;
+                this._client.commit(this._branch, markHistory.message);
+            } else {
+                this._client.sendEvent(this._branch, event);
+            }
         }
     }
 

--- a/src/aux-vm/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-vm/partitions/RemoteCausalRepoPartition.ts
@@ -8,6 +8,7 @@ import {
     SESSION_ID_CLAIM,
     USER_ROLE,
     RemoteAction,
+    Action,
 } from '@casual-simulation/causal-trees';
 import {
     Weave,
@@ -81,7 +82,7 @@ export class RemoteCausalRepoPartitionImpl
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
 
     protected _onError = new Subject<any>();
-    protected _onEvents = new Subject<DeviceAction[]>();
+    protected _onEvents = new Subject<Action[]>();
     protected _onStatusUpdated = new Subject<StatusUpdate>();
     protected _hasRegisteredSubs = false;
     private _sub = new Subscription();
@@ -113,7 +114,7 @@ export class RemoteCausalRepoPartitionImpl
         return this._onError;
     }
 
-    get onEvents(): Observable<DeviceAction[]> {
+    get onEvents(): Observable<Action[]> {
         return this._onEvents;
     }
 

--- a/src/aux-vm/partitions/index.ts
+++ b/src/aux-vm/partitions/index.ts
@@ -7,3 +7,4 @@ export * from './LocalCausalTreePartition';
 export * from './CausalRepoPartition';
 export * from './RemoteCausalRepoPartition';
 export * from './ProxyBridgePartition';
+export * from './RemoteCausalRepoHistoryPartition';

--- a/src/aux-vm/vm/AuxHelper.spec.ts
+++ b/src/aux-vm/vm/AuxHelper.spec.ts
@@ -1238,6 +1238,45 @@ describe('AuxHelper', () => {
             });
         });
 
+        it('should put the bot in the tempLocal partition if it is available', async () => {
+            tree = new AuxCausalTree(storedTree(site(1)));
+            helper = new AuxHelper({
+                shared: createMemoryPartition({
+                    type: 'memory',
+                    initialState: {},
+                }),
+                tempLocal: createMemoryPartition({
+                    type: 'memory',
+                    initialState: {},
+                }),
+            });
+            helper.userId = userId;
+
+            await tree.root();
+            await helper.createOrUpdateUserBot(
+                {
+                    id: 'testUser',
+                    username: 'username',
+                    name: 'test',
+                    isGuest: false,
+                    token: 'abc',
+                },
+                null
+            );
+
+            expect(helper.botsState['testUser']).toEqual({
+                id: 'testUser',
+                space: 'tempLocal',
+                tags: {
+                    [USERS_DIMENSION]: true,
+                    ['_auxUser']: 'username',
+                    ['_auxUserInventoryDimension']: '_user_username_inventory',
+                    ['_auxUserMenuDimension']: '_user_username_menu',
+                    ['_auxUserUniversesDimension']: '_user_username_universes',
+                },
+            });
+        });
+
         const dimensionCases = [
             ['menu dimension', '_auxUserMenuDimension', '_user_username_menu'],
             [

--- a/src/aux-vm/vm/AuxHelper.ts
+++ b/src/aux-vm/vm/AuxHelper.ts
@@ -294,13 +294,17 @@ export class AuxHelper extends BaseHelper<AuxBot> {
         const userMenuDimension = `_user_${user.username}_menu`;
         const userUniversesDimension = `_user_${user.username}_universes`;
         if (!userBot) {
-            await this.createBot(user.id, {
-                [USERS_DIMENSION]: true,
-                ['_auxUser']: user.username,
-                ['_auxUserInventoryDimension']: userInventoryDimension,
-                ['_auxUserMenuDimension']: userMenuDimension,
-                ['_auxUserUniversesDimension']: userUniversesDimension,
-            });
+            await this.createBot(
+                user.id,
+                {
+                    [USERS_DIMENSION]: true,
+                    ['_auxUser']: user.username,
+                    ['_auxUserInventoryDimension']: userInventoryDimension,
+                    ['_auxUserMenuDimension']: userMenuDimension,
+                    ['_auxUserUniversesDimension']: userUniversesDimension,
+                },
+                'tempLocal'
+            );
         } else {
             if (!userBot.tags['_auxUserMenuDimension']) {
                 await this.updateBot(userBot, {

--- a/src/aux-vm/vm/AuxHelper.ts
+++ b/src/aux-vm/vm/AuxHelper.ts
@@ -303,7 +303,7 @@ export class AuxHelper extends BaseHelper<AuxBot> {
                     ['_auxUserMenuDimension']: userMenuDimension,
                     ['_auxUserUniversesDimension']: userUniversesDimension,
                 },
-                'tempLocal'
+                'tempLocal' in this._partitions ? 'tempLocal' : undefined
             );
         } else {
             if (!userBot.tags['_auxUserMenuDimension']) {

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -46,6 +46,7 @@ import {
     SERVER_ROLE,
     RealtimeCausalTreeOptions,
     Atom,
+    Action,
 } from '@casual-simulation/causal-trees';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
 import { BotDependentInfo } from '../managers/DependencyManager';
@@ -520,8 +521,8 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
      * other components can decide what to do.
      * @param events The events.
      */
-    protected async _handleServerEvents(events: DeviceAction[]) {
-        await this.sendEvents(events);
+    protected async _handleServerEvents(events: Action[]) {
+        await this.sendEvents(<BotAction[]>events);
     }
 
     protected _handleStateUpdated(event: StateUpdatedEvent) {

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -64,6 +64,7 @@ import { PartitionConfig } from '../partitions/AuxPartitionConfig';
 import { StatusHelper } from './StatusHelper';
 import { StoredAux } from '../StoredAux';
 import pick from 'lodash/pick';
+import flatMap from 'lodash/flatMap';
 
 export interface AuxChannelOptions {
     sandboxFactory?: (lib: SandboxLibrary) => Sandbox;
@@ -239,14 +240,8 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
                     tap(state => this._handleStatusUpdated(statusMapper(state)))
                 )
                 .subscribe(null, (e: any) => console.error(e)),
-            ...partitions,
-            ...partitions.map(p =>
-                p.onError.subscribe(err => this._handleError(err))
-            ),
-            ...partitions.map(p =>
-                p.onEvents
-                    .pipe(tap(events => this._handleServerEvents(events)))
-                    .subscribe(null, (e: any) => console.error(e))
+            ...flatMap(partitions, p =>
+                this._getCleanupSubscriptionsForPartition(p)
             )
         );
 
@@ -259,6 +254,18 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
             partition.connect();
         }
         return null;
+    }
+
+    protected _getCleanupSubscriptionsForPartition(
+        partition: AuxPartition
+    ): SubscriptionLike[] {
+        return [
+            partition,
+            partition.onError.subscribe(err => this._handleError(err)),
+            partition.onEvents
+                .pipe(tap(events => this._handlePartitionEvents(events)))
+                .subscribe(null, (e: any) => console.error(e)),
+        ];
     }
 
     /**
@@ -429,11 +436,11 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
             })
         );
         for (let [key, partition] of iteratePartitions(this._partitions)) {
-            this._registerSubscriptionsForPartition(partition);
+            this._registerStateSubscriptionsForPartition(partition);
         }
     }
 
-    protected _registerSubscriptionsForPartition(partition: AuxPartition) {
+    protected _registerStateSubscriptionsForPartition(partition: AuxPartition) {
         this._subs.push(
             partition.onBotsAdded
                 .pipe(
@@ -541,11 +548,41 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
     }
 
     protected _handleLocalEvents(e: LocalActions[]) {
+        for (let event of e) {
+            if (event.type === 'load_space') {
+                this._loadPartition(event.space, event.config);
+            }
+        }
         this._onLocalEvents.next(e);
     }
 
     protected _handleDeviceEvents(e: DeviceAction[]) {
         this._onDeviceEvents.next(e);
+    }
+
+    protected async _loadPartition(space: string, config: PartitionConfig) {
+        if (space in this._partitions) {
+            console.log(
+                `[BaseAuxChannel] Cannot load partition for "${space}" since the space is already occupied`
+            );
+            return;
+        }
+
+        let partition = await this._createPartition(config);
+        if (!partition) {
+            return;
+        }
+
+        this._partitions[space] = partition;
+        this._subs.push(
+            ...this._getCleanupSubscriptionsForPartition(partition)
+        );
+
+        partition.connect();
+
+        if (this._hasRegisteredSubs) {
+            this._registerStateSubscriptionsForPartition(partition);
+        }
     }
 
     private async _initUserBot() {

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -522,14 +522,14 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
     }
 
     /**
-     * Decides what to do with device events from the server.
+     * Decides what to do with device events from partitions.
      * By default the events are processed as-is.
-     * This means that the onDeviceEvents observable will be triggered so that
-     * other components can decide what to do.
+     * This means that the events are sent directly to the AuxHelper via this.sendEvents().
      * @param events The events.
      */
-    protected async _handleServerEvents(events: Action[]) {
-        await this.sendEvents(<BotAction[]>events);
+    protected async _handlePartitionEvents(events: Action[]) {
+        const actions = <BotAction[]>events;
+        await this.sendEvents(actions);
     }
 
     protected _handleStateUpdated(event: StateUpdatedEvent) {

--- a/src/causal-tree-server/CausalRepoServer.spec.ts
+++ b/src/causal-tree-server/CausalRepoServer.spec.ts
@@ -1461,6 +1461,12 @@ describe('CausalRepoServer', () => {
         });
     });
 
+    // TODO: Implement a variant of CHECKOUT which creates a new commit
+    // instead of reseting the branch pointer.
+    // describe(RESTORE, () => {
+
+    // });
+
     describe(SEND_EVENT, () => {
         it('should notify the device that the event was sent to', async () => {
             server.init();

--- a/src/causal-tree-server/CausalRepoServer.spec.ts
+++ b/src/causal-tree-server/CausalRepoServer.spec.ts
@@ -39,6 +39,9 @@ import {
     ADD_COMMITS,
     CHECKOUT,
     CheckoutEvent,
+    RESTORE,
+    RestoreEvent,
+    CausalRepoCommit,
 } from '@casual-simulation/causal-trees/core2';
 import { waitAsync } from './test/TestHelpers';
 import { Subject } from 'rxjs';
@@ -1461,11 +1464,197 @@ describe('CausalRepoServer', () => {
         });
     });
 
-    // TODO: Implement a variant of CHECKOUT which creates a new commit
-    // instead of reseting the branch pointer.
-    // describe(RESTORE, () => {
+    describe(RESTORE, () => {
+        it('should create a commit referencing the restored commits index', async () => {
+            server.init();
 
-    // });
+            const device = new MemoryConnection(device1Info);
+            const restore = new Subject<RestoreEvent>();
+            const watchBranch = new Subject<string>();
+            device.events.set(RESTORE, restore);
+            device.events.set(WATCH_BRANCH, watchBranch);
+
+            connections.connection.next(device);
+
+            const a1 = atom(atomId('a', 1), null, {});
+            const a2 = atom(atomId('a', 2), a1, {});
+            const a3 = atom(atomId('a', 3), a2, {});
+            const a4 = atom(atomId('a', 4), a2, {});
+            const a5 = atom(atomId('a', 5), a2, {});
+
+            const idx1 = index(a1, a2, a3);
+            const idx2 = index(a1, a2, a4, a5);
+            const c1 = commit('message', new Date(2019, 9, 4), idx1, null);
+            const c2 = commit('message2', new Date(2019, 9, 4), idx2, c1);
+            const b = branch('testBranch', c2);
+
+            await storeData(store, [a1, a2, a3, a4, a5, idx1, idx2, c1, c2]);
+            await updateBranch(store, b);
+
+            watchBranch.next('testBranch');
+
+            await waitAsync();
+
+            restore.next({
+                branch: 'testBranch',
+                commit: c1.hash,
+            });
+
+            await waitAsync();
+
+            const [testBranch] = await store.getBranches('testBranch');
+            const [branchCommit] = await store.getObjects([testBranch.hash]);
+
+            expect(branchCommit).toEqual({
+                type: 'commit',
+                message: `Restore to ${c1.hash}`,
+                time: expect.any(Date),
+                hash: expect.any(String),
+                index: c1.index,
+                previousCommit: c2.hash,
+            });
+        });
+
+        it('should commit uncommitted changes', async () => {
+            server.init();
+
+            const device = new MemoryConnection(device1Info);
+            const restore = new Subject<RestoreEvent>();
+            const addAtoms = new Subject<AddAtomsEvent>();
+            const watchBranch = new Subject<string>();
+            device.events.set(RESTORE, restore);
+            device.events.set(ADD_ATOMS, addAtoms);
+            device.events.set(WATCH_BRANCH, watchBranch);
+
+            connections.connection.next(device);
+
+            const a1 = atom(atomId('a', 1), null, {});
+            const a2 = atom(atomId('a', 2), a1, {});
+            const a3 = atom(atomId('a', 3), a2, {});
+            const a4 = atom(atomId('a', 4), a2, {});
+            const a5 = atom(atomId('a', 5), a2, {});
+            const a6 = atom(atomId('a', 6), a2, {});
+
+            const idx1 = index(a1, a2, a3);
+            const idx2 = index(a1, a2, a4, a5);
+            const c1 = commit('message', new Date(2019, 9, 4), idx1, null);
+            const c2 = commit('message2', new Date(2019, 9, 4), idx2, c1);
+            const b = branch('testBranch', c2);
+
+            await storeData(store, [a1, a2, a3, a4, a5, idx1, idx2, c1, c2]);
+            await updateBranch(store, b);
+
+            watchBranch.next('testBranch');
+
+            await waitAsync();
+
+            addAtoms.next({
+                branch: 'testBranch',
+                atoms: [a6],
+            });
+
+            await waitAsync();
+
+            restore.next({
+                branch: 'testBranch',
+                commit: c1.hash,
+            });
+
+            await waitAsync();
+
+            const [testBranch] = await store.getBranches('testBranch');
+            const [branchCommit] = (await store.getObjects([
+                testBranch.hash,
+            ])) as CausalRepoCommit[];
+            const [changesCommit] = (await store.getObjects([
+                branchCommit.previousCommit,
+            ])) as CausalRepoCommit[];
+            const data = await loadCommit(store, changesCommit);
+
+            expect(branchCommit).toEqual({
+                type: 'commit',
+                message: `Restore to ${c1.hash}`,
+                time: expect.any(Date),
+                hash: expect.any(String),
+                index: c1.index,
+                previousCommit: changesCommit.hash,
+            });
+
+            expect(changesCommit).toEqual({
+                type: 'commit',
+                message: `Save before restore`,
+                time: expect.any(Date),
+                hash: expect.any(String),
+                index: expect.any(String),
+                previousCommit: c2.hash,
+            });
+            expect(data.atoms).toEqual(
+                new Map([
+                    [a1.hash, a1],
+                    [a2.hash, a2],
+                    [a4.hash, a4],
+                    [a5.hash, a5],
+                    [a6.hash, a6],
+                ])
+            );
+        });
+
+        it(`should send a ADD_ATOMS event with difference between the two commits`, async () => {
+            server.init();
+
+            const device = new MemoryConnection(device1Info);
+            const restore = new Subject<RestoreEvent>();
+            const watchBranch = new Subject<string>();
+            device.events.set(RESTORE, restore);
+            device.events.set(WATCH_BRANCH, watchBranch);
+
+            connections.connection.next(device);
+
+            const a1 = atom(atomId('a', 1), null, {});
+            const a2 = atom(atomId('a', 2), a1, {});
+            const a3 = atom(atomId('a', 3), a2, {});
+            const a4 = atom(atomId('a', 4), a2, {});
+            const a5 = atom(atomId('a', 5), a2, {});
+
+            const idx1 = index(a1, a2, a3);
+            const idx2 = index(a1, a2, a4, a5);
+            const c1 = commit('message', new Date(2019, 9, 4), idx1, null);
+            const c2 = commit('message2', new Date(2019, 9, 4), idx2, c1);
+            const b = branch('testBranch', c2);
+
+            await storeData(store, [a1, a2, a3, a4, a5, idx1, idx2, c1, c2]);
+            await updateBranch(store, b);
+
+            watchBranch.next('testBranch');
+
+            await waitAsync();
+
+            restore.next({
+                branch: 'testBranch',
+                commit: c1.hash,
+            });
+
+            await waitAsync();
+
+            expect(device.messages).toEqual([
+                {
+                    name: ADD_ATOMS,
+                    data: {
+                        branch: 'testBranch',
+                        atoms: [a1, a2, a4, a5],
+                    },
+                },
+                {
+                    name: ADD_ATOMS,
+                    data: {
+                        branch: 'testBranch',
+                        atoms: [a3],
+                        removedAtoms: [a4.hash, a5.hash],
+                    },
+                },
+            ]);
+        });
+    });
 
     describe(SEND_EVENT, () => {
         it('should notify the device that the event was sent to', async () => {

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -211,6 +211,11 @@ export class CausalRepoServer {
                 conn.event(CHECKOUT).subscribe(async event => {
                     const repo = await this._getOrLoadRepo(event.branch, true);
 
+                    console.log(
+                        `[CausalRepoServer] Checking out ${event.commit} on ${
+                            event.branch
+                        }`
+                    );
                     const current = repo.currentCommit;
                     await repo.reset(event.commit);
                     await this._stage.clearStage(event.branch);

--- a/src/causal-trees/core2/CausalRepo.spec.ts
+++ b/src/causal-trees/core2/CausalRepo.spec.ts
@@ -19,6 +19,7 @@ import {
     updateBranch,
     listBranches,
     atomMap,
+    listCommits,
 } from './CausalRepo';
 import {
     createIndex,
@@ -266,6 +267,27 @@ describe('CausalRepo', () => {
             applyDiff(weave, diff);
 
             expect(weave.getAtoms()).toEqual([a1, a4]);
+        });
+    });
+
+    describe('listCommits()', () => {
+        it('should return a list of commit data from the given commit hash', async () => {
+            const a1 = atom(atomId('a', 1), null, {});
+            const a2 = atom(atomId('a', 2), a1, {});
+            const a3 = atom(atomId('a', 3), a2, {});
+            const a4 = atom(atomId('a', 4), a1, {});
+
+            const idx1 = index(a1, a2);
+            const idx2 = index(a1, a2, a3, a4);
+
+            const c1 = commit('message1', new Date(2001, 1, 1), idx1, null);
+            const c2 = commit('message2', new Date(2001, 1, 2), idx2, c1);
+
+            await storeData(store, [a1, a2, a3, a4, idx1, idx2, c1, c2]);
+
+            const commits = await listCommits(store, c2.hash);
+
+            expect(commits).toEqual([c2, c1]);
         });
     });
 

--- a/src/causal-trees/core2/CausalRepoClient.spec.ts
+++ b/src/causal-trees/core2/CausalRepoClient.spec.ts
@@ -32,12 +32,17 @@ import {
     BranchInfoEvent,
     BRANCHES,
     BranchesEvent,
+    COMMIT,
+    WATCH_COMMITS,
+    AddCommitsEvent,
+    ADD_COMMITS,
 } from './CausalRepoEvents';
 import { Atom, atom, atomId } from './Atom2';
 import { deviceInfo } from '..';
 import { filter, map } from 'rxjs/operators';
 import { DeviceAction, device, remote } from '../core/Event';
 import { DeviceInfo } from '../core/DeviceInfo';
+import { CausalRepoCommit, index, commit } from '.';
 
 describe('CausalRepoClient', () => {
     let client: CausalRepoClient;
@@ -394,6 +399,84 @@ describe('CausalRepoClient', () => {
                     },
                 },
             ]);
+        });
+    });
+
+    describe('commit()', () => {
+        it('should send a commit event', async () => {
+            client.commit('abc', 'newCommit');
+
+            expect(connection.sentMessages).toEqual([
+                {
+                    name: COMMIT,
+                    data: {
+                        branch: 'abc',
+                        message: 'newCommit',
+                    },
+                },
+            ]);
+        });
+    });
+
+    describe('watchCommits()', () => {
+        it('should send a watch commits event after connecting', async () => {
+            client.watchCommits('abc').subscribe();
+
+            expect(connection.sentMessages).toEqual([]);
+
+            connection.connect();
+            await waitAsync();
+
+            expect(connection.sentMessages).toEqual([
+                {
+                    name: WATCH_COMMITS,
+                    data: 'abc',
+                },
+            ]);
+        });
+
+        it('should return an observable of commits for the branch', async () => {
+            const addCommits = new Subject<AddCommitsEvent>();
+            connection.events.set(ADD_COMMITS, addCommits);
+
+            let commits = [] as CausalRepoCommit[];
+            connection.connect();
+            client
+                .watchCommits('abc')
+                .pipe(map(e => e.commits))
+                .subscribe(c => commits.unshift(...c));
+
+            await waitAsync();
+
+            const a1 = atom(atomId('a', 1), null, {});
+            const a2 = atom(atomId('a', 2), a1, {});
+            const a3 = atom(atomId('a', 3), a2, {});
+            const b1 = atom(atomId('b', 1), null, {});
+            const b2 = atom(atomId('b', 2), a1, {});
+            const b3 = atom(atomId('b', 3), b2, {});
+
+            const idx1 = index(a1, a2);
+            const idx2 = index(a1, a2, a3);
+            const idx3 = index(b1, b2);
+            const idx4 = index(b1, b2, b3);
+            const c1 = commit('commit1', new Date(1900, 1, 1), idx1, null);
+            const c2 = commit('commit2', new Date(1900, 1, 1), idx2, c1);
+            const c3 = commit('commit3', new Date(1900, 1, 1), idx3, c2);
+            const c4 = commit('commit4', new Date(1900, 1, 1), idx4, c3);
+
+            addCommits.next({
+                branch: 'abc',
+                commits: [c2, c1],
+            });
+
+            addCommits.next({
+                branch: 'other',
+                commits: [c3, c4],
+            });
+
+            await waitAsync();
+
+            expect(commits).toEqual([c2, c1]);
         });
     });
 

--- a/src/causal-trees/core2/CausalRepoClient.spec.ts
+++ b/src/causal-trees/core2/CausalRepoClient.spec.ts
@@ -36,6 +36,7 @@ import {
     WATCH_COMMITS,
     AddCommitsEvent,
     ADD_COMMITS,
+    CHECKOUT,
 } from './CausalRepoEvents';
 import { Atom, atom, atomId } from './Atom2';
 import { deviceInfo } from '..';
@@ -412,6 +413,22 @@ describe('CausalRepoClient', () => {
                     data: {
                         branch: 'abc',
                         message: 'newCommit',
+                    },
+                },
+            ]);
+        });
+    });
+
+    describe('checkout()', () => {
+        it('should send a checkout event', async () => {
+            client.checkout('abc', 'commit');
+
+            expect(connection.sentMessages).toEqual([
+                {
+                    name: CHECKOUT,
+                    data: {
+                        branch: 'abc',
+                        commit: 'commit',
                     },
                 },
             ]);

--- a/src/causal-trees/core2/CausalRepoClient.spec.ts
+++ b/src/causal-trees/core2/CausalRepoClient.spec.ts
@@ -37,6 +37,7 @@ import {
     AddCommitsEvent,
     ADD_COMMITS,
     CHECKOUT,
+    RESTORE,
 } from './CausalRepoEvents';
 import { Atom, atom, atomId } from './Atom2';
 import { deviceInfo } from '..';
@@ -426,6 +427,22 @@ describe('CausalRepoClient', () => {
             expect(connection.sentMessages).toEqual([
                 {
                     name: CHECKOUT,
+                    data: {
+                        branch: 'abc',
+                        commit: 'commit',
+                    },
+                },
+            ]);
+        });
+    });
+
+    describe('restore()', () => {
+        it('should send a restore event', async () => {
+            client.restore('abc', 'commit');
+
+            expect(connection.sentMessages).toEqual([
+                {
+                    name: RESTORE,
                     data: {
                         branch: 'abc',
                         commit: 'commit',

--- a/src/causal-trees/core2/CausalRepoClient.ts
+++ b/src/causal-trees/core2/CausalRepoClient.ts
@@ -41,6 +41,8 @@ import {
     WATCH_COMMITS,
     UNWATCH_COMMITS,
     ADD_COMMITS,
+    CheckoutEvent,
+    CHECKOUT,
 } from './CausalRepoEvents';
 import { Atom } from './Atom2';
 import { DeviceAction, RemoteAction } from '../core/Event';
@@ -299,6 +301,19 @@ export class CausalRepoClient {
             message: message,
         };
         this._client.send(COMMIT, event);
+    }
+
+    /**
+     * Checks out the given hash for the given branch.
+     * @param branch The branch to move.
+     * @param hash The hash that the branch should checkout.
+     */
+    checkout(branch: string, hash: string) {
+        const event: CheckoutEvent = {
+            branch: branch,
+            commit: hash,
+        };
+        this._client.send(CHECKOUT, event);
     }
 
     watchCommits(branch: string): Observable<AddCommitsEvent> {

--- a/src/causal-trees/core2/CausalRepoClient.ts
+++ b/src/causal-trees/core2/CausalRepoClient.ts
@@ -43,6 +43,8 @@ import {
     ADD_COMMITS,
     CheckoutEvent,
     CHECKOUT,
+    RestoreEvent,
+    RESTORE,
 } from './CausalRepoEvents';
 import { Atom } from './Atom2';
 import { DeviceAction, RemoteAction } from '../core/Event';
@@ -314,6 +316,14 @@ export class CausalRepoClient {
             commit: hash,
         };
         this._client.send(CHECKOUT, event);
+    }
+
+    restore(branch: string, hash: string) {
+        const event: RestoreEvent = {
+            branch: branch,
+            commit: hash,
+        };
+        this._client.send(RESTORE, event);
     }
 
     watchCommits(branch: string): Observable<AddCommitsEvent> {

--- a/src/causal-trees/core2/CausalRepoEvents.ts
+++ b/src/causal-trees/core2/CausalRepoEvents.ts
@@ -45,6 +45,11 @@ export const WATCH_COMMITS = 'repo/watch_commits';
 export const UNWATCH_COMMITS = 'repo/unwatch_commits';
 
 /**
+ * The name of the event which checks out a commit with a branch.
+ */
+export const CHECKOUT = 'repo/checkout';
+
+/**
  * The name of the event which notifies that a commit was added.
  */
 export const ADD_COMMITS = 'repo/add_commits';
@@ -153,6 +158,26 @@ export interface AddCommitsEvent {
      * The commits that were added.
      */
     commits: CausalRepoCommit[];
+}
+
+/**
+ * Defines an event which indicates that a commit should be checked out by a branch.
+ */
+export interface CheckoutEvent {
+    /**
+     * The branch to checkout.
+     */
+    branch: string;
+
+    /**
+     * The hash of the commit to checkout.
+     */
+    commit: string;
+
+    /**
+     * The name of the branch that should be left at the commit the branch was previously at.
+     */
+    remnantBranch?: string;
 }
 
 /**

--- a/src/causal-trees/core2/CausalRepoEvents.ts
+++ b/src/causal-trees/core2/CausalRepoEvents.ts
@@ -50,6 +50,11 @@ export const UNWATCH_COMMITS = 'repo/unwatch_commits';
 export const CHECKOUT = 'repo/checkout';
 
 /**
+ * The name of the event which restores a commit's data to a branch.
+ */
+export const RESTORE = 'repo/restore';
+
+/**
  * The name of the event which notifies that a commit was added.
  */
 export const ADD_COMMITS = 'repo/add_commits';
@@ -173,11 +178,21 @@ export interface CheckoutEvent {
      * The hash of the commit to checkout.
      */
     commit: string;
+}
+
+/**
+ * Defines an event which indicates that a commit should be restored to a branch.
+ */
+export interface RestoreEvent {
+    /**
+     * The branch to restore.
+     */
+    branch: string;
 
     /**
-     * The name of the branch that should be left at the commit the branch was previously at.
+     * The hash of the commit to restore.
      */
-    remnantBranch?: string;
+    commit: string;
 }
 
 /**

--- a/src/causal-trees/core2/CausalRepoEvents.ts
+++ b/src/causal-trees/core2/CausalRepoEvents.ts
@@ -1,6 +1,7 @@
 import { Atom } from './Atom2';
 import { DeviceInfo } from '../core/DeviceInfo';
 import { RemoteAction, DeviceAction } from '../core/Event';
+import { CausalRepoCommit } from './CausalRepoObject';
 
 /**
  * The name of the event which starts watching for when branches are loaded/unloaded.
@@ -27,6 +28,26 @@ export const UNWATCH_BRANCH = 'repo/unwatch_branch';
  * The name of the event which notifies that some atoms were added to a branch.
  */
 export const ADD_ATOMS = 'repo/add_atoms';
+
+/**
+ * The name of the event which commits the current uncommitted state.
+ */
+export const COMMIT = 'repo/commit';
+
+/**
+ * The name of the event which starts watching commits made to a branch.
+ */
+export const WATCH_COMMITS = 'repo/watch_commits';
+
+/**
+ * The name of the event which stops watching commits made to a branch.
+ */
+export const UNWATCH_COMMITS = 'repo/unwatch_commits';
+
+/**
+ * The name of the event which notifies that a commit was added.
+ */
+export const ADD_COMMITS = 'repo/add_commits';
 
 /**
  * The name of the event which tries to send an event to a device.
@@ -102,6 +123,36 @@ export interface AddAtomsEvent {
      * The list of atom hashes that were removed.
      */
     removedAtoms?: string[];
+}
+
+/**
+ * Defines an event which indicates that changes to a branch should be committed.
+ */
+export interface CommitEvent {
+    /**
+     * The branch to commit.
+     */
+    branch: string;
+
+    /**
+     * The commit message.
+     */
+    message: string;
+}
+
+/**
+ * Defines an event which indicates that a set of commits was added to a branch.
+ */
+export interface AddCommitsEvent {
+    /**
+     * The branch.
+     */
+    branch: string;
+
+    /**
+     * The commits that were added.
+     */
+    commits: CausalRepoCommit[];
 }
 
 /**

--- a/src/causal-trees/core2/CausalRepoSession.ts
+++ b/src/causal-trees/core2/CausalRepoSession.ts
@@ -5,6 +5,7 @@ import {
     DisconnectedFromBranchEvent,
     BranchInfoEvent,
     SendRemoteActionEvent,
+    CommitEvent,
 } from './CausalRepoEvents';
 import { DeviceInfo } from '../core/DeviceInfo';
 
@@ -85,6 +86,18 @@ export interface CausalRepoSession extends GenericSession {
      * Gets an observable for events that request a list of available branches.
      */
     event(name: 'repo/branches'): Observable<void>;
+    /**
+     * Gets an observable for events which make a commit for a branch.
+     */
+    event(name: 'repo/commit'): Observable<CommitEvent>;
+    /**
+     * Gets an observable for events that start watching commits on a branch.
+     */
+    event(name: 'repo/watch_commits'): Observable<string>;
+    /**
+     * Gets an observable for events that stop watching commits on a branch.
+     */
+    event(name: 'repo/unwatch_commits'): Observable<string>;
 
     /**
      * Sends the given event to the session.

--- a/src/causal-trees/core2/CausalRepoSession.ts
+++ b/src/causal-trees/core2/CausalRepoSession.ts
@@ -7,6 +7,7 @@ import {
     SendRemoteActionEvent,
     CommitEvent,
     CheckoutEvent,
+    RestoreEvent,
 } from './CausalRepoEvents';
 import { DeviceInfo } from '../core/DeviceInfo';
 
@@ -103,6 +104,10 @@ export interface CausalRepoSession extends GenericSession {
      * Gets an observable for events that request a branch checkout a commit.
      */
     event(name: 'repo/checkout'): Observable<CheckoutEvent>;
+    /**
+     * Gets an observable for events that request a branch be restored to a commit.
+     */
+    event(name: 'repo/restore'): Observable<RestoreEvent>;
 
     /**
      * Sends the given event to the session.

--- a/src/causal-trees/core2/CausalRepoSession.ts
+++ b/src/causal-trees/core2/CausalRepoSession.ts
@@ -6,6 +6,7 @@ import {
     BranchInfoEvent,
     SendRemoteActionEvent,
     CommitEvent,
+    CheckoutEvent,
 } from './CausalRepoEvents';
 import { DeviceInfo } from '../core/DeviceInfo';
 
@@ -98,6 +99,10 @@ export interface CausalRepoSession extends GenericSession {
      * Gets an observable for events that stop watching commits on a branch.
      */
     event(name: 'repo/unwatch_commits'): Observable<string>;
+    /**
+     * Gets an observable for events that request a branch checkout a commit.
+     */
+    event(name: 'repo/checkout'): Observable<CheckoutEvent>;
 
     /**
      * Sends the given event to the session.


### PR DESCRIPTION
### Changes:

-   **Breaking Changes**
    -   Changed player bots to use the `tempLocal` space.
        -   This means that refreshing the page won't pollute the universe with a ton of extra bots.
    -   `player.loadUniverse()` will now create bots in the `tempLocal` space.
        -   Previously they were created in the `shared` space.
-   Improvements
    -   Added the ability to create, load, and restore version marks.
        -   The `player.markHistory(options)` function creates a history mark for the current version.
            -   `options` is an object with the following properties:
                -   `message` - The message that the new mark should have.
        -   The `player.browseHistory()` function loads the `history` space with all the marks that the universe has.
        -   The `player.restoreHistoryMark(mark)` function restores the state in the given mark to the universe.
            -   `mark` - The bot or bot ID of the mark that should be restored.
        -   The `player.restoreHistoryMarkToUniverse(mark, universe)` function restores the state in the given mark to the given universe.
            -   `mark` - The bot or bot ID of the mark that should be restored.
            -   `universe` - The universe that the mark should be restored to.