### PR TITLE
Add the ability to jump in and out of fullscreen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # AUX Changelog
 
+## V1.0.4
+
+### Date: TBD
+
+### Changes:
+
+#### :rocket: Features
+
+-   Added the `player.requestFullscreenMode()` and `player.exitFullscreenMode()` functions.
+    -   These functions allow jumping in and out of fullscreen, thereby hiding the browser UI controls.
+-   Added the `apple-mobile-web-app-*` meta tags to support jumping into fullscreen mode when launching from a bookmark on the iOS home screen.
+
 ## V1.0.3
 
 ### Date: 2/11/2020

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -1867,6 +1867,32 @@ const info = player.device();
 player.toast(info);
 ```
 
+### `player.requestFullscreenMode()`
+
+<FunctionCode name='requestFullscreenMode'/>
+
+Attempts to enter fullscreen mode. Depending on which web browser the player is using, this might ask for permission to go fullscreen.
+
+#### Examples:
+
+1. Enter fullscreen mode.
+```typescript
+player.requestFullscreenMode();
+```
+
+### `player.exitFullscreenMode()`
+
+<FunctionCode name='exitFullscreenMode'/>
+
+Exists fullscreen mode.
+
+#### Examples:
+
+1. Exit fullscreen mode.
+```typescript
+player.exitFullscreenMode();
+```
+
 ## Server Actions
 
 ### `server.backupToGithub(auth)`

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -63,6 +63,8 @@ import {
     enableVR as calcEnableVR,
     disableVR as calcDisableVR,
     showJoinCode as calcShowJoinCode,
+    requestFullscreen,
+    exitFullscreen,
 } from '../bots/BotEvents';
 import { calculateActionResultsUsingContext } from '../bots/BotsChannel';
 import uuid from 'uuid/v4';
@@ -1895,6 +1897,23 @@ function showJoinCode(universe?: string, dimension?: string) {
 }
 
 /**
+ * Requests that AUX enters fullscreen mode.
+ * Depending on the web browser, this may ask the player for permission.
+ */
+function requestFullscreenMode() {
+    const event = requestFullscreen();
+    return addAction(event);
+}
+
+/**
+ * Exits fullscreen mode.
+ */
+function exitFullscreenMode() {
+    const event = exitFullscreen();
+    return addAction(event);
+}
+
+/**
  * Shows some HTML to the user.
  * @param html The HTML to show.
  */
@@ -2366,6 +2385,8 @@ const player = {
     disableAR,
     disableVR,
     showJoinCode,
+    requestFullscreenMode,
+    exitFullscreenMode,
 
     openDevConsole,
 };

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -78,7 +78,9 @@ export type ExtraActions =
     | LoadSpaceAction
     | EnableARAction
     | EnableVRAction
-    | ShowJoinCodeAction;
+    | ShowJoinCodeAction
+    | RequestFullscreenAction
+    | ExitFullscreenAction;
 
 /**
  * Defines a bot event that indicates a bot was added to the state.
@@ -1067,6 +1069,21 @@ export interface ShowJoinCodeAction {
     dimension?: string;
 }
 
+/**
+ * Defines an event that requests that AUX enter fullscreen mode.
+ * This can be denied by the user.
+ */
+export interface RequestFullscreenAction {
+    type: 'request_fullscreen_mode';
+}
+
+/**
+ * Defines an event that exits fullscreen mode.
+ */
+export interface ExitFullscreenAction {
+    type: 'exit_fullscreen_mode';
+}
+
 /**z
  * Creates a new AddBotAction.
  * @param bot The bot that was added.
@@ -1801,5 +1818,23 @@ export function showJoinCode(
         type: 'show_join_code',
         universe,
         dimension,
+    };
+}
+
+/**
+ * Requests that the app go into fullscreen mode.
+ */
+export function requestFullscreen(): RequestFullscreenAction {
+    return {
+        type: 'request_fullscreen_mode',
+    };
+}
+
+/**
+ * Exists fullscreen mode.
+ */
+export function exitFullscreen(): ExitFullscreenAction {
+    return {
+        type: 'exit_fullscreen_mode',
     };
 }

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -47,6 +47,8 @@ import {
     disableVR,
     disableAR,
     showJoinCode,
+    requestFullscreen,
+    exitFullscreen,
 } from '../BotEvents';
 import { createBot, getActiveObjects, isBot } from '../BotCalculations';
 import { getBotsForAction } from '../BotsChannel';
@@ -3941,6 +3943,58 @@ export function botActionsTests(
                 expect(result.events).toEqual([
                     showJoinCode('universe', 'dimension'),
                 ]);
+            });
+        });
+
+        describe('player.requestFullscreenMode()', () => {
+            it('should issue a request_fullscreen action', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: '@player.requestFullscreenMode()',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([requestFullscreen()]);
+            });
+        });
+
+        describe('player.exitFullscreenMode()', () => {
+            it('should issue a request_fullscreen action', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: '@player.exitFullscreenMode()',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([exitFullscreen()]);
             });
         });
 

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -664,6 +664,20 @@ export default class PlayerApp extends Vue {
                         universe
                     )}&auxPagePortal=${encodeURIComponent(dimension)}`;
                     this._showQRCode(code);
+                } else if (e.type === 'request_fullscreen_mode') {
+                    if (document.fullscreenElement) {
+                        return;
+                    }
+                    if (document.documentElement.requestFullscreen) {
+                        document.documentElement.requestFullscreen();
+                    }
+                } else if (e.type === 'exit_fullscreen_mode') {
+                    if (!document.fullscreenElement) {
+                        return;
+                    }
+                    if (document.exitFullscreen) {
+                        document.exitFullscreen();
+                    }
                 }
             }),
             simulation.connection.connectionStateChanged.subscribe(

--- a/src/aux-server/aux-web/aux-player/index.html
+++ b/src/aux-server/aux-web/aux-player/index.html
@@ -6,6 +6,11 @@
             name="viewport"
             content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
         />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+            name="apple-mobile-web-app-status-bar-style"
+            content="black-translucent"
+        />
         <title>
             <%= htmlWebpackPlugin.options.title %>
         </title>


### PR DESCRIPTION
#### :rocket: Features

-   Added the `player.requestFullscreenMode()` and `player.exitFullscreenMode()` functions.
    -   These functions allow jumping in and out of fullscreen, thereby hiding the browser UI controls.
-   Added the `apple-mobile-web-app-*` meta tags to support jumping into fullscreen mode when launching from a bookmark on the iOS home screen.