### PR TITLE
Add the ability to load meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
 -   Added the `player.requestFullscreenMode()` and `player.exitFullscreenMode()` functions.
     -   These functions allow jumping in and out of fullscreen, thereby hiding the browser UI controls.
 -   Added the `apple-mobile-web-app-*` meta tags to support jumping into fullscreen mode when launching from a bookmark on the iOS home screen.
+-   Added the ability to load GLTF and [poly.google.com](https://poly.google.com) meshes.
+    -   To load a GLTF model from a URL:
+        -   Set `#auxForm` to `mesh`.
+        -   Set `#auxFormSubtype` to `gltf`.
+        -   Set `#auxFormAddress` to the URL.
+    -   To load a model from [poly.google.com](https://poly.google.com):
+        -   Set `#auxForm` to `mesh`.
+        -   Set `#auxFormSubtype` to `poly`.
+        -   Set `#auxFormAddress` to the ID of the model.
 
 ## V1.0.3
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -372,6 +372,27 @@ The shape that the bot should be displayed as.
   <PossibleValueCode value='sprite'>
     Camera facing (billboarded) sprite/quad images.
   </PossibleValueCode>
+  <PossibleValueCode value='mesh'>
+    A mesh loaded from the web. See <TagLink tag="#auxFormSubtype"/> for additional options.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
+### `auxFormSubtype`
+
+The subtype that the form should use. Useful for specifying how a mesh should be loaded.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='null'>
+    No subtype (default)
+  </PossibleValueCode>
+  <PossibleValueCode value='gltf'>
+    A [GLTF mesh](https://en.wikipedia.org/wiki/GlTF) loaded from a URL.
+  </PossibleValueCode>
+  <PossibleValueCode value='poly'>
+    A mesh loaded from [poly.google.com](https://poly.google.com).
+  </PossibleValueCode>
 </PossibleValuesTable>
 
 ### `auxFormAddress`
@@ -379,6 +400,8 @@ The shape that the bot should be displayed as.
 The address that the bot should represent data from.
 
 When <TagLink tag='auxForm'/> is set to `cube`, `sphere`, or `sprite`, the address should be the URL of the image that the bot should display.
+When <TagLink tag='auxForm'/> is set to `mesh` and <TagLink tag='auxFormSubtype'/> is set to `gltf`, the address should be the URL of the GLTF file that should be displayed.
+When <TagLink tag='auxForm'/> is set to `mesh` and <TagLink tag='auxFormSubtype'/> is set to `poly`, the address should be the ID of the mesh that should be displayed.
 
 ### `auxProgressBar`
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -252,7 +252,12 @@ export interface WorkspaceHex {
 /**
  * Defines the possible shapes that a bot can appear as.
  */
-export type BotShape = 'cube' | 'sphere' | 'sprite';
+export type BotShape = 'cube' | 'sphere' | 'sprite' | 'mesh';
+
+/**
+ * Defines the possible subtypes for shapes that a bot can appear as.
+ */
+export type BotSubShape = 'gltf' | 'poly' | null;
 
 /**
  * Defines the possible drag modes that a bot can have.
@@ -705,6 +710,7 @@ export const KNOWN_TAGS: string[] = [
     'auxScaleY',
     'auxScaleZ',
     'auxFormAddress',
+    'auxFormSubtype',
     'auxForm',
     'auxProgressBar',
     'auxProgressBarColor',
@@ -722,6 +728,8 @@ export const KNOWN_TAGS: string[] = [
     'auxIframeRotationZ',
     'auxIframeElementWidth',
     'auxIframeScale',
+
+    'polyApiKey',
 
     'auxTaskOutput',
     'auxTaskError',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -26,6 +26,7 @@ import {
     BotSpace,
     BOT_SPACE_TAG,
     PortalType,
+    BotSubShape,
 } from './Bot';
 
 import {
@@ -1183,10 +1184,31 @@ export function getBotScale(
  */
 export function getBotShape(calc: BotCalculationContext, bot: Bot): BotShape {
     const shape: BotShape = calculateBotValue(calc, bot, 'auxForm');
-    if (shape === 'cube' || shape === 'sphere' || shape === 'sprite') {
+    if (
+        shape === 'cube' ||
+        shape === 'sphere' ||
+        shape === 'sprite' ||
+        shape === 'mesh'
+    ) {
         return shape;
     }
     return DEFAULT_BOT_SHAPE;
+}
+
+/**
+ * Gets the sub-shape of the bot.
+ * @param calc The calculation context to use.
+ * @param bot The bot.
+ */
+export function getBotSubShape(
+    calc: BotCalculationContext,
+    bot: Bot
+): BotSubShape {
+    const shape: BotSubShape = calculateBotValue(calc, bot, 'auxFormSubtype');
+    if (shape === 'gltf' || shape === 'poly') {
+        return shape;
+    }
+    return null;
 }
 
 /**

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -54,6 +54,7 @@ import {
     getBotPositioningMode,
     convertToCopiableValue,
     getPortalConfigBotID,
+    getBotSubShape,
 } from '../BotCalculations';
 import {
     Bot,
@@ -3282,7 +3283,7 @@ export function botCalculationContextTests(
     });
 
     describe('getBotShape()', () => {
-        const cases = [['cube'], ['sphere'], ['sprite']];
+        const cases = [['cube'], ['sphere'], ['sprite'], ['mesh']];
         it.each(cases)('should return %s', (shape: string) => {
             const bot = createBot('test', {
                 auxForm: <any>shape,
@@ -3310,6 +3311,28 @@ export function botCalculationContextTests(
             const shape = getBotShape(calc, bot);
 
             expect(shape).toBe('sphere');
+        });
+    });
+
+    describe('getBotSubShape()', () => {
+        const cases = [['gltf'], ['poly']];
+        it.each(cases)('should return %s', (shape: string) => {
+            const bot = createBot('test', {
+                auxFormSubtype: <any>shape,
+            });
+
+            const calc = createCalculationContext([bot]);
+
+            expect(getBotSubShape(calc, bot)).toBe(shape);
+        });
+
+        it('should default to null', () => {
+            const bot = createBot();
+
+            const calc = createCalculationContext([bot]);
+            const shape = getBotSubShape(calc, bot);
+
+            expect(shape).toBe(null);
         });
     });
 

--- a/src/aux-server/aux-web/shared/public/three-legacy-gltf-loader/LICENSE
+++ b/src/aux-server/aux-web/shared/public/three-legacy-gltf-loader/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright © 2010-2020 three.js authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/aux-server/aux-web/shared/public/three-legacy-gltf-loader/LegacyGLTFLoader.js
+++ b/src/aux-server/aux-web/shared/public/three-legacy-gltf-loader/LegacyGLTFLoader.js
@@ -1,0 +1,2217 @@
+/**
+ * @author Rich Tibbett / https://github.com/richtr
+ * @author mrdoob / http://mrdoob.com/
+ * @author Tony Parisi / http://www.tonyparisi.com/
+ * @author Takahiro / https://github.com/takahirox
+ */
+
+let LegacyGLTFLoaderExport = ( function () {
+
+	function LegacyGLTFLoader( manager ) {
+
+		this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
+
+	}
+
+	LegacyGLTFLoader.prototype = {
+
+		constructor: LegacyGLTFLoader,
+
+		crossOrigin: 'Anonymous',
+
+		load: function ( url, onLoad, onProgress, onError ) {
+
+			var scope = this;
+
+			var path = this.path && ( typeof this.path === "string" ) ? this.path : THREE.Loader.prototype.extractUrlBase( url );
+
+			var loader = new THREE.FileLoader( scope.manager );
+
+			loader.setResponseType( 'arraybuffer' );
+
+			loader.load( url, function ( data ) {
+
+				scope.parse( data, onLoad, path );
+
+			}, onProgress, onError );
+
+		},
+
+		setCrossOrigin: function ( value ) {
+
+			this.crossOrigin = value;
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+
+		},
+
+		parse: function ( data, callback, path ) {
+
+			var content;
+			var extensions = {};
+
+			var magic = convertUint8ArrayToString( new Uint8Array( data, 0, 4 ) );
+
+			if ( magic === BINARY_EXTENSION_HEADER_DEFAULTS.magic ) {
+
+				extensions[ EXTENSIONS.KHR_BINARY_GLTF ] = new GLTFBinaryExtension( data );
+				content = extensions[ EXTENSIONS.KHR_BINARY_GLTF ].content;
+
+			} else {
+
+				content = convertUint8ArrayToString( new Uint8Array( data ) );
+
+			}
+
+			var json = JSON.parse( content );
+
+			if ( json.extensionsUsed && json.extensionsUsed.indexOf( EXTENSIONS.KHR_MATERIALS_COMMON ) >= 0 ) {
+
+				extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ] = new GLTFMaterialsCommonExtension( json );
+
+			}
+
+			console.time( 'LegacyGLTFLoader' );
+
+			var parser = new GLTFParser( json, extensions, {
+
+				path: path || this.path,
+				crossOrigin: this.crossOrigin
+
+			} );
+
+			parser.parse( function ( scene, scenes, cameras, animations ) {
+
+				console.timeEnd( 'LegacyGLTFLoader' );
+
+				var glTF = {
+					"scene": scene,
+					"scenes": scenes,
+					"cameras": cameras,
+					"animations": animations
+				};
+
+				callback( glTF );
+
+			} );
+
+		}
+
+	};
+
+	/* GLTFREGISTRY */
+
+	function GLTFRegistry() {
+
+		var objects = {};
+
+		return	{
+
+			get: function ( key ) {
+
+				return objects[ key ];
+
+			},
+
+			add: function ( key, object ) {
+
+				objects[ key ] = object;
+
+			},
+
+			remove: function ( key ) {
+
+				delete objects[ key ];
+
+			},
+
+			removeAll: function () {
+
+				objects = {};
+
+			},
+
+			update: function ( scene, camera ) {
+
+				for ( var name in objects ) {
+
+					var object = objects[ name ];
+
+					if ( object.update ) {
+
+						object.update( scene, camera );
+
+					}
+
+				}
+
+			}
+
+		};
+
+	}
+
+	/* GLTFSHADERS */
+
+	LegacyGLTFLoader.Shaders = {
+
+		update: function () {
+
+			console.warn( 'THREE.LegacyGLTFLoader.Shaders has been deprecated, and now updates automatically.' );
+
+		}
+
+	};
+
+	/* GLTFSHADER */
+
+	function GLTFShader( targetNode, allNodes ) {
+
+		var boundUniforms = {};
+
+		// bind each uniform to its source node
+
+		var uniforms = targetNode.material.uniforms;
+
+		for ( var uniformId in uniforms ) {
+
+			var uniform = uniforms[ uniformId ];
+
+			if ( uniform.semantic ) {
+
+				var sourceNodeRef = uniform.node;
+
+				var sourceNode = targetNode;
+
+				if ( sourceNodeRef ) {
+
+					sourceNode = allNodes[ sourceNodeRef ];
+
+				}
+
+				boundUniforms[ uniformId ] = {
+					semantic: uniform.semantic,
+					sourceNode: sourceNode,
+					targetNode: targetNode,
+					uniform: uniform
+				};
+
+			}
+
+		}
+
+		this.boundUniforms = boundUniforms;
+		this._m4 = new THREE.Matrix4();
+
+	}
+
+	// Update - update all the uniform values
+	GLTFShader.prototype.update = function ( scene, camera ) {
+
+		var boundUniforms = this.boundUniforms;
+
+		for ( var name in boundUniforms ) {
+
+			var boundUniform = boundUniforms[ name ];
+
+			switch ( boundUniform.semantic ) {
+
+				case "MODELVIEW":
+
+					var m4 = boundUniform.uniform.value;
+					m4.multiplyMatrices( camera.matrixWorldInverse, boundUniform.sourceNode.matrixWorld );
+					break;
+
+				case "MODELVIEWINVERSETRANSPOSE":
+
+					var m3 = boundUniform.uniform.value;
+					this._m4.multiplyMatrices( camera.matrixWorldInverse, boundUniform.sourceNode.matrixWorld );
+					m3.getNormalMatrix( this._m4 );
+					break;
+
+				case "PROJECTION":
+
+					var m4 = boundUniform.uniform.value;
+					m4.copy( camera.projectionMatrix );
+					break;
+
+				case "JOINTMATRIX":
+
+					var m4v = boundUniform.uniform.value;
+
+					for ( var mi = 0; mi < m4v.length; mi ++ ) {
+
+						// So it goes like this:
+						// SkinnedMesh world matrix is already baked into MODELVIEW;
+						// transform joints to local space,
+						// then transform using joint's inverse
+						m4v[ mi ]
+							.getInverse( boundUniform.sourceNode.matrixWorld )
+							.multiply( boundUniform.targetNode.skeleton.bones[ mi ].matrixWorld )
+							.multiply( boundUniform.targetNode.skeleton.boneInverses[ mi ] )
+							.multiply( boundUniform.targetNode.bindMatrix );
+
+					}
+
+					break;
+
+				default :
+
+					console.warn( "Unhandled shader semantic: " + boundUniform.semantic );
+					break;
+
+			}
+
+		}
+
+	};
+
+
+	/* ANIMATION */
+
+	LegacyGLTFLoader.Animations = {
+
+		update: function () {
+
+			console.warn( 'THREE.LegacyGLTFLoader.Animation has been deprecated. Use THREE.AnimationMixer instead.' );
+
+		}
+
+	};
+
+	/*********************************/
+	/********** EXTENSIONS ***********/
+	/*********************************/
+
+	var EXTENSIONS = {
+		KHR_BINARY_GLTF: 'KHR_binary_glTF',
+		KHR_MATERIALS_COMMON: 'KHR_materials_common'
+	};
+
+	/* MATERIALS COMMON EXTENSION */
+
+	function GLTFMaterialsCommonExtension( json ) {
+
+		this.name = EXTENSIONS.KHR_MATERIALS_COMMON;
+
+		this.lights = {};
+
+		var extension = ( json.extensions && json.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ] ) || {};
+		var lights = extension.lights || {};
+
+		for ( var lightId in lights ) {
+
+			var light = lights[ lightId ];
+			var lightNode;
+
+			var lightParams = light[ light.type ];
+			var color = new THREE.Color().fromArray( lightParams.color );
+
+			switch ( light.type ) {
+
+				case "directional":
+					lightNode = new THREE.DirectionalLight( color );
+					lightNode.position.set( 0, 0, 1 );
+					break;
+
+				case "point":
+					lightNode = new THREE.PointLight( color );
+					break;
+
+				case "spot":
+					lightNode = new THREE.SpotLight( color );
+					lightNode.position.set( 0, 0, 1 );
+					break;
+
+				case "ambient":
+					lightNode = new THREE.AmbientLight( color );
+					break;
+
+			}
+
+			if ( lightNode ) {
+
+				this.lights[ lightId ] = lightNode;
+
+			}
+
+		}
+
+	}
+
+	/* BINARY EXTENSION */
+
+	var BINARY_EXTENSION_BUFFER_NAME = 'binary_glTF';
+
+	var BINARY_EXTENSION_HEADER_DEFAULTS = { magic: 'glTF', version: 1, contentFormat: 0 };
+
+	var BINARY_EXTENSION_HEADER_LENGTH = 20;
+
+	function GLTFBinaryExtension( data ) {
+
+		this.name = EXTENSIONS.KHR_BINARY_GLTF;
+
+		var headerView = new DataView( data, 0, BINARY_EXTENSION_HEADER_LENGTH );
+
+		var header = {
+			magic: convertUint8ArrayToString( new Uint8Array( data.slice( 0, 4 ) ) ),
+			version: headerView.getUint32( 4, true ),
+			length: headerView.getUint32( 8, true ),
+			contentLength: headerView.getUint32( 12, true ),
+			contentFormat: headerView.getUint32( 16, true )
+		};
+
+		for ( var key in BINARY_EXTENSION_HEADER_DEFAULTS ) {
+
+			var value = BINARY_EXTENSION_HEADER_DEFAULTS[ key ];
+
+			if ( header[ key ] !== value ) {
+
+				throw new Error( 'Unsupported glTF-Binary header: Expected "%s" to be "%s".', key, value );
+
+			}
+
+		}
+
+		var contentArray = new Uint8Array( data, BINARY_EXTENSION_HEADER_LENGTH, header.contentLength );
+
+		this.header = header;
+		this.content = convertUint8ArrayToString( contentArray );
+		this.body = data.slice( BINARY_EXTENSION_HEADER_LENGTH + header.contentLength, header.length );
+
+	}
+
+	GLTFBinaryExtension.prototype.loadShader = function ( shader, bufferViews ) {
+
+		var bufferView = bufferViews[ shader.extensions[ EXTENSIONS.KHR_BINARY_GLTF ].bufferView ];
+		var array = new Uint8Array( bufferView );
+
+		return convertUint8ArrayToString( array );
+
+	};
+
+	GLTFBinaryExtension.prototype.loadTextureSourceUri = function ( source, bufferViews ) {
+
+		var metadata = source.extensions[ EXTENSIONS.KHR_BINARY_GLTF ];
+		var bufferView = bufferViews[ metadata.bufferView ];
+		var stringData = convertUint8ArrayToString( new Uint8Array( bufferView ) );
+
+		return 'data:' + metadata.mimeType + ';base64,' + btoa( stringData );
+
+	};
+
+	/*********************************/
+	/********** INTERNALS ************/
+	/*********************************/
+
+	/* CONSTANTS */
+
+	var WEBGL_CONSTANTS = {
+		FLOAT: 5126,
+		//FLOAT_MAT2: 35674,
+		FLOAT_MAT3: 35675,
+		FLOAT_MAT4: 35676,
+		FLOAT_VEC2: 35664,
+		FLOAT_VEC3: 35665,
+		FLOAT_VEC4: 35666,
+		LINEAR: 9729,
+		REPEAT: 10497,
+		SAMPLER_2D: 35678,
+		TRIANGLES: 4,
+		LINES: 1,
+		UNSIGNED_BYTE: 5121,
+		UNSIGNED_SHORT: 5123,
+
+		VERTEX_SHADER: 35633,
+		FRAGMENT_SHADER: 35632
+	};
+
+	var WEBGL_TYPE = {
+		5126: Number,
+		//35674: THREE.Matrix2,
+		35675: THREE.Matrix3,
+		35676: THREE.Matrix4,
+		35664: THREE.Vector2,
+		35665: THREE.Vector3,
+		35666: THREE.Vector4,
+		35678: THREE.Texture
+	};
+
+	var WEBGL_COMPONENT_TYPES = {
+		5120: Int8Array,
+		5121: Uint8Array,
+		5122: Int16Array,
+		5123: Uint16Array,
+		5125: Uint32Array,
+		5126: Float32Array
+	};
+
+	var WEBGL_FILTERS = {
+		9728: THREE.NearestFilter,
+		9729: THREE.LinearFilter,
+		9984: THREE.NearestMipMapNearestFilter,
+		9985: THREE.LinearMipMapNearestFilter,
+		9986: THREE.NearestMipMapLinearFilter,
+		9987: THREE.LinearMipMapLinearFilter
+	};
+
+	var WEBGL_WRAPPINGS = {
+		33071: THREE.ClampToEdgeWrapping,
+		33648: THREE.MirroredRepeatWrapping,
+		10497: THREE.RepeatWrapping
+	};
+
+	var WEBGL_TEXTURE_FORMATS = {
+		6406: THREE.AlphaFormat,
+		6407: THREE.RGBFormat,
+		6408: THREE.RGBAFormat,
+		6409: THREE.LuminanceFormat,
+		6410: THREE.LuminanceAlphaFormat
+	};
+
+	var WEBGL_TEXTURE_DATATYPES = {
+		5121: THREE.UnsignedByteType,
+		32819: THREE.UnsignedShort4444Type,
+		32820: THREE.UnsignedShort5551Type,
+		33635: THREE.UnsignedShort565Type
+	};
+
+	var WEBGL_SIDES = {
+		1028: THREE.BackSide,  // Culling front
+		1029: THREE.FrontSide  // Culling back
+		//1032: THREE.NoSide   // Culling front and back, what to do?
+	};
+
+	var WEBGL_DEPTH_FUNCS = {
+		512: THREE.NeverDepth,
+		513: THREE.LessDepth,
+		514: THREE.EqualDepth,
+		515: THREE.LessEqualDepth,
+		516: THREE.GreaterEqualDepth,
+		517: THREE.NotEqualDepth,
+		518: THREE.GreaterEqualDepth,
+		519: THREE.AlwaysDepth
+	};
+
+	var WEBGL_BLEND_EQUATIONS = {
+		32774: THREE.AddEquation,
+		32778: THREE.SubtractEquation,
+		32779: THREE.ReverseSubtractEquation
+	};
+
+	var WEBGL_BLEND_FUNCS = {
+		0: THREE.ZeroFactor,
+		1: THREE.OneFactor,
+		768: THREE.SrcColorFactor,
+		769: THREE.OneMinusSrcColorFactor,
+		770: THREE.SrcAlphaFactor,
+		771: THREE.OneMinusSrcAlphaFactor,
+		772: THREE.DstAlphaFactor,
+		773: THREE.OneMinusDstAlphaFactor,
+		774: THREE.DstColorFactor,
+		775: THREE.OneMinusDstColorFactor,
+		776: THREE.SrcAlphaSaturateFactor
+		// The followings are not supported by Three.js yet
+		//32769: CONSTANT_COLOR,
+		//32770: ONE_MINUS_CONSTANT_COLOR,
+		//32771: CONSTANT_ALPHA,
+		//32772: ONE_MINUS_CONSTANT_COLOR
+	};
+
+	var WEBGL_TYPE_SIZES = {
+		'SCALAR': 1,
+		'VEC2': 2,
+		'VEC3': 3,
+		'VEC4': 4,
+		'MAT2': 4,
+		'MAT3': 9,
+		'MAT4': 16
+	};
+
+	var PATH_PROPERTIES = {
+		scale: 'scale',
+		translation: 'position',
+		rotation: 'quaternion'
+	};
+
+	var INTERPOLATION = {
+		LINEAR: THREE.InterpolateLinear,
+		STEP: THREE.InterpolateDiscrete
+	};
+
+	var STATES_ENABLES = {
+		2884: 'CULL_FACE',
+		2929: 'DEPTH_TEST',
+		3042: 'BLEND',
+		3089: 'SCISSOR_TEST',
+		32823: 'POLYGON_OFFSET_FILL',
+		32926: 'SAMPLE_ALPHA_TO_COVERAGE'
+	};
+
+	/* UTILITY FUNCTIONS */
+
+	function _each( object, callback, thisObj ) {
+
+		if ( !object ) {
+			return Promise.resolve();
+		}
+
+		var results;
+		var fns = [];
+
+		if ( Object.prototype.toString.call( object ) === '[object Array]' ) {
+
+			results = [];
+
+			var length = object.length;
+
+			for ( var idx = 0; idx < length; idx ++ ) {
+
+				var value = callback.call( thisObj || this, object[ idx ], idx );
+
+				if ( value ) {
+
+					fns.push( value );
+
+					if ( value instanceof Promise ) {
+
+						value.then( function( key, value ) {
+
+							results[ key ] = value;
+
+						}.bind( this, idx ));
+
+					} else {
+
+						results[ idx ] = value;
+
+					}
+
+				}
+
+			}
+
+		} else {
+
+			results = {};
+
+			for ( var key in object ) {
+
+				if ( object.hasOwnProperty( key ) ) {
+
+					var value = callback.call( thisObj || this, object[ key ], key );
+
+					if ( value ) {
+
+						fns.push( value );
+
+						if ( value instanceof Promise ) {
+
+							value.then( function( key, value ) {
+
+								results[ key ] = value;
+
+							}.bind( this, key ));
+
+						} else {
+
+							results[ key ] = value;
+
+						}
+
+					}
+
+				}
+
+			}
+
+		}
+
+		return Promise.all( fns ).then( function() {
+
+			return results;
+
+		});
+
+	}
+
+	function resolveURL( url, path ) {
+
+		// Invalid URL
+		if ( typeof url !== 'string' || url === '' )
+			return '';
+
+		// Absolute URL http://,https://,//
+		if ( /^(https?:)?\/\//i.test( url ) ) {
+
+			return url;
+
+		}
+
+		// Data URI
+		if ( /^data:.*,.*$/i.test( url ) ) {
+
+			return url;
+
+		}
+
+		// Relative URL
+		return ( path || '' ) + url;
+
+	}
+
+	function convertUint8ArrayToString( array ) {
+
+		if ( window.TextDecoder !== undefined ) {
+
+			return new TextDecoder().decode( array );
+
+		}
+
+		// Avoid the String.fromCharCode.apply(null, array) shortcut, which
+		// throws a "maximum call stack size exceeded" error for large arrays.
+
+		var s = '';
+
+		for ( var i = 0, il = array.length; i < il; i ++ ) {
+
+			s += String.fromCharCode( array[ i ] );
+
+		}
+
+		return s;
+
+	}
+
+	// Three.js seems too dependent on attribute names so globally
+	// replace those in the shader code
+	function replaceTHREEShaderAttributes( shaderText, technique ) {
+
+		// Expected technique attributes
+		var attributes = {};
+
+		for ( var attributeId in technique.attributes ) {
+
+			var pname = technique.attributes[ attributeId ];
+
+			var param = technique.parameters[ pname ];
+			var atype = param.type;
+			var semantic = param.semantic;
+
+			attributes[ attributeId ] = {
+				type: atype,
+				semantic: semantic
+			};
+
+		}
+
+		// Figure out which attributes to change in technique
+
+		var shaderParams = technique.parameters;
+		var shaderAttributes = technique.attributes;
+		var params = {};
+
+		for ( var attributeId in attributes ) {
+
+			var pname = shaderAttributes[ attributeId ];
+			var shaderParam = shaderParams[ pname ];
+			var semantic = shaderParam.semantic;
+			if ( semantic ) {
+
+				params[ attributeId ] = shaderParam;
+
+			}
+
+		}
+
+		for ( var pname in params ) {
+
+			var param = params[ pname ];
+			var semantic = param.semantic;
+
+			var regEx = new RegExp( "\\b" + pname + "\\b", "g" );
+
+			switch ( semantic ) {
+
+				case "POSITION":
+
+					shaderText = shaderText.replace( regEx, 'position' );
+					break;
+
+				case "NORMAL":
+
+					shaderText = shaderText.replace( regEx, 'normal' );
+					break;
+
+				case 'TEXCOORD_0':
+				case 'TEXCOORD0':
+				case 'TEXCOORD':
+
+					shaderText = shaderText.replace( regEx, 'uv' );
+					break;
+
+				case 'TEXCOORD_1':
+
+					shaderText = shaderText.replace( regEx, 'uv2' );
+					break;
+
+				case 'COLOR_0':
+				case 'COLOR0':
+				case 'COLOR':
+
+					shaderText = shaderText.replace( regEx, 'color' );
+					break;
+
+				case "WEIGHT":
+
+					shaderText = shaderText.replace( regEx, 'skinWeight' );
+					break;
+
+				case "JOINT":
+
+					shaderText = shaderText.replace( regEx, 'skinIndex' );
+					break;
+
+			}
+
+		}
+
+		return shaderText;
+
+	}
+
+	function createDefaultMaterial() {
+
+		return new THREE.MeshPhongMaterial( {
+			color: 0x00000,
+			emissive: 0x888888,
+			specular: 0x000000,
+			shininess: 0,
+			transparent: false,
+			depthTest: true,
+			side: THREE.FrontSide
+		} );
+
+	}
+
+	// Deferred constructor for RawShaderMaterial types
+	function DeferredShaderMaterial( params ) {
+
+		this.isDeferredShaderMaterial = true;
+
+		this.params = params;
+
+	}
+
+	DeferredShaderMaterial.prototype.create = function () {
+
+		var uniforms = THREE.UniformsUtils.clone( this.params.uniforms );
+
+		for ( var uniformId in this.params.uniforms ) {
+
+			var originalUniform = this.params.uniforms[ uniformId ];
+
+			if ( originalUniform.value instanceof THREE.Texture ) {
+
+				uniforms[ uniformId ].value = originalUniform.value;
+				uniforms[ uniformId ].value.needsUpdate = true;
+
+			}
+
+			uniforms[ uniformId ].semantic = originalUniform.semantic;
+			uniforms[ uniformId ].node = originalUniform.node;
+
+		}
+
+		this.params.uniforms = uniforms;
+
+		return new THREE.RawShaderMaterial( this.params );
+
+	};
+
+	/* GLTF PARSER */
+
+	function GLTFParser( json, extensions, options ) {
+
+		this.json = json || {};
+		this.extensions = extensions || {};
+		this.options = options || {};
+
+		// loader object cache
+		this.cache = new GLTFRegistry();
+
+	}
+
+	GLTFParser.prototype._withDependencies = function ( dependencies ) {
+
+		var _dependencies = {};
+
+		for ( var i = 0; i < dependencies.length; i ++ ) {
+
+			var dependency = dependencies[ i ];
+			var fnName = "load" + dependency.charAt( 0 ).toUpperCase() + dependency.slice( 1 );
+
+			var cached = this.cache.get( dependency );
+
+			if ( cached !== undefined ) {
+
+				_dependencies[ dependency ] = cached;
+
+			} else if ( this[ fnName ] ) {
+
+				var fn = this[ fnName ]();
+				this.cache.add( dependency, fn );
+
+				_dependencies[ dependency ] = fn;
+
+			}
+
+		}
+
+		return _each( _dependencies, function ( dependency ) {
+
+			return dependency;
+
+		} );
+
+	};
+
+	GLTFParser.prototype.parse = function ( callback ) {
+
+		var json = this.json;
+
+		// Clear the loader cache
+		this.cache.removeAll();
+
+		// Fire the callback on complete
+		this._withDependencies( [
+
+			"scenes",
+			"cameras",
+			"animations"
+
+		] ).then( function ( dependencies ) {
+
+			var scenes = [];
+
+			for ( var name in dependencies.scenes ) {
+
+				scenes.push( dependencies.scenes[ name ] );
+
+			}
+
+			var scene = json.scene !== undefined ? dependencies.scenes[ json.scene ] : scenes[ 0 ];
+
+			var cameras = [];
+
+			for ( var name in dependencies.cameras ) {
+
+				var camera = dependencies.cameras[ name ];
+				cameras.push( camera );
+
+			}
+
+			var animations = [];
+
+			for ( var name in dependencies.animations ) {
+
+				animations.push( dependencies.animations[ name ] );
+
+			}
+
+			callback( scene, scenes, cameras, animations );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadShaders = function () {
+
+		var json = this.json;
+		var extensions = this.extensions;
+		var options = this.options;
+
+		return this._withDependencies( [
+
+			"bufferViews"
+
+		] ).then( function ( dependencies ) {
+
+			return _each( json.shaders, function ( shader ) {
+
+				if ( shader.extensions && shader.extensions[ EXTENSIONS.KHR_BINARY_GLTF ] ) {
+
+					return extensions[ EXTENSIONS.KHR_BINARY_GLTF ].loadShader( shader, dependencies.bufferViews );
+
+				}
+
+				return new Promise( function ( resolve ) {
+
+					var loader = new THREE.FileLoader();
+					loader.setResponseType( 'text' );
+					loader.load( resolveURL( shader.uri, options.path ), function ( shaderText ) {
+
+						resolve( shaderText );
+
+					} );
+
+				} );
+
+			} );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadBuffers = function () {
+
+		var json = this.json;
+		var extensions = this.extensions;
+		var options = this.options;
+
+		return _each( json.buffers, function ( buffer, name ) {
+
+			if ( name === BINARY_EXTENSION_BUFFER_NAME ) {
+
+				return extensions[ EXTENSIONS.KHR_BINARY_GLTF ].body;
+
+			}
+
+			if ( buffer.type === 'arraybuffer' || buffer.type === undefined ) {
+
+				return new Promise( function ( resolve ) {
+
+					var loader = new THREE.FileLoader();
+					loader.setResponseType( 'arraybuffer' );
+					loader.load( resolveURL( buffer.uri, options.path ), function ( buffer ) {
+
+						resolve( buffer );
+
+					} );
+
+				} );
+
+			} else {
+
+				console.warn( 'THREE.LegacyGLTFLoader: ' + buffer.type + ' buffer type is not supported' );
+
+			}
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadBufferViews = function () {
+
+		var json = this.json;
+
+		return this._withDependencies( [
+
+			"buffers"
+
+		] ).then( function ( dependencies ) {
+
+			return _each( json.bufferViews, function ( bufferView ) {
+
+				var arraybuffer = dependencies.buffers[ bufferView.buffer ];
+
+				var byteLength = bufferView.byteLength !== undefined ? bufferView.byteLength : 0;
+
+				return arraybuffer.slice( bufferView.byteOffset, bufferView.byteOffset + byteLength );
+
+			} );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadAccessors = function () {
+
+		var json = this.json;
+
+		return this._withDependencies( [
+
+			"bufferViews"
+
+		] ).then( function ( dependencies ) {
+
+			return _each( json.accessors, function ( accessor ) {
+
+				var arraybuffer = dependencies.bufferViews[ accessor.bufferView ];
+				var itemSize = WEBGL_TYPE_SIZES[ accessor.type ];
+				var TypedArray = WEBGL_COMPONENT_TYPES[ accessor.componentType ];
+
+				// For VEC3: itemSize is 3, elementBytes is 4, itemBytes is 12.
+				var elementBytes = TypedArray.BYTES_PER_ELEMENT;
+				var itemBytes = elementBytes * itemSize;
+
+				// The buffer is not interleaved if the stride is the item size in bytes.
+				if ( accessor.byteStride && accessor.byteStride !== itemBytes ) {
+
+					// Use the full buffer if it's interleaved.
+					var array = new TypedArray( arraybuffer );
+
+					// Integer parameters to IB/IBA are in array elements, not bytes.
+					var ib = new THREE.InterleavedBuffer( array, accessor.byteStride / elementBytes );
+
+					return new THREE.InterleavedBufferAttribute( ib, itemSize, accessor.byteOffset / elementBytes );
+
+				} else {
+
+					array = new TypedArray( arraybuffer, accessor.byteOffset, accessor.count * itemSize );
+
+					return new THREE.BufferAttribute( array, itemSize );
+
+				}
+
+			} );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadTextures = function () {
+
+		var json = this.json;
+		var extensions = this.extensions;
+		var options = this.options;
+
+		return this._withDependencies( [
+
+			"bufferViews"
+
+		] ).then( function ( dependencies ) {
+
+			return _each( json.textures, function ( texture ) {
+
+				if ( texture.source ) {
+
+					return new Promise( function ( resolve ) {
+
+						var source = json.images[ texture.source ];
+						var sourceUri = source.uri;
+
+						if ( source.extensions && source.extensions[ EXTENSIONS.KHR_BINARY_GLTF ] ) {
+
+							sourceUri = extensions[ EXTENSIONS.KHR_BINARY_GLTF ].loadTextureSourceUri( source, dependencies.bufferViews );
+
+						}
+
+						var textureLoader = THREE.Loader.Handlers.get( sourceUri );
+
+						if ( textureLoader === null ) {
+
+							textureLoader = new THREE.TextureLoader();
+
+						}
+
+						textureLoader.setCrossOrigin( options.crossOrigin );
+
+						textureLoader.load( resolveURL( sourceUri, options.path ), function ( _texture ) {
+
+							_texture.flipY = false;
+
+							if ( texture.name !== undefined ) _texture.name = texture.name;
+
+							_texture.format = texture.format !== undefined ? WEBGL_TEXTURE_FORMATS[ texture.format ] : THREE.RGBAFormat;
+
+							if ( texture.internalFormat !== undefined && _texture.format !== WEBGL_TEXTURE_FORMATS[ texture.internalFormat ] ) {
+
+								console.warn( 'THREE.LegacyGLTFLoader: Three.js doesn\'t support texture internalFormat which is different from texture format. ' +
+															'internalFormat will be forced to be the same value as format.' );
+
+							}
+
+							_texture.type = texture.type !== undefined ? WEBGL_TEXTURE_DATATYPES[ texture.type ] : THREE.UnsignedByteType;
+
+							if ( texture.sampler ) {
+
+								var sampler = json.samplers[ texture.sampler ];
+
+								_texture.magFilter = WEBGL_FILTERS[ sampler.magFilter ] || THREE.LinearFilter;
+								_texture.minFilter = WEBGL_FILTERS[ sampler.minFilter ] || THREE.NearestMipMapLinearFilter;
+								_texture.wrapS = WEBGL_WRAPPINGS[ sampler.wrapS ] || THREE.RepeatWrapping;
+								_texture.wrapT = WEBGL_WRAPPINGS[ sampler.wrapT ] || THREE.RepeatWrapping;
+
+							}
+
+							resolve( _texture );
+
+						}, undefined, function () {
+
+							resolve();
+
+						} );
+
+					} );
+
+				}
+
+			} );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadMaterials = function () {
+
+		var json = this.json;
+
+		return this._withDependencies( [
+
+			"shaders",
+			"textures"
+
+		] ).then( function ( dependencies ) {
+
+			return _each( json.materials, function ( material ) {
+
+				var materialType;
+				var materialValues = {};
+				var materialParams = {};
+
+				var khr_material;
+
+				if ( material.extensions && material.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ] ) {
+
+					khr_material = material.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ];
+
+				}
+
+				if ( khr_material ) {
+
+					// don't copy over unused values to avoid material warning spam
+					var keys = [ 'ambient', 'emission', 'transparent', 'transparency', 'doubleSided' ];
+
+					switch ( khr_material.technique ) {
+
+						case 'BLINN' :
+						case 'PHONG' :
+							materialType = THREE.MeshPhongMaterial;
+							keys.push( 'diffuse', 'specular', 'shininess' );
+							break;
+
+						case 'LAMBERT' :
+							materialType = THREE.MeshLambertMaterial;
+							keys.push( 'diffuse' );
+							break;
+
+						case 'CONSTANT' :
+						default :
+							materialType = THREE.MeshBasicMaterial;
+							break;
+
+					}
+
+					keys.forEach( function( v ) {
+
+						if ( khr_material.values[ v ] !== undefined ) materialValues[ v ] = khr_material.values[ v ];
+
+					} );
+
+					if ( khr_material.doubleSided || materialValues.doubleSided ) {
+
+						materialParams.side = THREE.DoubleSide;
+
+					}
+
+					if ( khr_material.transparent || materialValues.transparent ) {
+
+						materialParams.transparent = true;
+						materialParams.opacity = ( materialValues.transparency !== undefined ) ? materialValues.transparency : 1;
+
+					}
+
+				} else if ( material.technique === undefined ) {
+
+					materialType = THREE.MeshPhongMaterial;
+
+					Object.assign( materialValues, material.values );
+
+				} else {
+
+					materialType = DeferredShaderMaterial;
+
+					var technique = json.techniques[ material.technique ];
+
+					materialParams.uniforms = {};
+
+					var program = json.programs[ technique.program ];
+
+					if ( program ) {
+
+						materialParams.fragmentShader = dependencies.shaders[ program.fragmentShader ];
+
+						if ( ! materialParams.fragmentShader ) {
+
+							console.warn( "ERROR: Missing fragment shader definition:", program.fragmentShader );
+							materialType = THREE.MeshPhongMaterial;
+
+						}
+
+						var vertexShader = dependencies.shaders[ program.vertexShader ];
+
+						if ( ! vertexShader ) {
+
+							console.warn( "ERROR: Missing vertex shader definition:", program.vertexShader );
+							materialType = THREE.MeshPhongMaterial;
+
+						}
+
+						// IMPORTANT: FIX VERTEX SHADER ATTRIBUTE DEFINITIONS
+						materialParams.vertexShader = replaceTHREEShaderAttributes( vertexShader, technique );
+
+						var uniforms = technique.uniforms;
+
+						for ( var uniformId in uniforms ) {
+
+							var pname = uniforms[ uniformId ];
+							var shaderParam = technique.parameters[ pname ];
+
+							var ptype = shaderParam.type;
+
+							if ( WEBGL_TYPE[ ptype ] ) {
+
+								var pcount = shaderParam.count;
+								var value;
+
+								if ( material.values !== undefined ) value = material.values[ pname ];
+
+								var uvalue = new WEBGL_TYPE[ ptype ]();
+								var usemantic = shaderParam.semantic;
+								var unode = shaderParam.node;
+
+								switch ( ptype ) {
+
+									case WEBGL_CONSTANTS.FLOAT:
+
+										uvalue = shaderParam.value;
+
+										if ( pname == "transparency" ) {
+
+											materialParams.transparent = true;
+
+										}
+
+										if ( value !== undefined ) {
+
+											uvalue = value;
+
+										}
+
+										break;
+
+									case WEBGL_CONSTANTS.FLOAT_VEC2:
+									case WEBGL_CONSTANTS.FLOAT_VEC3:
+									case WEBGL_CONSTANTS.FLOAT_VEC4:
+									case WEBGL_CONSTANTS.FLOAT_MAT3:
+
+										if ( shaderParam && shaderParam.value ) {
+
+											uvalue.fromArray( shaderParam.value );
+
+										}
+
+										if ( value ) {
+
+											uvalue.fromArray( value );
+
+										}
+
+										break;
+
+									case WEBGL_CONSTANTS.FLOAT_MAT2:
+
+										// what to do?
+										console.warn( "FLOAT_MAT2 is not a supported uniform type" );
+										break;
+
+									case WEBGL_CONSTANTS.FLOAT_MAT4:
+
+										if ( pcount ) {
+
+											uvalue = new Array( pcount );
+
+											for ( var mi = 0; mi < pcount; mi ++ ) {
+
+												uvalue[ mi ] = new WEBGL_TYPE[ ptype ]();
+
+											}
+
+											if ( shaderParam && shaderParam.value ) {
+
+												var m4v = shaderParam.value;
+												uvalue.fromArray( m4v );
+
+											}
+
+											if ( value ) {
+
+												uvalue.fromArray( value );
+
+											}
+
+										} else {
+
+											if ( shaderParam && shaderParam.value ) {
+
+												var m4 = shaderParam.value;
+												uvalue.fromArray( m4 );
+
+											}
+
+											if ( value ) {
+
+												uvalue.fromArray( value );
+
+											}
+
+										}
+
+										break;
+
+									case WEBGL_CONSTANTS.SAMPLER_2D:
+
+										if ( value !== undefined ) {
+
+											uvalue = dependencies.textures[ value ];
+
+										} else if ( shaderParam.value !== undefined ) {
+
+											uvalue = dependencies.textures[ shaderParam.value ];
+
+										} else {
+
+											uvalue = null;
+
+										}
+
+										break;
+
+								}
+
+								materialParams.uniforms[ uniformId ] = {
+									value: uvalue,
+									semantic: usemantic,
+									node: unode
+								};
+
+							} else {
+
+								throw new Error( "Unknown shader uniform param type: " + ptype );
+
+							}
+
+						}
+
+						var states = technique.states || {};
+						var enables = states.enable || [];
+						var functions = states.functions || {};
+
+						var enableCullFace = false;
+						var enableDepthTest = false;
+						var enableBlend = false;
+
+						for ( var i = 0, il = enables.length; i < il; i ++ ) {
+
+							var enable = enables[ i ];
+
+							switch ( STATES_ENABLES[ enable ] ) {
+
+								case 'CULL_FACE':
+
+									enableCullFace = true;
+
+									break;
+
+								case 'DEPTH_TEST':
+
+									enableDepthTest = true;
+
+									break;
+
+								case 'BLEND':
+
+									enableBlend = true;
+
+									break;
+
+								// TODO: implement
+								case 'SCISSOR_TEST':
+								case 'POLYGON_OFFSET_FILL':
+								case 'SAMPLE_ALPHA_TO_COVERAGE':
+
+									break;
+
+								default:
+
+									throw new Error( "Unknown technique.states.enable: " + enable );
+
+							}
+
+						}
+
+						if ( enableCullFace ) {
+
+							materialParams.side = functions.cullFace !== undefined ? WEBGL_SIDES[ functions.cullFace ] : THREE.FrontSide;
+
+						} else {
+
+							materialParams.side = THREE.DoubleSide;
+
+						}
+
+						materialParams.depthTest = enableDepthTest;
+						materialParams.depthFunc = functions.depthFunc !== undefined ? WEBGL_DEPTH_FUNCS[ functions.depthFunc ] : THREE.LessDepth;
+						materialParams.depthWrite = functions.depthMask !== undefined ? functions.depthMask[ 0 ] : true;
+
+						materialParams.blending = enableBlend ? THREE.CustomBlending : THREE.NoBlending;
+						materialParams.transparent = enableBlend;
+
+						var blendEquationSeparate = functions.blendEquationSeparate;
+
+						if ( blendEquationSeparate !== undefined ) {
+
+							materialParams.blendEquation = WEBGL_BLEND_EQUATIONS[ blendEquationSeparate[ 0 ] ];
+							materialParams.blendEquationAlpha = WEBGL_BLEND_EQUATIONS[ blendEquationSeparate[ 1 ] ];
+
+						} else {
+
+							materialParams.blendEquation = THREE.AddEquation;
+							materialParams.blendEquationAlpha = THREE.AddEquation;
+
+						}
+
+						var blendFuncSeparate = functions.blendFuncSeparate;
+
+						if ( blendFuncSeparate !== undefined ) {
+
+							materialParams.blendSrc = WEBGL_BLEND_FUNCS[ blendFuncSeparate[ 0 ] ];
+							materialParams.blendDst = WEBGL_BLEND_FUNCS[ blendFuncSeparate[ 1 ] ];
+							materialParams.blendSrcAlpha = WEBGL_BLEND_FUNCS[ blendFuncSeparate[ 2 ] ];
+							materialParams.blendDstAlpha = WEBGL_BLEND_FUNCS[ blendFuncSeparate[ 3 ] ];
+
+						} else {
+
+							materialParams.blendSrc = THREE.OneFactor;
+							materialParams.blendDst = THREE.ZeroFactor;
+							materialParams.blendSrcAlpha = THREE.OneFactor;
+							materialParams.blendDstAlpha = THREE.ZeroFactor;
+
+						}
+
+					}
+
+				}
+
+				if ( Array.isArray( materialValues.diffuse ) ) {
+
+					materialParams.color = new THREE.Color().fromArray( materialValues.diffuse );
+
+				} else if ( typeof( materialValues.diffuse ) === 'string' ) {
+
+					materialParams.map = dependencies.textures[ materialValues.diffuse ];
+
+				}
+
+				delete materialParams.diffuse;
+
+				if ( typeof( materialValues.reflective ) === 'string' ) {
+
+					materialParams.envMap = dependencies.textures[ materialValues.reflective ];
+
+				}
+
+				if ( typeof( materialValues.bump ) === 'string' ) {
+
+					materialParams.bumpMap = dependencies.textures[ materialValues.bump ];
+
+				}
+
+				if ( Array.isArray( materialValues.emission ) ) {
+
+					if ( materialType === THREE.MeshBasicMaterial ) {
+
+						materialParams.color = new THREE.Color().fromArray( materialValues.emission );
+
+					} else {
+
+						materialParams.emissive = new THREE.Color().fromArray( materialValues.emission );
+
+					}
+
+				} else if ( typeof( materialValues.emission ) === 'string' ) {
+
+					if ( materialType === THREE.MeshBasicMaterial ) {
+
+						materialParams.map = dependencies.textures[ materialValues.emission ];
+
+					} else {
+
+						materialParams.emissiveMap = dependencies.textures[ materialValues.emission ];
+
+					}
+
+				}
+
+				if ( Array.isArray( materialValues.specular ) ) {
+
+					materialParams.specular = new THREE.Color().fromArray( materialValues.specular );
+
+				} else if ( typeof( materialValues.specular ) === 'string' ) {
+
+					materialParams.specularMap = dependencies.textures[ materialValues.specular ];
+
+				}
+
+				if ( materialValues.shininess !== undefined ) {
+
+					materialParams.shininess = materialValues.shininess;
+
+				}
+
+				var _material = new materialType( materialParams );
+				if ( material.name !== undefined ) _material.name = material.name;
+
+				return _material;
+
+			} );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadMeshes = function () {
+
+		var json = this.json;
+
+		return this._withDependencies( [
+
+			"accessors",
+			"materials"
+
+		] ).then( function ( dependencies ) {
+
+			return _each( json.meshes, function ( mesh ) {
+
+				var group = new THREE.Group();
+				if ( mesh.name !== undefined ) group.name = mesh.name;
+
+				if ( mesh.extras ) group.userData = mesh.extras;
+
+				var primitives = mesh.primitives || [];
+
+				for ( var name in primitives ) {
+
+					var primitive = primitives[ name ];
+
+					if ( primitive.mode === WEBGL_CONSTANTS.TRIANGLES || primitive.mode === undefined ) {
+
+						var geometry = new THREE.BufferGeometry();
+
+						var attributes = primitive.attributes;
+
+						for ( var attributeId in attributes ) {
+
+							var attributeEntry = attributes[ attributeId ];
+
+							if ( ! attributeEntry ) return;
+
+							var bufferAttribute = dependencies.accessors[ attributeEntry ];
+
+							switch ( attributeId ) {
+
+								case 'POSITION':
+									geometry.addAttribute( 'position', bufferAttribute );
+									break;
+
+								case 'NORMAL':
+									geometry.addAttribute( 'normal', bufferAttribute );
+									break;
+
+								case 'TEXCOORD_0':
+								case 'TEXCOORD0':
+								case 'TEXCOORD':
+									geometry.addAttribute( 'uv', bufferAttribute );
+									break;
+
+								case 'TEXCOORD_1':
+									geometry.addAttribute( 'uv2', bufferAttribute );
+									break;
+
+								case 'COLOR_0':
+								case 'COLOR0':
+								case 'COLOR':
+									geometry.addAttribute( 'color', bufferAttribute );
+									break;
+
+								case 'WEIGHT':
+									geometry.addAttribute( 'skinWeight', bufferAttribute );
+									break;
+
+								case 'JOINT':
+									geometry.addAttribute( 'skinIndex', bufferAttribute );
+									break;
+
+							}
+
+						}
+
+						if ( primitive.indices ) {
+
+							geometry.setIndex( dependencies.accessors[ primitive.indices ] );
+
+						}
+
+						var material = dependencies.materials !== undefined ? dependencies.materials[ primitive.material ] : createDefaultMaterial();
+
+						var meshNode = new THREE.Mesh( geometry, material );
+						meshNode.castShadow = true;
+						meshNode.name = ( name === "0" ? group.name : group.name + name );
+
+						if ( primitive.extras ) meshNode.userData = primitive.extras;
+
+						group.add( meshNode );
+
+					} else if ( primitive.mode === WEBGL_CONSTANTS.LINES ) {
+
+						var geometry = new THREE.BufferGeometry();
+
+						var attributes = primitive.attributes;
+
+						for ( var attributeId in attributes ) {
+
+							var attributeEntry = attributes[ attributeId ];
+
+							if ( ! attributeEntry ) return;
+
+							var bufferAttribute = dependencies.accessors[ attributeEntry ];
+
+							switch ( attributeId ) {
+
+								case 'POSITION':
+									geometry.addAttribute( 'position', bufferAttribute );
+									break;
+
+								case 'COLOR_0':
+								case 'COLOR0':
+								case 'COLOR':
+									geometry.addAttribute( 'color', bufferAttribute );
+									break;
+
+							}
+
+						}
+
+						var material = dependencies.materials[ primitive.material ];
+
+						var meshNode;
+
+						if ( primitive.indices ) {
+
+							geometry.setIndex( dependencies.accessors[ primitive.indices ] );
+
+							meshNode = new THREE.LineSegments( geometry, material );
+
+						} else {
+
+							meshNode = new THREE.Line( geometry, material );
+
+						}
+
+						meshNode.name = ( name === "0" ? group.name : group.name + name );
+
+						if ( primitive.extras ) meshNode.userData = primitive.extras;
+
+						group.add( meshNode );
+
+					} else {
+
+						console.warn( "Only triangular and line primitives are supported" );
+
+					}
+
+				}
+
+				return group;
+
+			} );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadCameras = function () {
+
+		var json = this.json;
+
+		return _each( json.cameras, function ( camera ) {
+
+			if ( camera.type == "perspective" && camera.perspective ) {
+
+				var yfov = camera.perspective.yfov;
+				var aspectRatio = camera.perspective.aspectRatio !== undefined ? camera.perspective.aspectRatio : 1;
+
+				// According to COLLADA spec...
+				// aspectRatio = xfov / yfov
+				var xfov = yfov * aspectRatio;
+
+				var _camera = new THREE.PerspectiveCamera( THREE.Math.radToDeg( xfov ), aspectRatio, camera.perspective.znear || 1, camera.perspective.zfar || 2e6 );
+				if ( camera.name !== undefined ) _camera.name = camera.name;
+
+				if ( camera.extras ) _camera.userData = camera.extras;
+
+				return _camera;
+
+			} else if ( camera.type == "orthographic" && camera.orthographic ) {
+
+				var _camera = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, camera.orthographic.znear, camera.orthographic.zfar );
+				if ( camera.name !== undefined ) _camera.name = camera.name;
+
+				if ( camera.extras ) _camera.userData = camera.extras;
+
+				return _camera;
+
+			}
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadSkins = function () {
+
+		var json = this.json;
+
+		return this._withDependencies( [
+
+			"accessors"
+
+		] ).then( function ( dependencies ) {
+
+			return _each( json.skins, function ( skin ) {
+
+				var bindShapeMatrix = new THREE.Matrix4();
+
+				if ( skin.bindShapeMatrix !== undefined ) bindShapeMatrix.fromArray( skin.bindShapeMatrix );
+
+				var _skin = {
+					bindShapeMatrix: bindShapeMatrix,
+					jointNames: skin.jointNames,
+					inverseBindMatrices: dependencies.accessors[ skin.inverseBindMatrices ]
+				};
+
+				return _skin;
+
+			} );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadAnimations = function () {
+
+		var json = this.json;
+
+		return this._withDependencies( [
+
+			"accessors",
+			"nodes"
+
+		] ).then( function ( dependencies ) {
+
+			return _each( json.animations, function ( animation, animationId ) {
+
+				var tracks = [];
+
+				for ( var channelId in animation.channels ) {
+
+					var channel = animation.channels[ channelId ];
+					var sampler = animation.samplers[ channel.sampler ];
+
+					if ( sampler ) {
+
+						var target = channel.target;
+						var name = target.id;
+						var input = animation.parameters !== undefined ? animation.parameters[ sampler.input ] : sampler.input;
+						var output = animation.parameters !== undefined ? animation.parameters[ sampler.output ] : sampler.output;
+
+						var inputAccessor = dependencies.accessors[ input ];
+						var outputAccessor = dependencies.accessors[ output ];
+
+						var node = dependencies.nodes[ name ];
+
+						if ( node ) {
+
+							node.updateMatrix();
+							node.matrixAutoUpdate = true;
+
+							var TypedKeyframeTrack = PATH_PROPERTIES[ target.path ] === PATH_PROPERTIES.rotation
+								? THREE.QuaternionKeyframeTrack
+								: THREE.VectorKeyframeTrack;
+
+							var targetName = node.name ? node.name : node.uuid;
+							var interpolation = sampler.interpolation !== undefined ? INTERPOLATION[ sampler.interpolation ] : THREE.InterpolateLinear;
+
+							// KeyframeTrack.optimize() will modify given 'times' and 'values'
+							// buffers before creating a truncated copy to keep. Because buffers may
+							// be reused by other tracks, make copies here.
+							tracks.push( new TypedKeyframeTrack(
+								targetName + '.' + PATH_PROPERTIES[ target.path ],
+								THREE.AnimationUtils.arraySlice( inputAccessor.array, 0 ),
+								THREE.AnimationUtils.arraySlice( outputAccessor.array, 0 ),
+								interpolation
+							) );
+
+						}
+
+					}
+
+				}
+
+				var name = animation.name !== undefined ? animation.name : "animation_" + animationId;
+
+				return new THREE.AnimationClip( name, undefined, tracks );
+
+			} );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadNodes = function () {
+
+		var json = this.json;
+		var extensions = this.extensions;
+		var scope = this;
+
+		return _each( json.nodes, function ( node ) {
+
+			var matrix = new THREE.Matrix4();
+
+			var _node;
+
+			if ( node.jointName ) {
+
+				_node = new THREE.Bone();
+				_node.name = node.name !== undefined ? node.name : node.jointName;
+				_node.jointName = node.jointName;
+
+			} else {
+
+				_node = new THREE.Object3D();
+				if ( node.name !== undefined ) _node.name = node.name;
+
+			}
+
+			if ( node.extras ) _node.userData = node.extras;
+
+			if ( node.matrix !== undefined ) {
+
+				matrix.fromArray( node.matrix );
+				_node.applyMatrix( matrix );
+
+			} else {
+
+				if ( node.translation !== undefined ) {
+
+					_node.position.fromArray( node.translation );
+
+				}
+
+				if ( node.rotation !== undefined ) {
+
+					_node.quaternion.fromArray( node.rotation );
+
+				}
+
+				if ( node.scale !== undefined ) {
+
+					_node.scale.fromArray( node.scale );
+
+				}
+
+			}
+
+			return _node;
+
+		} ).then( function ( __nodes ) {
+
+			return scope._withDependencies( [
+
+				"meshes",
+				"skins",
+				"cameras"
+
+			] ).then( function ( dependencies ) {
+
+				return _each( __nodes, function ( _node, nodeId ) {
+
+					var node = json.nodes[ nodeId ];
+
+					if ( node.meshes !== undefined ) {
+
+						for ( var meshId in node.meshes ) {
+
+							var mesh = node.meshes[ meshId ];
+							var group = dependencies.meshes[ mesh ];
+
+							if ( group === undefined ) {
+
+								console.warn( 'LegacyGLTFLoader: Couldn\'t find node "' + mesh + '".' );
+								continue;
+
+							}
+
+							for ( var childrenId in group.children ) {
+
+								var child = group.children[ childrenId ];
+
+								// clone Mesh to add to _node
+
+								var originalMaterial = child.material;
+								var originalGeometry = child.geometry;
+								var originalUserData = child.userData;
+								var originalName = child.name;
+
+								var material;
+
+								if ( originalMaterial.isDeferredShaderMaterial ) {
+
+									originalMaterial = material = originalMaterial.create();
+
+								} else {
+
+									material = originalMaterial;
+
+								}
+
+								switch ( child.type ) {
+
+									case 'LineSegments':
+										child = new THREE.LineSegments( originalGeometry, material );
+										break;
+
+									case 'LineLoop':
+										child = new THREE.LineLoop( originalGeometry, material );
+										break;
+
+									case 'Line':
+										child = new THREE.Line( originalGeometry, material );
+										break;
+
+									default:
+										child = new THREE.Mesh( originalGeometry, material );
+
+								}
+
+								child.castShadow = true;
+								child.userData = originalUserData;
+								child.name = originalName;
+
+								var skinEntry;
+
+								if ( node.skin ) {
+
+									skinEntry = dependencies.skins[ node.skin ];
+
+								}
+
+								// Replace Mesh with SkinnedMesh in library
+								if ( skinEntry ) {
+
+									var getJointNode = function ( jointId ) {
+
+										var keys = Object.keys( __nodes );
+
+										for ( var i = 0, il = keys.length; i < il; i ++ ) {
+
+											var n = __nodes[ keys[ i ] ];
+
+											if ( n.jointName === jointId ) return n;
+
+										}
+
+										return null;
+
+									};
+
+									var geometry = originalGeometry;
+									var material = originalMaterial;
+									material.skinning = true;
+
+									child = new THREE.SkinnedMesh( geometry, material );
+									child.castShadow = true;
+									child.userData = originalUserData;
+									child.name = originalName;
+
+									var bones = [];
+									var boneInverses = [];
+
+									for ( var i = 0, l = skinEntry.jointNames.length; i < l; i ++ ) {
+
+										var jointId = skinEntry.jointNames[ i ];
+										var jointNode = getJointNode( jointId );
+
+										if ( jointNode ) {
+
+											bones.push( jointNode );
+
+											var m = skinEntry.inverseBindMatrices.array;
+											var mat = new THREE.Matrix4().fromArray( m, i * 16 );
+											boneInverses.push( mat );
+
+										} else {
+
+											console.warn( "WARNING: joint: '" + jointId + "' could not be found" );
+
+										}
+
+									}
+
+									child.bind( new THREE.Skeleton( bones, boneInverses ), skinEntry.bindShapeMatrix );
+
+									var buildBoneGraph = function ( parentJson, parentObject, property ) {
+
+										var children = parentJson[ property ];
+
+										if ( children === undefined ) return;
+
+										for ( var i = 0, il = children.length; i < il; i ++ ) {
+
+											var nodeId = children[ i ];
+											var bone = __nodes[ nodeId ];
+											var boneJson = json.nodes[ nodeId ];
+
+											if ( bone !== undefined && bone.isBone === true && boneJson !== undefined ) {
+
+												parentObject.add( bone );
+												buildBoneGraph( boneJson, bone, 'children' );
+
+											}
+
+										}
+
+									};
+
+									buildBoneGraph( node, child, 'skeletons' );
+
+								}
+
+								_node.add( child );
+
+							}
+
+						}
+
+					}
+
+					if ( node.camera !== undefined ) {
+
+						var camera = dependencies.cameras[ node.camera ];
+
+						_node.add( camera );
+
+					}
+
+					if ( node.extensions
+							 && node.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ]
+							 && node.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ].light ) {
+
+						var extensionLights = extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ].lights;
+						var light = extensionLights[ node.extensions[ EXTENSIONS.KHR_MATERIALS_COMMON ].light ];
+
+						_node.add( light );
+
+					}
+
+					return _node;
+
+				} );
+
+			} );
+
+		} );
+
+	};
+
+	GLTFParser.prototype.loadScenes = function () {
+
+		var json = this.json;
+
+		// scene node hierachy builder
+
+		function buildNodeHierachy( nodeId, parentObject, allNodes ) {
+
+			var _node = allNodes[ nodeId ];
+			parentObject.add( _node );
+
+			var node = json.nodes[ nodeId ];
+
+			if ( node.children ) {
+
+				var children = node.children;
+
+				for ( var i = 0, l = children.length; i < l; i ++ ) {
+
+					var child = children[ i ];
+					buildNodeHierachy( child, _node, allNodes );
+
+				}
+
+			}
+
+		}
+
+		return this._withDependencies( [
+
+			"nodes"
+
+		] ).then( function ( dependencies ) {
+
+			return _each( json.scenes, function ( scene ) {
+
+				var _scene = new THREE.Scene();
+				if ( scene.name !== undefined ) _scene.name = scene.name;
+
+				if ( scene.extras ) _scene.userData = scene.extras;
+
+				var nodes = scene.nodes || [];
+
+				for ( var i = 0, l = nodes.length; i < l; i ++ ) {
+
+					var nodeId = nodes[ i ];
+					buildNodeHierachy( nodeId, _scene, dependencies.nodes );
+
+				}
+
+				_scene.traverse( function ( child ) {
+
+					// Register raw material meshes with LegacyGLTFLoader.Shaders
+					if ( child.material && child.material.isRawShaderMaterial ) {
+
+						child.gltfShader = new GLTFShader( child, dependencies.nodes );
+						child.onBeforeRender = function(renderer, scene, camera){
+							this.gltfShader.update(scene, camera);
+						};
+
+					}
+
+				} );
+
+				return _scene;
+
+			} );
+
+		} );
+
+	};
+
+	return LegacyGLTFLoader;
+
+} )();
+
+export var LegacyGLTFLoader = LegacyGLTFLoaderExport;

--- a/src/aux-server/aux-web/shared/public/three-legacy-gltf-loader/LegacyGLTFLoader.js
+++ b/src/aux-server/aux-web/shared/public/three-legacy-gltf-loader/LegacyGLTFLoader.js
@@ -23,7 +23,7 @@ let LegacyGLTFLoaderExport = ( function () {
 
 			var scope = this;
 
-			var path = this.path && ( typeof this.path === "string" ) ? this.path : THREE.Loader.prototype.extractUrlBase( url );
+			var path = this.path && ( typeof this.path === "string" ) ? this.path : THREE.LoaderUtils.extractUrlBase( url );
 
 			var loader = new THREE.FileLoader( scope.manager );
 
@@ -75,8 +75,6 @@ let LegacyGLTFLoaderExport = ( function () {
 
 			}
 
-			console.time( 'LegacyGLTFLoader' );
-
 			var parser = new GLTFParser( json, extensions, {
 
 				path: path || this.path,
@@ -85,8 +83,6 @@ let LegacyGLTFLoaderExport = ( function () {
 			} );
 
 			parser.parse( function ( scene, scenes, cameras, animations ) {
-
-				console.timeEnd( 'LegacyGLTFLoader' );
 
 				var glTF = {
 					"scene": scene,

--- a/src/aux-server/aux-web/shared/public/three-legacy-gltf-loader/index.d.ts
+++ b/src/aux-server/aux-web/shared/public/three-legacy-gltf-loader/index.d.ts
@@ -1,0 +1,20 @@
+import {
+    AnimationClip,
+    Camera,
+    LoadingManager,
+    Scene,
+  } from 'three';
+import {GLTF} from 'three/examples/jsm/loaders/GLTFLoader';
+  
+export class LegacyGLTFLoader {
+    constructor(manager?: LoadingManager);
+    manager: LoadingManager;
+    path: string;
+
+    load(url: string, onLoad: (gltf: GLTF) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void) : void;
+    setPath(path: string) : LegacyGLTFLoader;
+    setResourcePath(path: string) : LegacyGLTFLoader;
+    setCrossOrigin(value: string): LegacyGLTFLoader;
+    setDRACOLoader(dracoLoader: object): LegacyGLTFLoader;
+    parse(data: ArrayBuffer | string, path: string, onLoad: (gltf: GLTF) => void, onError?: (event: ErrorEvent) => void) : void;
+}

--- a/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
@@ -86,7 +86,7 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
         this.add(this.display);
 
         this.decorators = decoratorFactory.loadDecorators(this);
-        this._frameUpdateList = this.decorators.filter(d => !!d.frameUpdate);
+        this.updateFrameUpdateList();
     }
 
     /**
@@ -172,6 +172,10 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
             );
         }
         this._updatesInFrame = 0;
+    }
+
+    updateFrameUpdateList() {
+        this._frameUpdateList = this.decorators.filter(d => !!d.frameUpdate);
     }
 
     dispose() {

--- a/src/aux-server/aux-web/shared/scene/GLTFHelpers.ts
+++ b/src/aux-server/aux-web/shared/scene/GLTFHelpers.ts
@@ -1,8 +1,10 @@
 import { GLTFLoader, GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { LegacyGLTFLoader } from 'three-legacy-gltf-loader';
+import { Scene, AnimationClip } from 'three';
 
 const loader = new GLTFLoader();
 const legacy = new LegacyGLTFLoader();
+const pools = new Map<string, GLTFPool>();
 
 /**
  * Loads a GLTF file from the given URL using the new GLTF loader.
@@ -18,6 +20,56 @@ export function loadNewGLTF(url: string): Promise<GLTF> {
  */
 export function loadOldGLTF(url: string): Promise<GLTF> {
     return _loadGLTF(url, legacy);
+}
+
+/**
+ * Gets a GLTF Pool with the given name.
+ * @param name The name of the pool to load.
+ */
+export function getGLTFPool(name: string): GLTFPool {
+    let pool = pools.get(name);
+    if (!pool) {
+        pool = new GLTFPool();
+        pools.set(name, pool);
+    }
+    return pool;
+}
+
+/**
+ * Defines a class that represents a pool of GLTF meshes that were loaded.
+ */
+export class GLTFPool {
+    private _cache = new Map<string, Promise<GLTF>>();
+
+    async loadGLTF(
+        url: string,
+        useLegacyLoader: boolean = false
+    ): Promise<GLTF> {
+        let promise = this._cache.get(url);
+        if (!promise) {
+            promise = useLegacyLoader ? loadOldGLTF(url) : loadNewGLTF(url);
+            this._cache.set(url, promise);
+        }
+        const gltf = await promise;
+
+        return _cloneGLTF(gltf);
+    }
+}
+
+function _cloneGLTF(gltf: GLTF): GLTF {
+    const animations = gltf.animations.map(anim => {
+        const json = (<any>AnimationClip.toJSON)(anim);
+        return AnimationClip.parse(json);
+    });
+    const scene = gltf.scene.clone(true);
+
+    return {
+        asset: gltf.asset,
+        animations,
+        cameras: [],
+        scenes: [scene],
+        scene,
+    };
 }
 
 function _loadGLTF(

--- a/src/aux-server/aux-web/shared/scene/GLTFHelpers.ts
+++ b/src/aux-server/aux-web/shared/scene/GLTFHelpers.ts
@@ -1,0 +1,30 @@
+import { GLTFLoader, GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
+import { LegacyGLTFLoader } from 'three-legacy-gltf-loader';
+
+const loader = new GLTFLoader();
+const legacy = new LegacyGLTFLoader();
+
+/**
+ * Loads a GLTF file from the given URL using the new GLTF loader.
+ * @param url The url.
+ */
+export function loadNewGLTF(url: string): Promise<GLTF> {
+    return _loadGLTF(url, loader);
+}
+
+/**
+ * Loads a GLTF file from the given URl using the legacy loader.
+ * @param url The url.
+ */
+export function loadOldGLTF(url: string): Promise<GLTF> {
+    return _loadGLTF(url, legacy);
+}
+
+function _loadGLTF(
+    url: string,
+    loader: GLTFLoader | LegacyGLTFLoader
+): Promise<GLTF> {
+    return new Promise((resolve, reject) => {
+        loader.load(url, gltf => resolve(gltf), null, err => reject(err));
+    });
+}

--- a/src/aux-server/aux-web/shared/scene/PolyUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/PolyUtils.ts
@@ -1,0 +1,9 @@
+import { Simulation } from '@casual-simulation/aux-vm';
+import { calculateStringTagValue } from '@casual-simulation/aux-common';
+
+export function getPolyKey(sim: Simulation): string {
+    const calc = sim.helper.createContext();
+    const config = sim.helper.globalsBot;
+    const key = calculateStringTagValue(calc, config, 'polyApiKey', null);
+    return key;
+}

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -402,6 +402,17 @@ export function disposeObject3D(
 }
 
 /**
+ * Disposes of the entire scene.
+ * @param scene The scene to dispose.
+ */
+export function disposeScene(scene: Scene) {
+    if (!scene) {
+        return;
+    }
+    scene.traverse(obj => disposeObject3D(obj));
+}
+
+/**
  * Calculates the position and rotation that the given object should be placed at for the given anchor and position.
  * @param anchorBounds The bounds being anchored to.
  * @param anchorType The anchor type that will be calculated.

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -28,6 +28,7 @@ import {
     PerspectiveCamera,
     OrthographicCamera,
     Color,
+    MeshStandardMaterial,
 } from 'three';
 import flatMap from 'lodash/flatMap';
 import {
@@ -593,4 +594,25 @@ export function disposeHtmlMixerContext(
     parentElement: HTMLElement
 ) {
     parentElement.removeChild(mixerContext.rendererCss.domElement);
+}
+
+/**
+ * Changes the mesh's material to the given color.
+ * @param mesh The mesh.
+ * @param color The color.
+ */
+export function setColor(mesh: Mesh | Sprite, color: string) {
+    if (!mesh) {
+        return;
+    }
+    const shapeMat = <MeshStandardMaterial | MeshToonMaterial>mesh.material;
+    if (color) {
+        shapeMat.visible = !isTransparent(color);
+        if (shapeMat.visible) {
+            shapeMat.color = new Color(color);
+        }
+    } else {
+        shapeMat.visible = true;
+        shapeMat.color = new Color(0xffffff);
+    }
 }

--- a/src/aux-server/aux-web/shared/scene/debugobjectmanager/DebugObjectManager.ts
+++ b/src/aux-server/aux-web/shared/scene/debugobjectmanager/DebugObjectManager.ts
@@ -256,7 +256,7 @@ export namespace DebugObjectManager {
      * @param point The Vector3 to represent.
      * @param size How big the axes helper should be. Default is 1.
      * @param color The color the debug object should. Default is the color of axes that the lines represent (red, green, blue).
-     * @param duration How long the debug object should render for. Default is one frame.
+     * @param duration The number of seconds the point should render for. Default is one frame.
      */
     export function drawPoint(
         point: Vector3,

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -292,8 +292,7 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         box.getSize(size);
         const maxScale = Math.max(size.x, size.y, size.z);
         gltf.scene.scale.divideScalar(maxScale);
-        this.scene = this.collider = gltf.scene;
-        this.bot3D.colliders.push(this.collider);
+        this.scene = gltf.scene;
         this.container.add(gltf.scene);
         this.bot3D.updateMatrixWorld(true);
     }

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -39,6 +39,7 @@ import { GLTFLoader, GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { getPolyKey } from '../PolyUtils';
 import axios from 'axios';
 import { getGLTFPool } from '../GLTFHelpers';
+import { DebugObjectManager } from '../debugobjectmanager/DebugObjectManager';
 
 const gltfPool = getGLTFPool('main');
 
@@ -273,19 +274,32 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
     }
 
     private _setGltf(gltf: GLTF) {
+        // Positioning
         let box = new Box3();
         box.setFromObject(gltf.scene);
         let size = new Vector3();
         box.getSize(size);
+        let center = new Vector3();
+        box.getCenter(center);
         const maxScale = Math.max(size.x, size.y, size.z);
+        size.divideScalar(maxScale);
+        center.divideScalar(maxScale);
+
+        let bottomCenter = new Vector3(-center.x, -center.y, -center.z);
+
+        // Scene
         gltf.scene.scale.divideScalar(maxScale);
+        gltf.scene.position.copy(bottomCenter);
         this.scene = gltf.scene;
-        const collider = (this.collider = createCube(0.8));
-        this.collider.position.set(0, 0.25, 0);
+        this.container.add(gltf.scene);
+
+        // Collider
+        const collider = (this.collider = createCube(1));
+        this.collider.scale.copy(size);
         setColor(collider, 'clear');
         this.container.add(this.collider);
         this.bot3D.colliders.push(this.collider);
-        this.container.add(gltf.scene);
+
         this.bot3D.updateMatrixWorld(true);
     }
 

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -37,7 +37,9 @@ import { ArgEvent } from '@casual-simulation/aux-common/Events';
 import { GLTFLoader, GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { getPolyKey } from '../PolyUtils';
 import axios from 'axios';
-import { loadNewGLTF, loadOldGLTF } from '../GLTFHelpers';
+import { getGLTFPool } from '../GLTFHelpers';
+
+const gltfPool = getGLTFPool('main');
 
 export class BotShapeDecorator extends AuxBot3DDecoratorBase
     implements IMeshDecorator {
@@ -273,9 +275,7 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
 
     private async _loadGLTF(url: string, legacy: boolean) {
         try {
-            const gltf = !legacy
-                ? await loadNewGLTF(url)
-                : await loadOldGLTF(url);
+            const gltf = await gltfPool.loadGLTF(url, legacy);
             this._setGltf(gltf);
         } catch (err) {
             console.error(

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -31,6 +31,7 @@ import {
     createSprite,
     disposeScene,
     disposeObject3D,
+    setColor,
 } from '../SceneUtils';
 import { IMeshDecorator } from './IMeshDecorator';
 import { ArgEvent } from '@casual-simulation/aux-common/Events';
@@ -174,21 +175,7 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
     }
 
     private _setColor(color: any) {
-        if (!this.mesh) {
-            return;
-        }
-        const shapeMat = <MeshStandardMaterial | MeshToonMaterial>(
-            this.mesh.material
-        );
-        if (color) {
-            shapeMat.visible = !isTransparent(color);
-            if (shapeMat.visible) {
-                shapeMat.color = new Color(color);
-            }
-        } else {
-            shapeMat.visible = true;
-            shapeMat.color = new Color(0xffffff);
-        }
+        setColor(this.mesh, color);
     }
 
     private _rebuildShape(
@@ -293,6 +280,11 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         const maxScale = Math.max(size.x, size.y, size.z);
         gltf.scene.scale.divideScalar(maxScale);
         this.scene = gltf.scene;
+        const collider = (this.collider = createCube(0.8));
+        this.collider.position.set(0, 0.25, 0);
+        setColor(collider, 'clear');
+        this.container.add(this.collider);
+        this.bot3D.colliders.push(this.collider);
         this.container.add(gltf.scene);
         this.bot3D.updateMatrixWorld(true);
     }

--- a/src/aux-server/aux-web/shared/scene/decorators/IMeshDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/IMeshDecorator.ts
@@ -8,6 +8,12 @@ export interface IMeshDecorator {
     mesh: Mesh | Sprite;
 
     /**
+     * Whether additional modifications to the mesh
+     * are allowed.
+     */
+    allowModifications: boolean;
+
+    /**
      * Event that gets fired when the mesh is updated.
      */
     onMeshUpdated: ArgEvent<IMeshDecorator>;

--- a/src/aux-server/aux-web/shared/scene/decorators/OutlineDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/OutlineDecorator.ts
@@ -51,6 +51,10 @@ export class OutlineDecorator extends AuxBot3DDecoratorBase
      */
     color: string = DEFAULT_OUTLINE_COLOR;
 
+    get allowModifications() {
+        return true;
+    }
+
     onMeshUpdated: ArgEvent<IMeshDecorator> = new ArgEvent<IMeshDecorator>();
 
     private _targetMeshDecorator: IMeshDecorator;

--- a/src/aux-server/aux-web/shared/scene/decorators/ProgressBarDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/ProgressBarDecorator.ts
@@ -37,6 +37,10 @@ export class ProgressBarDecorator extends AuxBot3DDecoratorBase
 
     onMeshUpdated: ArgEvent<IMeshDecorator> = new ArgEvent<IMeshDecorator>();
 
+    get allowModifications() {
+        return true;
+    }
+
     private _anchor: BotLabelAnchor = 'top';
     private _targetMeshDecorator: IMeshDecorator;
 

--- a/src/aux-server/aux-web/shared/scene/decorators/TextureDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/TextureDecorator.ts
@@ -10,6 +10,7 @@ import {
     BotCalculationContext,
     calculateBotValue,
     hasValue,
+    getBotShape,
 } from '@casual-simulation/aux-common';
 import { AuxBot3DDecorator, AuxBot3DDecoratorBase } from '../AuxBot3DDecorator';
 import { AuxBot3D } from '../AuxBot3D';
@@ -108,6 +109,10 @@ export class TextureDecorator extends AuxBot3DDecoratorBase {
     }
 
     private _updateTargetMeshTexture(): void {
+        if (!this._targetMeshDecorator.allowModifications) {
+            return;
+        }
+
         let material = <
             | MeshBasicMaterial
             | MeshToonMaterial

--- a/src/aux-server/aux-web/shared/scene/decorators/UserMeshDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/UserMeshDecorator.ts
@@ -36,6 +36,10 @@ export class UserMeshDecorator extends AuxBot3DDecoratorBase
      */
     container: Group;
 
+    get allowModifications() {
+        return true;
+    }
+
     onMeshUpdated: ArgEvent<IMeshDecorator> = new ArgEvent<IMeshDecorator>();
 
     constructor(bot3D: AuxBot3D) {

--- a/src/aux-server/aux-web/shared/scene/decorators/WordBubbleDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/WordBubbleDecorator.ts
@@ -46,21 +46,26 @@ export class WordBubbleDecorator extends AuxBot3DDecoratorBase {
     }
 
     private _updateWorldBubble(calc: BotCalculationContext): void {
-        let botBoundingBox = this.bot3D.boundingBox;
-        if (!botBoundingBox) {
-            this.bot3D.remove(this.wordBubble);
-            this.wordBubble.visible = false;
-            return;
-        }
-
         let anchor = getBotLabelAnchor(calc, this.bot3D.bot);
         const wasVisible = this.wordBubble.visible;
-        this.wordBubble.visible = anchor === 'floating';
+
+        const hasBubble = (this.wordBubble.visible = anchor === 'floating');
         if (wasVisible && !this.wordBubble.visible) {
             this.bot3D.remove(this.wordBubble);
         } else if (!wasVisible && this.wordBubble.visible) {
             this.bot3D.add(this.wordBubble);
             this.wordBubble.updateMatrixWorld(true);
+        }
+
+        if (!hasBubble) {
+            return;
+        }
+
+        let botBoundingBox = this.bot3D.boundingBox;
+        if (!botBoundingBox) {
+            this.bot3D.remove(this.wordBubble);
+            this.wordBubble.visible = false;
+            return;
         }
 
         let arrowPoint = new Vector3();

--- a/src/aux-server/aux-web/webpack.common.js
+++ b/src/aux-server/aux-web/webpack.common.js
@@ -129,6 +129,10 @@ module.exports = {
                 __dirname,
                 'shared/public/three-bmfont-text/'
             ),
+            'three-legacy-gltf-loader': path.resolve(
+                __dirname,
+                'shared/public/three-legacy-gltf-loader/LegacyGLTFLoader.js'
+            ),
             'layout-bmfont-text': path.resolve(
                 __dirname,
                 'shared/public/layout-bmfont-text/index.js'

--- a/src/aux-server/tsconfig.json
+++ b/src/aux-server/tsconfig.json
@@ -6,6 +6,9 @@
         "paths": {
             "vue-json-tree-view": [
                 "aux-web/shared/public/VueJsonTreeView/index.ts"
+            ],
+            "three-legacy-gltf-loader": [
+                "aux-web/shared/public/three-legacy-gltf-loader/index.d.ts"
             ]
         },
         "lib": ["es2015", "es5", "dom", "webworker"]


### PR DESCRIPTION
#### :rocket: Features

-   Added the ability to load GLTF and [poly.google.com](https://poly.google.com) meshes.
    -   To load a GLTF model from a URL:
        -   Set `#auxForm` to `mesh`.
        -   Set `#auxFormSubtype` to `gltf`.
        -   Set `#auxFormAddress` to the URL.
    -   To load a model from [poly.google.com](https://poly.google.com):
        -   Set `#auxForm` to `mesh`.
        -   Set `#auxFormSubtype` to `poly`.
        -   Set `#auxFormAddress` to the ID of the model.