### PR TITLE
Add the ability to free-drag bots with a VR controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 -   :bug: Bug Fixes
     -   Fixed several issues with using numbers for the `auxUniverse` and `auxPagePortal` query parameters.
+    -   Fixed an issue that would cause a service worker to fail to update because an external resource could not be fetched.
+    -   Fixed an issue that would cause a stack overflow error when too many uncommitted atoms are loaded.
 
 ## V1.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
     -   The `player.device()` function returns whether AR/VR are supported.
     -   The `player.enableAR()` and `player.enableVR()` functions are used to jump into AR/VR.
     -   The world is placed on the ground (if supported by the device) and bots are 1 meter cubed by default.
+    -   When using a controller, dragging a bot with `#auxPositioningMode` set to `absolute` will move it in free space.
+        -   Additionally, using the grip/squeeze button on the controller while dragging will allow rotating the bot.
 
 -   :bug: Bug Fixes
     -   Fixed several issues with using numbers for the `auxUniverse` and `auxPagePortal` query parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
     -   The `player.enableAR()` and `player.enableVR()` functions are used to jump into AR/VR.
     -   The world is placed on the ground (if supported by the device) and bots are 1 meter cubed by default.
     -   When using a controller, dragging a bot with `#auxPositioningMode` set to `absolute` will move it in free space.
-        -   Additionally, using the grip/squeeze button on the controller while dragging will allow rotating the bot.
 
 -   :bug: Bug Fixes
     -   Fixed several issues with using numbers for the `auxUniverse` and `auxPagePortal` query parameters.

--- a/src/aux-server/aux-web/aux-player/PlayerGrid3D.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerGrid3D.ts
@@ -57,6 +57,21 @@ export class PlayerGrid3D extends Object3D {
     }
 
     /**
+     * Scales the given position by the tile scale and returns the result.
+     * @param position The input position.
+     */
+    getGridPosition(position: Vector3): Vector3 {
+        const result = new Vector3()
+            .copy(position)
+            .divideScalar(this.tileScale);
+        return new Vector3(
+            result.x,
+            this.useAuxCoordinates ? -result.z : result.z,
+            result.y
+        );
+    }
+
+    /**
      * Retrive the grid tile that contains the given position.
      * @param position The world space position.
      */

--- a/src/aux-server/aux-web/aux-player/interaction/ClickOperation/PlayerBotClickOperation.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/ClickOperation/PlayerBotClickOperation.ts
@@ -35,9 +35,10 @@ export class PlayerBotClickOperation extends BaseBotClickOperation {
         interaction: PlayerInteractionManager,
         bot: AuxBot3D,
         faceValue: string,
-        inputMethod: InputMethod
+        inputMethod: InputMethod,
+        hit: Intersection
     ) {
-        super(simulation3D, interaction, bot.bot, bot, inputMethod);
+        super(simulation3D, interaction, bot.bot, bot, inputMethod, hit);
 
         this._argument = { face: faceValue, dimension: null };
     }
@@ -93,7 +94,8 @@ export class PlayerBotClickOperation extends BaseBotClickOperation {
                 this._inputMethod,
                 fromCoord,
                 undefined,
-                this._argument.face
+                this._argument.face,
+                this._hit
             );
         }
 

--- a/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
@@ -98,7 +98,8 @@ export class PlayerInteractionManager extends BaseInteractionManager {
                 this,
                 gameObject,
                 faceValue,
-                method
+                method,
+                hit
             );
             return botClickOp;
         } else {

--- a/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseBotClickOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseBotClickOperation.ts
@@ -3,7 +3,7 @@ import {
     ControllerData,
     InputMethod,
 } from '../../../shared/scene/Input';
-import { Vector2 } from 'three';
+import { Vector2, Intersection } from 'three';
 import { IOperation } from '../IOperation';
 import { BaseInteractionManager } from '../BaseInteractionManager';
 import {
@@ -34,9 +34,10 @@ export abstract class BaseBotClickOperation extends BaseClickOperation {
         interaction: BaseInteractionManager,
         bot: Bot,
         bot3D: AuxBot3D | DimensionGroup3D | null,
-        inputMethod: InputMethod
+        inputMethod: InputMethod,
+        hit?: Intersection
     ) {
-        super(simulation3D, interaction, inputMethod);
+        super(simulation3D, interaction, inputMethod, hit);
         this._bot = bot;
         this._bot3D = bot3D;
     }

--- a/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseClickOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseClickOperation.ts
@@ -3,7 +3,7 @@ import {
     ControllerData,
     InputMethod,
 } from '../../../shared/scene/Input';
-import { Vector2, Object3D } from 'three';
+import { Vector2, Object3D, Intersection } from 'three';
 import { IOperation } from '../IOperation';
 import { BaseInteractionManager } from '../BaseInteractionManager';
 import {
@@ -35,6 +35,7 @@ export abstract class BaseClickOperation implements IOperation {
     protected _startScreenPos: Vector2;
     protected _startVRControllerPose: Object3D;
     protected _dragOperation: IOperation;
+    protected _hit: Intersection;
 
     protected heldTime: number;
     protected isMobile: boolean;
@@ -50,13 +51,15 @@ export abstract class BaseClickOperation implements IOperation {
     constructor(
         simulation3D: Simulation3D,
         interaction: BaseInteractionManager,
-        inputMethod: InputMethod
+        inputMethod: InputMethod,
+        hit?: Intersection
     ) {
         this._simulation3D = simulation3D;
         this._interaction = interaction;
         this._inputMethod = inputMethod;
         this._controller =
             inputMethod.type === 'controller' ? inputMethod.controller : null;
+        this._hit = hit;
 
         if (this._controller) {
             // Store the pose of the vr controller when the click occured.

--- a/src/aux-server/aux-web/shared/interaction/DragOperation/BaseBotDragOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/DragOperation/BaseBotDragOperation.ts
@@ -1,6 +1,6 @@
 import { IOperation } from '../IOperation';
 import { BaseInteractionManager } from '../BaseInteractionManager';
-import { Vector2, Object3D, Vector3, Euler } from 'three';
+import { Vector2, Object3D, Vector3, Euler, Intersection } from 'three';
 import {
     Bot,
     botUpdated,
@@ -63,6 +63,7 @@ export abstract class BaseBotDragOperation implements IOperation {
     protected _inputMethod: InputMethod;
     protected _childOperation: IOperation;
     protected _clickedFace: string;
+    protected _hit: Intersection;
 
     /**
      * The bot that the onDropEnter event was sent to.
@@ -99,7 +100,8 @@ export abstract class BaseBotDragOperation implements IOperation {
         inputMethod: InputMethod,
         fromCoord?: Vector2,
         skipOnDragEvents?: boolean,
-        clickedFace?: string
+        clickedFace?: string,
+        hit?: Intersection
     ) {
         this._simulation3D = simulation3D;
         this._interaction = interaction;
@@ -114,6 +116,7 @@ export abstract class BaseBotDragOperation implements IOperation {
             inputMethod.type === 'controller' ? inputMethod.controller : null;
         this._fromCoord = fromCoord;
         this._clickedFace = clickedFace;
+        this._hit = hit;
         this._sub = new Subscription();
 
         if (this._controller) {

--- a/src/aux-server/aux-web/shared/scene/debugobjectmanager/DebugObjectManager.ts
+++ b/src/aux-server/aux-web/shared/scene/debugobjectmanager/DebugObjectManager.ts
@@ -15,6 +15,7 @@ import {
     PlaneHelper,
     Mesh,
     MeshBasicMaterial,
+    Quaternion,
 } from 'three';
 import { Time } from '../Time';
 import { getOptionalValue } from '../../SharedUtils';
@@ -28,8 +29,10 @@ import { Input } from '../Input';
 import { ArrowHelperPool } from '../objectpools/ArrowHelperPool';
 import { drawExamples } from './DebugExamples';
 import { PlaneHelperPool } from '../objectpools/PlaneHelerPool';
+import { CubeHelperPool } from '../objectpools/CubeHelperPool';
 
 const BOX3HELPER_POOL_ID = 'box3helper_pool';
+const CUBEHELPER_POOL_ID = 'cubehelper_pool';
 const PLANEHELPER_POOL_ID = 'planehelper_pool';
 const POINTHELPER_POOL_ID = 'pointhelper_pool';
 const LINEHELPER_POOL_ID = 'linehelper_pool';
@@ -97,6 +100,11 @@ export namespace DebugObjectManager {
         _objectPools.set(
             ARROWHELPER_POOL_ID,
             new ArrowHelperPool(ARROWHELPER_POOL_ID).initializePool(startSize)
+        );
+
+        _objectPools.set(
+            CUBEHELPER_POOL_ID,
+            new CubeHelperPool(CUBEHELPER_POOL_ID).initializePool(startSize)
         );
     }
 
@@ -198,6 +206,46 @@ export namespace DebugObjectManager {
         _debugObjects.push({
             object3D: box3Helper,
             poolId: BOX3HELPER_POOL_ID,
+            killTime: _time.timeSinceStart + duration,
+        });
+    }
+
+    /**
+     * Draw a wireframe cube that represents the given position and rotation.
+     * @param box3 The box3 to represent.
+     * @param color The color the debug object should. Default is green.
+     * @param duration How long the debug object should render for. Default is one frame.
+     */
+    export function drawCube(
+        position: Vector3,
+        rotation: Quaternion,
+        color?: Color,
+        duration?: number
+    ) {
+        if (!_initialized) return;
+        if (!enabled) return;
+        if (!position) return;
+        if (!rotation) return;
+        color = getOptionalValue(color, new Color(0, 1, 0));
+        duration = getOptionalValue(duration, 0);
+        const cubeHelper = <LineSegments>(
+            _objectPools.get(CUBEHELPER_POOL_ID).retrieve()
+        );
+
+        const lineMaterial = <LineBasicMaterial>cubeHelper.material;
+        lineMaterial.vertexColors = NoColors;
+        lineMaterial.color = color;
+
+        _scene.add(cubeHelper);
+
+        // Position the box helper using the given box3.
+        cubeHelper.position.copy(position);
+        cubeHelper.quaternion.copy(rotation);
+        cubeHelper.rotation.setFromQuaternion(rotation);
+
+        _debugObjects.push({
+            object3D: cubeHelper,
+            poolId: CUBEHELPER_POOL_ID,
             killTime: _time.timeSinceStart + duration,
         });
     }

--- a/src/aux-server/aux-web/shared/scene/debugobjectmanager/DebugObjectManager.ts
+++ b/src/aux-server/aux-web/shared/scene/debugobjectmanager/DebugObjectManager.ts
@@ -46,7 +46,7 @@ export namespace DebugObjectManager {
     /**
      * Wether or not debug object manager is enabled.
      */
-    export var enabled: boolean = false;
+    export var enabled: boolean = true;
 
     /**
      * Wether or not debug objects are rendered with the depth buffer (objects can occlude debug objects),

--- a/src/aux-server/aux-web/shared/scene/objectpools/CubeHelperPool.ts
+++ b/src/aux-server/aux-web/shared/scene/objectpools/CubeHelperPool.ts
@@ -1,0 +1,42 @@
+import {
+    disposeObject3D,
+    disposeMesh,
+    createCubeStrokeGeometry,
+} from '../SceneUtils';
+import { ObjectPool } from './ObjectPool';
+import { Vector3, Mesh, LineSegments, LineBasicMaterial } from 'three';
+
+export class CubeHelperPool extends ObjectPool<LineSegments> {
+    constructor(name?: string, poolEmptyWarn?: boolean) {
+        super(name, poolEmptyWarn);
+    }
+
+    onRetrieved(obj: LineSegments): void {
+        // Do nothing.
+    }
+
+    onRestored(obj: LineSegments): void {
+        if (obj.parent) {
+            // Remove from its current parent.
+            obj.parent.remove(obj);
+            obj.parent = null;
+        }
+    }
+
+    createPoolObject(): LineSegments {
+        const geo = createCubeStrokeGeometry();
+        const material = new LineBasicMaterial({
+            color: 0x000000,
+        });
+
+        return new LineSegments(geo, material);
+    }
+
+    getPoolObjectId(obj: LineSegments): string {
+        return obj.uuid;
+    }
+
+    disposePoolObject(obj: LineSegments): void {
+        disposeMesh(obj);
+    }
+}

--- a/src/aux-server/aux-web/shared/scene/xr/WebXRHelpers.ts
+++ b/src/aux-server/aux-web/shared/scene/xr/WebXRHelpers.ts
@@ -30,4 +30,5 @@ export async function createMotionController(inputSource: XRInputSource) {
 export function copyPose(pose: XRPose, obj: Object3D) {
     obj.matrix.fromArray(pose.transform.matrix);
     obj.matrix.decompose(obj.position, <any>obj.rotation, obj.scale);
+    obj.updateMatrixWorld();
 }

--- a/src/aux-server/aux-web/webpack.common.js
+++ b/src/aux-server/aux-web/webpack.common.js
@@ -240,9 +240,7 @@ module.exports = {
                     requestTypes: ['navigate'],
                 },
             ],
-            externals: [
-                'https://fonts.googleapis.com/css?family=Roboto:400,500,700,400italic|Material+Icons',
-            ],
+            externals: [],
         }),
         new CopyPlugin([
             {

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -457,9 +457,9 @@ export class CausalRepoServer {
                     : null,
             });
             const stage = await this._stage.getStage(branch);
-            repo.add(...stage.additions);
+            repo.addMany(stage.additions);
             const hashes = Object.keys(stage.deletions);
-            repo.remove(...hashes);
+            repo.removeMany(hashes);
 
             this._repos.set(branch, repo);
             this._branchLoaded(branch);

--- a/src/causal-trees/core2/CausalRepo.ts
+++ b/src/causal-trees/core2/CausalRepo.ts
@@ -374,6 +374,14 @@ export class CausalRepo {
      * @param atoms The atoms to add.
      */
     add(...atoms: Atom<any>[]) {
+        return this.addMany(atoms);
+    }
+
+    /**
+     * Adds the given atoms to the stage.
+     * @param atoms The atoms to add.
+     */
+    addMany(atoms: Atom<any>[]) {
         let added = [] as Atom<any>[];
         for (let atom of atoms) {
             const existing = this._getAtomFromCurrentState(atom.hash);
@@ -392,6 +400,14 @@ export class CausalRepo {
      * @param hashes The list of hashes to remove.
      */
     remove(...hashes: string[]) {
+        return this.removeMany(hashes);
+    }
+
+    /**
+     * Removes the given atoms with the given hashes.
+     * @param hashes The list of hashes to remove.
+     */
+    removeMany(hashes: string[]) {
         let removed = [] as Atom<any>[];
         for (let hash of hashes) {
             const existing = this._getAtomFromCurrentState(hash);


### PR DESCRIPTION
#### :rocket: Improvements
-   When using a controller, dragging a bot with `#auxPositioningMode` set to `absolute` will move it in free space.
     -   Additionally, using the grip/squeeze button on the controller while dragging will allow rotating the bot.