### PR TITLE
Added support for config bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
     -   To load meshes from poly.google.com, you must make the API requests manually.
     -   See https://casualos.com/home/google-poly-example for an example.
 
+#### :rocket: Improvements
+
+-   Added the `config`, `configTag`, and `tagName` variables.
+    -   These variables are useful for creating values and scripts that are shared across multiple bots.
+    -   The `config` variable is a shortcut for `getBot("#id", tags.auxConfigBot)`.
+    -   The `tagName` variable is the name of the tag that the script is running in.
+    -   The `configTag` variable is a shortcut for `config.tags[tagName]`.
+
 ## V1.0.5
 
 ### Date: 2/14/2020

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -184,6 +184,11 @@ Determines whether this bot responds to whispers or shouts. If this tag is set t
   </PossibleValueCode>
 </PossibleValuesTable>
 
+### `auxConfigBot`
+
+The ID of the bot that "configures" this bot.
+When set, the `config` variable will be available in scripts and formulas as a shortcut to the specified bot.
+
 ## Visualization Tags
 
 ### `auxColor`

--- a/src/aux-common/Formulas/Dependencies.spec.ts
+++ b/src/aux-common/Formulas/Dependencies.spec.ts
@@ -7,6 +7,7 @@ import {
     AuxScriptSimpleFunctionDependency,
     AuxScriptReplacements,
     AuxScriptSimpleMemberDependency,
+    tagNameSymbol,
 } from './Dependencies';
 
 describe('Dependencies', () => {
@@ -33,11 +34,13 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'num',
+                            reference: null,
                             object: {
                                 type: type,
                                 identifier: {
                                     type: 'member',
                                     identifier: symbol,
+                                    reference: null,
                                     object: null,
                                 },
                                 dependencies: [
@@ -51,11 +54,13 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'num',
+                            reference: null,
                             object: {
                                 type: type,
                                 identifier: {
                                     type: 'member',
                                     identifier: symbol,
+                                    reference: null,
                                     object: null,
                                 },
                                 dependencies: [
@@ -81,11 +86,13 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'num',
+                            reference: null,
                             object: {
                                 type: type,
                                 identifier: {
                                     type: 'member',
                                     identifier: symbol,
+                                    reference: null,
                                     object: null,
                                 },
                                 dependencies: [
@@ -113,6 +120,7 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: symbol,
+                                reference: null,
                                 object: null,
                             },
                             dependencies: [
@@ -147,6 +155,7 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: symbol,
+                                reference: null,
                                 object: null,
                             },
                             dependencies: [
@@ -162,9 +171,11 @@ describe('Dependencies', () => {
                                             identifier: {
                                                 type: 'member',
                                                 identifier: 'indexOf',
+                                                reference: null,
                                                 object: {
                                                     type: 'member',
                                                     identifier: 'x',
+                                                    reference: null,
                                                     object: null,
                                                 },
                                             },
@@ -200,6 +211,7 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: symbol,
+                                reference: null,
                                 object: null,
                             },
                             dependencies: [
@@ -222,6 +234,7 @@ describe('Dependencies', () => {
                                 {
                                     type: 'member',
                                     identifier: 'isBuilder',
+                                    reference: null,
                                     object: null,
                                 },
                             ],
@@ -241,14 +254,17 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'second',
+                            reference: null,
                             object: {
                                 type: 'member',
                                 identifier: 'first',
+                                reference: null,
                                 object: {
                                     type: type,
                                     identifier: {
                                         type: 'member',
                                         identifier: symbol,
+                                        reference: null,
                                         object: null,
                                     },
                                     dependencies: [
@@ -275,11 +291,13 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'funny',
+                            reference: null,
                             object: {
                                 type: type,
                                 identifier: {
                                     type: 'member',
                                     identifier: symbol,
+                                    reference: null,
                                     object: null,
                                 },
                                 dependencies: [
@@ -315,9 +333,11 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: 'sum',
+                                reference: null,
                                 object: {
                                     type: 'member',
                                     identifier: 'math',
+                                    reference: null,
                                     object: null,
                                 },
                             },
@@ -325,11 +345,13 @@ describe('Dependencies', () => {
                                 {
                                     type: 'member',
                                     identifier: 'length',
+                                    reference: null,
                                     object: {
                                         type: type,
                                         identifier: {
                                             type: 'member',
                                             identifier: symbol,
+                                            reference: null,
                                             object: null,
                                         },
                                         dependencies: [
@@ -359,11 +381,13 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: 'filter',
+                                reference: null,
                                 object: {
                                     type: type,
                                     identifier: {
                                         type: 'member',
                                         identifier: symbol,
+                                        reference: null,
                                         object: null,
                                     },
                                     dependencies: [
@@ -393,6 +417,7 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: symbol,
+                                reference: null,
                                 object: null,
                             },
                             dependencies: [
@@ -406,14 +431,17 @@ describe('Dependencies', () => {
                                         {
                                             type: 'member',
                                             identifier: 'x',
+                                            reference: null,
                                             object: null,
                                         },
                                         {
                                             type: 'member',
                                             identifier: 'val',
+                                            reference: null,
                                             object: {
                                                 type: 'member',
                                                 identifier: 'this',
+                                                reference: null,
                                                 object: null,
                                             },
                                         },
@@ -438,6 +466,7 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: symbol,
+                                reference: null,
                                 object: null,
                             },
                             dependencies: [
@@ -451,14 +480,17 @@ describe('Dependencies', () => {
                                         {
                                             type: 'member',
                                             identifier: 'x',
+                                            reference: null,
                                             object: null,
                                         },
                                         {
                                             type: 'member',
                                             identifier: 'val',
+                                            reference: null,
                                             object: {
                                                 type: 'member',
                                                 identifier: 'this',
+                                                reference: null,
                                                 object: null,
                                             },
                                         },
@@ -483,30 +515,37 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'num',
+                            reference: null,
                             object: {
                                 type: 'member',
                                 identifier: 'this',
+                                reference: null,
                                 object: null,
                             },
                         },
                         {
                             type: 'member',
                             identifier: 'index',
+                            reference: null,
                             object: {
                                 type: 'member',
                                 identifier: 'this',
+                                reference: null,
                                 object: null,
                             },
                         },
                         {
                             type: 'member',
                             identifier: 'else',
+                            reference: null,
                             object: {
                                 type: 'member',
                                 identifier: 'something',
+                                reference: null,
                                 object: {
                                     type: 'member',
                                     identifier: 'this',
+                                    reference: null,
                                     object: null,
                                 },
                             },
@@ -514,12 +553,15 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'thing',
+                            reference: null,
                             object: {
                                 type: 'member',
                                 identifier: 'other',
+                                reference: null,
                                 object: {
                                     type: 'member',
                                     identifier: 'this',
+                                    reference: null,
                                     object: null,
                                 },
                             },
@@ -537,6 +579,7 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'this',
+                            reference: null,
                             object: null,
                         },
                     ],
@@ -554,6 +597,7 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'abc',
+                            reference: null,
                             object: null,
                         },
                     ],
@@ -570,9 +614,11 @@ describe('Dependencies', () => {
 
                             // Should be null because we can't figure out the name
                             identifier: null,
+                            reference: 'def',
                             object: {
                                 type: 'member',
                                 identifier: 'abc',
+                                reference: null,
                                 object: null,
                             },
                         },
@@ -590,9 +636,11 @@ describe('Dependencies', () => {
 
                             // Should be null because we can't figure out the name
                             identifier: null,
+                            reference: null,
                             object: {
                                 type: 'member',
                                 identifier: 'abc',
+                                reference: null,
                                 object: null,
                             },
                         },
@@ -615,6 +663,7 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: 'getBotsInContext',
+                                reference: null,
                                 object: null,
                             },
                             dependencies: [
@@ -641,15 +690,18 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: 'getBotsInContext',
+                                reference: null,
                                 object: null,
                             },
                             dependencies: [
                                 {
                                     type: 'member',
                                     identifier: 'abc',
+                                    reference: null,
                                     object: {
                                         type: 'member',
                                         identifier: 'this',
+                                        reference: null,
                                         object: null,
                                     },
                                 },
@@ -676,9 +728,11 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: 'toast',
+                                reference: null,
                                 object: {
                                     type: 'member',
                                     identifier: 'player',
+                                    reference: null,
                                     object: null,
                                 },
                             },
@@ -686,9 +740,11 @@ describe('Dependencies', () => {
                                 {
                                     type: 'member',
                                     identifier: 'abc',
+                                    reference: null,
                                     object: {
                                         type: 'member',
                                         identifier: 'this',
+                                        reference: null,
                                         object: null,
                                     },
                                 },
@@ -709,9 +765,11 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: 'toast',
+                                reference: null,
                                 object: {
                                     type: 'member',
                                     identifier: 'player',
+                                    reference: null,
                                     object: null,
                                 },
                             },
@@ -719,6 +777,7 @@ describe('Dependencies', () => {
                                 {
                                     type: 'member',
                                     identifier: 'abc',
+                                    reference: null,
                                     object: null,
                                 },
                             ],
@@ -738,14 +797,17 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'test',
+                            reference: null,
                             object: {
                                 type: 'call',
                                 identifier: {
                                     type: 'member',
                                     identifier: 'toast',
+                                    reference: null,
                                     object: {
                                         type: 'member',
                                         identifier: 'player',
+                                        reference: null,
                                         object: null,
                                     },
                                 },
@@ -753,6 +815,7 @@ describe('Dependencies', () => {
                                     {
                                         type: 'member',
                                         identifier: 'abc',
+                                        reference: null,
                                         object: null,
                                     },
                                 ],
@@ -775,6 +838,7 @@ describe('Dependencies', () => {
                             identifier: {
                                 type: 'member',
                                 identifier: 'toast',
+                                reference: null,
                                 object: null,
                             },
                             dependencies: [
@@ -790,6 +854,7 @@ describe('Dependencies', () => {
                                             identifier: {
                                                 type: 'member',
                                                 identifier: 'getBots',
+                                                reference: null,
                                                 object: null,
                                             },
                                             dependencies: [
@@ -804,6 +869,7 @@ describe('Dependencies', () => {
                                             identifier: {
                                                 type: 'member',
                                                 identifier: 'func',
+                                                reference: null,
                                                 object: null,
                                             },
                                             dependencies: [],
@@ -871,9 +937,11 @@ describe('Dependencies', () => {
                         identifier: {
                             type: 'member',
                             identifier: 'abc',
+                            reference: null,
                             object: {
                                 type: 'member',
                                 identifier: 'test',
+                                reference: null,
                                 object: null,
                             },
                         },
@@ -900,9 +968,11 @@ describe('Dependencies', () => {
                         identifier: {
                             type: 'member',
                             identifier: 'abc',
+                            reference: null,
                             object: {
                                 type: 'member',
                                 identifier: 'test',
+                                reference: null,
                                 object: null,
                             },
                         },
@@ -910,18 +980,22 @@ describe('Dependencies', () => {
                             {
                                 type: 'member',
                                 identifier: 'xyz',
+                                reference: null,
                                 object: {
                                     type: 'member',
                                     identifier: 'this',
+                                    reference: null,
                                     object: null,
                                 },
                             },
                             {
                                 type: 'member',
                                 identifier: 'def',
+                                reference: null,
                                 object: {
                                     type: 'member',
                                     identifier: 'this',
+                                    reference: null,
                                     object: null,
                                 },
                             },
@@ -963,6 +1037,7 @@ describe('Dependencies', () => {
                         identifier: {
                             type: 'member',
                             identifier: 'toast',
+                            reference: null,
                             object: null,
                         },
                         dependencies: [
@@ -983,6 +1058,7 @@ describe('Dependencies', () => {
                                         identifier: {
                                             type: 'member',
                                             identifier: 'func',
+                                            reference: null,
                                             object: null,
                                         },
                                         dependencies: [],
@@ -1027,6 +1103,7 @@ describe('Dependencies', () => {
                         identifier: {
                             type: 'member',
                             identifier: 'abc',
+                            reference: null,
                             object: {
                                 type: 'tag',
                                 name: 'test',
@@ -1037,6 +1114,7 @@ describe('Dependencies', () => {
                             {
                                 type: 'member',
                                 identifier: 'def',
+                                reference: null,
                                 object: null,
                             },
                         ],
@@ -1053,6 +1131,7 @@ describe('Dependencies', () => {
                 {
                     type: 'member',
                     name: 'def',
+                    reference: null,
                     dependencies: [],
                 },
             ]);
@@ -1065,9 +1144,11 @@ describe('Dependencies', () => {
                     {
                         type: 'member',
                         identifier: 'abc',
+                        reference: null,
                         object: {
                             type: 'member',
                             identifier: 'test',
+                            reference: null,
                             object: null,
                         },
                     },
@@ -1078,10 +1159,12 @@ describe('Dependencies', () => {
                 {
                     type: 'member',
                     name: 'test',
+                    reference: null,
                     dependencies: [
                         {
                             type: 'member',
                             name: 'abc',
+                            reference: null,
                             dependencies: [],
                         },
                     ],
@@ -1096,9 +1179,11 @@ describe('Dependencies', () => {
                     {
                         type: 'member',
                         identifier: 'abc',
+                        reference: null,
                         object: {
                             type: 'member',
                             identifier: 'test.other',
+                            reference: null,
                             object: null,
                         },
                     },
@@ -1109,10 +1194,12 @@ describe('Dependencies', () => {
                 {
                     type: 'member',
                     name: 'test.other',
+                    reference: null,
                     dependencies: [
                         {
                             type: 'member',
                             name: 'abc',
+                            reference: null,
                             dependencies: [],
                         },
                     ],
@@ -1132,9 +1219,11 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             identifier: 'abc',
+                            reference: null,
                             object: {
                                 type: 'member',
                                 identifier: 'test',
+                                reference: null,
                                 object: {
                                     type: type,
                                     name: 'hello',
@@ -1165,6 +1254,7 @@ describe('Dependencies', () => {
                                 {
                                     type: 'member',
                                     identifier: 'isBuilder',
+                                    reference: null,
                                     object: null,
                                 },
                                 {
@@ -1172,9 +1262,11 @@ describe('Dependencies', () => {
                                     identifier: {
                                         type: 'member',
                                         identifier: 'isBuilder',
+                                        reference: null,
                                         object: {
                                             type: 'member',
                                             identifier: 'player',
+                                            reference: null,
                                             object: null,
                                         },
                                     },
@@ -1193,6 +1285,7 @@ describe('Dependencies', () => {
                             {
                                 type: 'member',
                                 name: 'isBuilder',
+                                reference: null,
                                 dependencies: [],
                             },
                             {
@@ -1212,6 +1305,7 @@ describe('Dependencies', () => {
             const result = dependencies.getMemberName({
                 type: 'member',
                 identifier: 'abc',
+                reference: null,
                 object: null,
             });
 
@@ -1222,9 +1316,11 @@ describe('Dependencies', () => {
             const result = dependencies.getMemberName({
                 type: 'member',
                 identifier: 'abc',
+                reference: null,
                 object: {
                     type: 'member',
                     identifier: 'def',
+                    reference: null,
                     object: null,
                 },
             });
@@ -1236,11 +1332,13 @@ describe('Dependencies', () => {
             const result = dependencies.getMemberName({
                 type: 'member',
                 identifier: 'abc',
+                reference: null,
                 object: {
                     type: 'call',
                     identifier: {
                         type: 'member',
                         identifier: 'def',
+                        reference: null,
                         object: null,
                     },
                     dependencies: [],
@@ -1260,9 +1358,11 @@ describe('Dependencies', () => {
                 const result = dependencies.getMemberName({
                     type: 'member',
                     identifier: 'abc',
+                    reference: null,
                     object: {
                         type: 'member',
                         identifier: 'def',
+                        reference: null,
                         object: {
                             type: type,
                             name: 'tag.abc',
@@ -1371,6 +1471,7 @@ describe('Dependencies', () => {
                                 {
                                     type: 'member',
                                     name: 'myVar',
+                                    reference: null,
                                     dependencies: [],
                                 },
                             ],
@@ -1430,6 +1531,7 @@ describe('Dependencies', () => {
                 {
                     type: 'member',
                     name: 'a',
+                    reference: null,
                     dependencies: [],
                 },
                 {
@@ -1439,7 +1541,7 @@ describe('Dependencies', () => {
                 {
                     type: 'member',
                     name: 'a',
-
+                    reference: null,
                     dependencies: [],
                 },
                 {
@@ -1469,6 +1571,7 @@ describe('Dependencies', () => {
                 {
                     type: 'member',
                     name: 'abc',
+                    reference: null,
                     dependencies: [],
                 },
                 {
@@ -1503,6 +1606,7 @@ describe('Dependencies', () => {
                                 {
                                     type: 'member',
                                     name: 'this',
+                                    reference: null,
                                     dependencies: [],
                                 },
                             ],
@@ -1536,6 +1640,7 @@ describe('Dependencies', () => {
                 {
                     type: 'member',
                     name: 'abc',
+                    reference: null,
                     dependencies: [],
                 },
                 {
@@ -1579,6 +1684,7 @@ describe('Dependencies', () => {
                                 {
                                     type: 'member',
                                     name: 'this',
+                                    reference: null,
                                     dependencies: [],
                                 },
                             ],
@@ -1597,6 +1703,7 @@ describe('Dependencies', () => {
                         {
                             type: 'member',
                             name: 'this',
+                            reference: null,
                             dependencies: [],
                         },
                     ],
@@ -1604,6 +1711,7 @@ describe('Dependencies', () => {
                 {
                     type: 'member',
                     name: 'this',
+                    reference: null,
                     dependencies: [],
                 },
                 {
@@ -1713,6 +1821,7 @@ describe('Dependencies', () => {
                     {
                         type: 'member',
                         name: name,
+                        reference: null,
                         dependencies: [],
                     },
                 ]);
@@ -1782,6 +1891,7 @@ describe('Dependencies', () => {
                     {
                         type: 'member',
                         name: 'getBotTagValues',
+                        reference: null,
                         dependencies: [],
                     },
                 ]);
@@ -1815,10 +1925,12 @@ describe('Dependencies', () => {
                     {
                         type: 'member',
                         name: 'player',
+                        reference: null,
                         dependencies: [
                             {
                                 type: 'member',
                                 name: 'hasBotInInventory',
+                                reference: null,
                                 dependencies: [],
                             },
                         ],
@@ -1885,10 +1997,12 @@ describe('Dependencies', () => {
                     {
                         type: 'member',
                         name: names[0],
+                        reference: null,
                         dependencies: [
                             {
                                 type: 'member',
                                 name: names[1],
+                                reference: null,
                                 dependencies: [],
                             },
                         ],
@@ -1910,7 +2024,12 @@ describe('Dependencies', () => {
                         type: 'tag_value',
                         name: 'abc.xyz',
                         dependencies: [
-                            { type: 'member', name: 'myVar', dependencies: [] },
+                            {
+                                type: 'member',
+                                name: 'myVar',
+                                reference: null,
+                                dependencies: [],
+                            },
                         ],
                     },
                 ]);
@@ -1928,7 +2047,12 @@ describe('Dependencies', () => {
                         type: 'tag_value',
                         name: 'abc.xyz',
                         dependencies: [
-                            { type: 'member', name: 'myVar', dependencies: [] },
+                            {
+                                type: 'member',
+                                name: 'myVar',
+                                reference: null,
+                                dependencies: [],
+                            },
                         ],
                     },
                     {
@@ -1948,6 +2072,7 @@ describe('Dependencies', () => {
                     {
                         type: 'member',
                         name: 'getTag',
+                        reference: null,
                         dependencies: [],
                     },
                 ]);
@@ -2070,6 +2195,7 @@ describe('Dependencies', () => {
                     {
                         type: 'member',
                         name: 'ref',
+                        reference: null,
                         dependencies: [
                             {
                                 type: 'tag_value',
@@ -2081,7 +2207,7 @@ describe('Dependencies', () => {
                 ]);
             });
 
-            it.skip('should support using the tagName variable in an indexer', () => {
+            it('should support using the tagName variable in an indexer', () => {
                 const tree = dependencies.dependencyTree(`${name}[tagName]`);
                 const simple = dependencies.simplify(tree);
                 const replaced = dependencies.replaceAuxDependencies(simple);
@@ -2089,10 +2215,25 @@ describe('Dependencies', () => {
                 expect(replaced).toEqual([
                     {
                         type: 'tag_value',
+                        name: tagNameSymbol,
                         dependencies: [],
                     },
                 ]);
             });
+        });
+
+        it('should support using the tagName variable as a normal variable', () => {
+            const tree = dependencies.dependencyTree(`tagName`);
+            const simple = dependencies.simplify(tree);
+            const replaced = dependencies.replaceAuxDependencies(simple);
+
+            expect(replaced).toEqual([
+                {
+                    type: 'tag_value',
+                    name: tagNameSymbol,
+                    dependencies: [],
+                },
+            ]);
         });
 
         const botTagDependencyCases = [
@@ -2128,10 +2269,12 @@ describe('Dependencies', () => {
                             {
                                 type: 'member',
                                 name: 'prop',
+                                reference: null,
                                 dependencies: [
                                     {
                                         type: 'member',
                                         name: 'abc',
+                                        reference: null,
                                         dependencies: [],
                                     },
                                 ],
@@ -2177,6 +2320,7 @@ describe('Dependencies', () => {
             expect(replaced).toEqual([
                 {
                     type: 'tag_value',
+                    name: tagNameSymbol,
                     dependencies: [],
                 },
             ]);
@@ -2212,7 +2356,12 @@ describe('Dependencies', () => {
                     type: 'tag_value',
                     name: 'def',
                     dependencies: [
-                        { type: 'member', name: 'abc', dependencies: [] },
+                        {
+                            type: 'member',
+                            name: 'abc',
+                            reference: null,
+                            dependencies: [],
+                        },
                     ],
                 },
             ]);

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -139,6 +139,7 @@ export interface BotTags {
     ['auxIframeElementWidth']?: number;
     ['auxIframeScale']?: number;
     ['auxCreator']?: string;
+    ['auxConfigBot']?: string;
     ['auxProgressBar']?: unknown;
     ['auxProgressBarColor']?: unknown;
     ['auxProgressBarBackgroundColor']?: unknown;
@@ -196,8 +197,6 @@ export interface BotTags {
     ['auxInventoryPortalResizable']?: boolean;
 
     // Stripe tags
-    ['stripePublishableKey']?: string;
-    ['stripeSecretKey']?: string;
     ['stripeCharges']?: boolean;
     ['stripeSuccessfulCharges']?: boolean;
     ['stripeFailedCharges']?: boolean;
@@ -698,6 +697,7 @@ export const KNOWN_TAGS: string[] = [
 
     'auxColor',
     'auxCreator',
+    'auxConfigBot',
     'auxDraggable',
     'auxDraggableMode',
     'auxPositioningMode',

--- a/src/aux-common/bots/BotActions.ts
+++ b/src/aux-common/bots/BotActions.ts
@@ -156,7 +156,7 @@ export function calculateFormulaEvents(
         sandboxFactory
     );
 
-    let [botEvents] = formulaActions(context, null, null, [formula]);
+    let [botEvents] = formulaActions(context, null, null, formula);
 
     return [...botEvents, ...context.sandbox.interface.getBotUpdates()];
 }

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -2396,10 +2396,22 @@ export function convertToCopiableValue(value: any): any {
 }
 
 export function getCreatorVariable(context: BotSandboxContext, bot: ScriptBot) {
+    return getBotVariable(context, bot, 'auxCreator');
+}
+
+export function getConfigVariable(context: BotSandboxContext, bot: ScriptBot) {
+    return getBotVariable(context, bot, 'auxConfigBot');
+}
+
+export function getBotVariable(
+    context: BotSandboxContext,
+    bot: ScriptBot,
+    tag: string
+): ScriptBot {
     if (!bot) {
         return null;
     }
-    let creatorId = context.sandbox.interface.getTag(bot, 'auxCreator');
+    let creatorId = context.sandbox.interface.getTag(bot, tag);
     if (creatorId) {
         let obj = context.sandbox.interface.getBot(creatorId);
         if (obj) {

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -2403,6 +2403,15 @@ export function getConfigVariable(context: BotSandboxContext, bot: ScriptBot) {
     return getBotVariable(context, bot, 'auxConfigBot');
 }
 
+export function getConfigTagVariable(
+    context: BotSandboxContext,
+    bot: ScriptBot,
+    tag: keyof BotTags,
+    config: ScriptBot
+) {
+    return config && tag ? config.tags[tag] : null;
+}
+
 export function getBotVariable(
     context: BotSandboxContext,
     bot: ScriptBot,
@@ -2442,11 +2451,16 @@ function _calculateFormulaValue(
     const scriptBot = getScriptBot(context, object);
     setCurrentBot(scriptBot);
 
+    const creator = getCreatorVariable(context, scriptBot);
+    const config = getConfigVariable(context, scriptBot);
     let vars = {
         bot: scriptBot,
         tags: scriptBot ? scriptBot.tags : null,
         raw: scriptBot ? scriptBot.raw : null,
-        creator: getCreatorVariable(context, scriptBot),
+        tagName: tag || null,
+        creator: creator,
+        config: config,
+        configTag: getConfigTagVariable(context, scriptBot, tag, config),
     };
 
     // NOTE: The energy should not get reset

--- a/src/aux-common/bots/BotsChannel.ts
+++ b/src/aux-common/bots/BotsChannel.ts
@@ -17,6 +17,7 @@ import {
     isBot,
     isScript,
     parseScript,
+    getConfigVariable,
 } from './BotCalculations';
 import {
     getActions,
@@ -207,6 +208,7 @@ export function formulaActions(
         vars['tags'] = scriptBot ? scriptBot.tags : null;
         vars['raw'] = scriptBot ? scriptBot.raw : null;
         vars['creator'] = getCreatorVariable(context, scriptBot);
+        vars['config'] = getConfigVariable(context, scriptBot);
 
         for (let script of scripts) {
             const result = context.sandbox.run(script, {}, scriptBot, vars);

--- a/src/aux-common/bots/BotsChannel.ts
+++ b/src/aux-common/bots/BotsChannel.ts
@@ -18,6 +18,7 @@ import {
     isScript,
     parseScript,
     getConfigVariable,
+    getConfigTagVariable,
 } from './BotCalculations';
 import {
     getActions,
@@ -219,7 +220,12 @@ export function formulaActions(
         vars['tagName'] = tag || null;
         vars['creator'] = getCreatorVariable(context, scriptBot);
         const config = (vars['config'] = getConfigVariable(context, scriptBot));
-        vars['configTag'] = config && tag ? config.tags[tag] : null;
+        vars['configTag'] = getConfigTagVariable(
+            context,
+            scriptBot,
+            tag,
+            config
+        );
 
         const result = context.sandbox.run(script, {}, scriptBot, vars);
         if (result.error) {

--- a/src/aux-common/bots/BotsChannel.ts
+++ b/src/aux-common/bots/BotsChannel.ts
@@ -162,21 +162,30 @@ function eventActions(
         return;
     }
 
-    const scripts = [calculateBotValue(context, bot, eventName)]
-        .map(parseScript)
-        .filter(hasValue)
-        .map(script => `(function() { \n${script.toString()}\n }).call(this)`);
+    const rawScript = calculateBotValue(context, bot, eventName);
+    const parsed = parseScript(rawScript);
+    if (!hasValue(parsed)) {
+        return [[], [], false];
+    }
+    const final = `(function() { \n${parsed.toString()}\n }).call(this)`;
 
-    const [events, results] = formulaActions(context, bot, argument, scripts);
+    const [events, results] = formulaActions(
+        context,
+        bot,
+        argument,
+        final,
+        eventName
+    );
 
-    return [events, results, scripts.length > 0];
+    return [events, results, true];
 }
 
 export function formulaActions(
     context: BotSandboxContext,
     thisObject: Bot,
     arg: any,
-    scripts: string[]
+    script: string,
+    tag?: string
 ): [BotAction[], any[]] {
     let previous = getActions();
     let prevContext = getCalculationContext();
@@ -207,16 +216,16 @@ export function formulaActions(
         vars['bot'] = scriptBot;
         vars['tags'] = scriptBot ? scriptBot.tags : null;
         vars['raw'] = scriptBot ? scriptBot.raw : null;
+        vars['tagName'] = tag || null;
         vars['creator'] = getCreatorVariable(context, scriptBot);
-        vars['config'] = getConfigVariable(context, scriptBot);
+        const config = (vars['config'] = getConfigVariable(context, scriptBot));
+        vars['configTag'] = config && tag ? config.tags[tag] : null;
 
-        for (let script of scripts) {
-            const result = context.sandbox.run(script, {}, scriptBot, vars);
-            if (result.error) {
-                throw result.error;
-            }
-            results.push(result.result);
+        const result = context.sandbox.run(script, {}, scriptBot, vars);
+        if (result.error) {
+            throw result.error;
         }
+        results.push(result.result);
     }
     setActions(previous);
     setCalculationContext(prevContext);

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -529,228 +529,380 @@ export function botActionsTests(
             ]);
         });
 
-        it('should pass in a creator variable which equals getBot("id", tags.auxCreator)', () => {
-            const state: BotsState = {
-                thisBot: {
-                    id: 'thisBot',
-                    tags: {
-                        _position: { x: 0, y: 0, z: 0 },
-                        _workspace: 'abc',
-                        auxCreator: 'thatBot',
-                        test: '@setTag(this, "creatorId", creator.id)',
+        describe('creator', () => {
+            it('should pass in a creator variable which equals getBot("id", tags.auxCreator)', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            _position: { x: 0, y: 0, z: 0 },
+                            _workspace: 'abc',
+                            auxCreator: 'thatBot',
+                            test: '@setTag(this, "creatorId", creator.id)',
+                        },
                     },
-                },
-                thatBot: {
-                    id: 'thatBot',
-                    tags: {
-                        _position: { x: 0, y: 0, z: 0 },
-                        _workspace: 'def',
-                        name: 'Joe',
+                    thatBot: {
+                        id: 'thatBot',
+                        tags: {
+                            _position: { x: 0, y: 0, z: 0 },
+                            _workspace: 'def',
+                            name: 'Joe',
+                        },
                     },
-                },
-            };
+                };
 
-            // specify the UUID to use next
-            uuidMock.mockReturnValue('uuid-0');
-            const botAction = action('test', ['thisBot']);
-            const result = calculateActionEvents(
-                state,
-                botAction,
-                createSandbox
-            );
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
 
-            expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.hasUserDefinedEvents).toBe(true);
 
-            expect(result.events).toEqual([
-                botUpdated('thisBot', {
-                    tags: {
-                        creatorId: 'thatBot',
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            creatorId: 'thatBot',
+                        },
+                    }),
+                ]);
+            });
+
+            it('the creator variable should be null if the bot has no creator', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test:
+                                '@setTag(this, "hasCreator", creator !== null)',
+                        },
                     },
-                }),
-            ]);
+                    thatBot: {
+                        id: 'thatBot',
+                        tags: {
+                            name: 'Joe',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            hasCreator: false,
+                        },
+                    }),
+                ]);
+            });
+
+            it('the creator variable should be null if the bot is referencing a missing creator', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            auxCreator: 'none',
+                            test:
+                                '@setTag(this, "hasCreator", creator !== null)',
+                        },
+                    },
+                    thatBot: {
+                        id: 'thatBot',
+                        tags: {
+                            name: 'Joe',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            hasCreator: false,
+                        },
+                    }),
+                ]);
+            });
         });
 
-        it('the creator variable should be null if the bot has no creator', () => {
-            const state: BotsState = {
-                thisBot: {
-                    id: 'thisBot',
-                    tags: {
-                        test: '@setTag(this, "hasCreator", creator !== null)',
+        describe('config', () => {
+            it('should pass in a config variable which equals getBot("id", tags.auxConfigBot)', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            auxConfigBot: 'thatBot',
+                            test: '@setTag(this, "configId", config.id)',
+                        },
                     },
-                },
-                thatBot: {
-                    id: 'thatBot',
-                    tags: {
-                        name: 'Joe',
+                    thatBot: {
+                        id: 'thatBot',
+                        tags: {
+                            name: 'Joe',
+                        },
                     },
-                },
-            };
+                };
 
-            // specify the UUID to use next
-            uuidMock.mockReturnValue('uuid-0');
-            const botAction = action('test', ['thisBot']);
-            const result = calculateActionEvents(
-                state,
-                botAction,
-                createSandbox
-            );
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
 
-            expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.hasUserDefinedEvents).toBe(true);
 
-            expect(result.events).toEqual([
-                botUpdated('thisBot', {
-                    tags: {
-                        hasCreator: false,
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            configId: 'thatBot',
+                        },
+                    }),
+                ]);
+            });
+
+            it('the config variable should be null if auxConfigBot is not set', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: '@setTag(this, "hasConfig", config !== null)',
+                        },
                     },
-                }),
-            ]);
+                    thatBot: {
+                        id: 'thatBot',
+                        tags: {
+                            name: 'Joe',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            hasConfig: false,
+                        },
+                    }),
+                ]);
+            });
+
+            it('the config variable should be null if auxConfigBot is referencing a missing bot', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            auxConfigBot: 'none',
+                            test: '@setTag(this, "hasConfig", config !== null)',
+                        },
+                    },
+                    thatBot: {
+                        id: 'thatBot',
+                        tags: {
+                            name: 'Joe',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            hasConfig: false,
+                        },
+                    }),
+                ]);
+            });
         });
 
-        it('the creator variable should be null if the bot is referencing a missing creator', () => {
-            const state: BotsState = {
-                thisBot: {
-                    id: 'thisBot',
-                    tags: {
-                        auxCreator: 'none',
-                        test: '@setTag(this, "hasCreator", creator !== null)',
+        describe('tagName', () => {
+            it('should pass in a tagName variable which is the name of the tag that is currently executing', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: '@setTag(this, "runningTag", tagName)',
+                        },
                     },
-                },
-                thatBot: {
-                    id: 'thatBot',
-                    tags: {
-                        name: 'Joe',
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            runningTag: 'test',
+                        },
+                    }),
+                ]);
+            });
+
+            it('should set the tagName variable to the name of the original tag even in formulas', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            val: '@setTag(this, "runningTag", tagName)',
+                            test: '=tags.val',
+                        },
                     },
-                },
-            };
+                };
 
-            // specify the UUID to use next
-            uuidMock.mockReturnValue('uuid-0');
-            const botAction = action('test', ['thisBot']);
-            const result = calculateActionEvents(
-                state,
-                botAction,
-                createSandbox
-            );
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
 
-            expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.hasUserDefinedEvents).toBe(true);
 
-            expect(result.events).toEqual([
-                botUpdated('thisBot', {
-                    tags: {
-                        hasCreator: false,
-                    },
-                }),
-            ]);
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            runningTag: 'test',
+                        },
+                    }),
+                ]);
+            });
         });
 
-        it('should pass in a config variable which equals getBot("id", tags.auxConfigBot)', () => {
-            const state: BotsState = {
-                thisBot: {
-                    id: 'thisBot',
-                    tags: {
-                        auxConfigBot: 'thatBot',
-                        test: '@setTag(this, "configId", config.id)',
+        describe('configTag', () => {
+            it('should define a configTag variable which equals config.tags[tagName]', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            auxConfigBot: 'thatBot',
+                            test: '@setTag(this, "parentScript", configTag)',
+                        },
                     },
-                },
-                thatBot: {
-                    id: 'thatBot',
-                    tags: {
-                        name: 'Joe',
+                    thatBot: {
+                        id: 'thatBot',
+                        tags: {
+                            test: 'player.toast("hello")',
+                            name: 'Joe',
+                        },
                     },
-                },
-            };
+                };
 
-            // specify the UUID to use next
-            uuidMock.mockReturnValue('uuid-0');
-            const botAction = action('test', ['thisBot']);
-            const result = calculateActionEvents(
-                state,
-                botAction,
-                createSandbox
-            );
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
 
-            expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.hasUserDefinedEvents).toBe(true);
 
-            expect(result.events).toEqual([
-                botUpdated('thisBot', {
-                    tags: {
-                        configId: 'thatBot',
+                expect(result.events).toEqual([
+                    botUpdated('thisBot', {
+                        tags: {
+                            parentScript: 'player.toast("hello")',
+                        },
+                    }),
+                ]);
+            });
+
+            it('should contain the value that the config bot contained when the script started', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            auxConfigBot: 'thatBot',
+                            test: `@config.tags.test = "abc"; setTag(this, "parentScript", configTag)`,
+                        },
                     },
-                }),
-            ]);
-        });
-
-        it('the config variable should be null if auxConfigBot is not set', () => {
-            const state: BotsState = {
-                thisBot: {
-                    id: 'thisBot',
-                    tags: {
-                        test: '@setTag(this, "hasConfig", config !== null)',
+                    thatBot: {
+                        id: 'thatBot',
+                        tags: {
+                            test: 'player.toast("hello")',
+                            name: 'Joe',
+                        },
                     },
-                },
-                thatBot: {
-                    id: 'thatBot',
-                    tags: {
-                        name: 'Joe',
-                    },
-                },
-            };
+                };
 
-            // specify the UUID to use next
-            uuidMock.mockReturnValue('uuid-0');
-            const botAction = action('test', ['thisBot']);
-            const result = calculateActionEvents(
-                state,
-                botAction,
-                createSandbox
-            );
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
 
-            expect(result.hasUserDefinedEvents).toBe(true);
+                expect(result.hasUserDefinedEvents).toBe(true);
 
-            expect(result.events).toEqual([
-                botUpdated('thisBot', {
-                    tags: {
-                        hasConfig: false,
-                    },
-                }),
-            ]);
-        });
-
-        it('the config variable should be null if auxConfigBot is referencing a missing bot', () => {
-            const state: BotsState = {
-                thisBot: {
-                    id: 'thisBot',
-                    tags: {
-                        auxConfigBot: 'none',
-                        test: '@setTag(this, "hasConfig", config !== null)',
-                    },
-                },
-                thatBot: {
-                    id: 'thatBot',
-                    tags: {
-                        name: 'Joe',
-                    },
-                },
-            };
-
-            // specify the UUID to use next
-            uuidMock.mockReturnValue('uuid-0');
-            const botAction = action('test', ['thisBot']);
-            const result = calculateActionEvents(
-                state,
-                botAction,
-                createSandbox
-            );
-
-            expect(result.hasUserDefinedEvents).toBe(true);
-
-            expect(result.events).toEqual([
-                botUpdated('thisBot', {
-                    tags: {
-                        hasConfig: false,
-                    },
-                }),
-            ]);
+                expect(result.events).toEqual([
+                    botUpdated('thatBot', {
+                        tags: {
+                            test: 'abc',
+                        },
+                    }),
+                    botUpdated('thisBot', {
+                        tags: {
+                            parentScript: 'player.toast("hello")',
+                        },
+                    }),
+                ]);
+            });
         });
 
         it('should not allow changing the ID', () => {

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -570,6 +570,189 @@ export function botActionsTests(
             ]);
         });
 
+        it('the creator variable should be null if the bot has no creator', () => {
+            const state: BotsState = {
+                thisBot: {
+                    id: 'thisBot',
+                    tags: {
+                        test: '@setTag(this, "hasCreator", creator !== null)',
+                    },
+                },
+                thatBot: {
+                    id: 'thatBot',
+                    tags: {
+                        name: 'Joe',
+                    },
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const botAction = action('test', ['thisBot']);
+            const result = calculateActionEvents(
+                state,
+                botAction,
+                createSandbox
+            );
+
+            expect(result.hasUserDefinedEvents).toBe(true);
+
+            expect(result.events).toEqual([
+                botUpdated('thisBot', {
+                    tags: {
+                        hasCreator: false,
+                    },
+                }),
+            ]);
+        });
+
+        it('the creator variable should be null if the bot is referencing a missing creator', () => {
+            const state: BotsState = {
+                thisBot: {
+                    id: 'thisBot',
+                    tags: {
+                        auxCreator: 'none',
+                        test: '@setTag(this, "hasCreator", creator !== null)',
+                    },
+                },
+                thatBot: {
+                    id: 'thatBot',
+                    tags: {
+                        name: 'Joe',
+                    },
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const botAction = action('test', ['thisBot']);
+            const result = calculateActionEvents(
+                state,
+                botAction,
+                createSandbox
+            );
+
+            expect(result.hasUserDefinedEvents).toBe(true);
+
+            expect(result.events).toEqual([
+                botUpdated('thisBot', {
+                    tags: {
+                        hasCreator: false,
+                    },
+                }),
+            ]);
+        });
+
+        it('should pass in a config variable which equals getBot("id", tags.auxConfigBot)', () => {
+            const state: BotsState = {
+                thisBot: {
+                    id: 'thisBot',
+                    tags: {
+                        auxConfigBot: 'thatBot',
+                        test: '@setTag(this, "configId", config.id)',
+                    },
+                },
+                thatBot: {
+                    id: 'thatBot',
+                    tags: {
+                        name: 'Joe',
+                    },
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const botAction = action('test', ['thisBot']);
+            const result = calculateActionEvents(
+                state,
+                botAction,
+                createSandbox
+            );
+
+            expect(result.hasUserDefinedEvents).toBe(true);
+
+            expect(result.events).toEqual([
+                botUpdated('thisBot', {
+                    tags: {
+                        configId: 'thatBot',
+                    },
+                }),
+            ]);
+        });
+
+        it('the config variable should be null if auxConfigBot is not set', () => {
+            const state: BotsState = {
+                thisBot: {
+                    id: 'thisBot',
+                    tags: {
+                        test: '@setTag(this, "hasConfig", config !== null)',
+                    },
+                },
+                thatBot: {
+                    id: 'thatBot',
+                    tags: {
+                        name: 'Joe',
+                    },
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const botAction = action('test', ['thisBot']);
+            const result = calculateActionEvents(
+                state,
+                botAction,
+                createSandbox
+            );
+
+            expect(result.hasUserDefinedEvents).toBe(true);
+
+            expect(result.events).toEqual([
+                botUpdated('thisBot', {
+                    tags: {
+                        hasConfig: false,
+                    },
+                }),
+            ]);
+        });
+
+        it('the config variable should be null if auxConfigBot is referencing a missing bot', () => {
+            const state: BotsState = {
+                thisBot: {
+                    id: 'thisBot',
+                    tags: {
+                        auxConfigBot: 'none',
+                        test: '@setTag(this, "hasConfig", config !== null)',
+                    },
+                },
+                thatBot: {
+                    id: 'thatBot',
+                    tags: {
+                        name: 'Joe',
+                    },
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const botAction = action('test', ['thisBot']);
+            const result = calculateActionEvents(
+                state,
+                botAction,
+                createSandbox
+            );
+
+            expect(result.hasUserDefinedEvents).toBe(true);
+
+            expect(result.events).toEqual([
+                botUpdated('thisBot', {
+                    tags: {
+                        hasConfig: false,
+                    },
+                }),
+            ]);
+        });
+
         it('should not allow changing the ID', () => {
             const state: BotsState = {
                 thisBot: {

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -2471,6 +2471,51 @@ export function botCalculationContextTests(
                 });
             });
 
+            describe('config', () => {
+                it('should define a config variable which is the bot that referenced by auxConfigBot', () => {
+                    const bot = createBot('test', {
+                        auxConfigBot: 'other',
+                        formula: `=config.id`,
+                    });
+                    const other = createBot('other', {});
+
+                    const context = createCalculationContext([bot, other]);
+                    const value = calculateBotValue(context, bot, 'formula');
+
+                    expect(value).toEqual('other');
+                });
+            });
+
+            describe('tagName', () => {
+                it('should define a tagName variable which is equal to the current tag', () => {
+                    const bot = createBot('test', {
+                        formula: `=tagName`,
+                    });
+
+                    const context = createCalculationContext([bot]);
+                    const value = calculateBotValue(context, bot, 'formula');
+
+                    expect(value).toEqual('formula');
+                });
+            });
+
+            describe('configTag', () => {
+                it('should define a configTag variable which is equal to config.tags[tagName]', () => {
+                    const bot = createBot('test', {
+                        auxConfigBot: 'other',
+                        formula: `=configTag`,
+                    });
+                    const other = createBot('other', {
+                        formula: 'abc',
+                    });
+
+                    const context = createCalculationContext([bot, other]);
+                    const value = calculateBotValue(context, bot, 'formula');
+
+                    expect(value).toEqual('abc');
+                });
+            });
+
             describe('getID()', () => {
                 it('should get the ID of the given bot', () => {
                     const bot = createBot('test', {

--- a/src/aux-server/aux-web/shared/FormulaHelpers.ts
+++ b/src/aux-server/aux-web/shared/FormulaHelpers.ts
@@ -25,6 +25,11 @@ export function calculateFormulaDefinitions(options?: FormulaLibraryOptions) {
             ...Object.keys(formulaLib).map(k => `  const ${k}: _${k};`),
             `  const bot: Bot;`,
             `  const tags: BotTags;`,
+            `  const raw: BotTags;`,
+            `  const creator: Bot;`,
+            `  const config: Bot`,
+            `  const tagName: string;`,
+            `  const configTag: any`,
             '}',
         ].join('\n');
 

--- a/src/aux-vm/managers/DependencyManager.spec.ts
+++ b/src/aux-vm/managers/DependencyManager.spec.ts
@@ -310,6 +310,29 @@ describe('DependencyManager', () => {
                 test: new Set(['formula']),
             });
         });
+
+        it('should support tagName references', async () => {
+            let subject = new DependencyManager();
+
+            let test = createBot('test', {
+                control: 'abc',
+                formula: '=getBots(tagName)',
+            });
+
+            let test3 = createBot('test3', {
+                name: 'bot3',
+                formula: 'abc',
+            });
+
+            let updates = subject.addBot(test);
+            expect(updates).toEqual({});
+
+            updates = subject.addBot(test3);
+
+            expect(updates).toEqual({
+                test: new Set(['formula']),
+            });
+        });
     });
 
     describe('addBots()', () => {


### PR DESCRIPTION
#### :rocket: Improvements

-   Added the `config`, `configTag`, and `tagName` variables.
    -   These variables are useful for creating values and scripts that are shared across multiple bots.
    -   The `config` variable is a shortcut for `getBot("#id", tags.auxConfigBot)`.
    -   The `tagName` variable is the name of the tag that the script is running in.
    -   The `configTag` variable is a shortcut for `config.tags[tagName]`.