### PR TITLE
VR Improvements, Documentation, and a Download Bug Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # AUX Changelog
 
+## V1.0.15
+
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+
+    -   Improved `@onPlayerPortalChanged` to support `auxLeftWristPortal` and `auxRightWristPortal`.
+    -   Moved the left and right wrist portals to the top of the wrist instead of the bottom.
+
+-   :book: Documentation
+    -   Added documentation for the wrist portals and their related config bot tags.
+
 ## V1.0.14
 
 ### Date: 3/6/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
     -   Moved the left and right wrist portals to the top of the wrist instead of the bottom.
 
 -   :book: Documentation
+
     -   Added documentation for the wrist portals and their related config bot tags.
+
+-   :bug: Bug Fixes
+    -   Fixed `player.downloadUniverse()` to only include bots from the shared space.
 
 ## V1.0.14
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -1447,11 +1447,11 @@ player.unloadUniverse('fun');
 
 <FunctionCode name='downloadUniverse'/>
 
-Downloads the entire universe into a `.aux` file on the player's computer.
+Downloads all of the shared bots into a `.aux` file on the player's computer.
 The file will have the same name as the universe.
 
 Note that this function is almost exactly the same as <ActionLink action='player.downloadBots(bots, filename)'/>.
-The only difference is that all bots are included and the file is named for you automatically.
+The only difference is that all bots in the shared space are included and the file is named for you automatically.
 
 #### Examples:
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -764,7 +764,7 @@ The size of bots in the portal.
 #### Possible values are:
 <PossibleValuesTable>
   <PossibleValue value='Any Number > 0'>
-    The size of bots in the portal. (Default is 0.2)
+    The size of bots in the portal. (Default is 0.025 for wrist portals and 0.2 for all other portals)
   </PossibleValue>
 </PossibleValuesTable>
 
@@ -802,6 +802,28 @@ Whether the player will be able to resize the viewport for the inventory portal.
   <PossibleValueCode value='false'>
     The inventory is not resizable.
   </PossibleValueCode>
+</PossibleValuesTable>
+
+### `auxWristPortalHeight`
+
+The number of grid spaces that the wrist portal should have in the Y direction.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValue value='Numbers >= 1'>
+    The number of of grid spaces that the portal should have in the Y direction. (Default is 6)
+  </PossibleValue>
+</PossibleValuesTable>
+
+### `auxWristPortalWidth`
+
+The number of grid spaces that the wrist portal should have in the X direction.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValue value='Numbers >= 1'>
+    The number of of grid spaces that the portal should have in the X direction. (Default is 6)
+  </PossibleValue>
 </PossibleValuesTable>
 
 ## Channel Config Tags
@@ -1072,6 +1094,24 @@ Only available on the player bot.
 </Badges>
 
 The dimension that is loaded into the "menu" portal in auxPlayer.
+Only available on the player bot.
+
+### `auxLeftWristPortal`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The dimension that is loaded onto the left controller near the wrist when in VR.
+Only available on the player bot.
+
+### `auxRightWristPortal`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The dimension that is loaded onto the right controller near the wrist when in VR.
 Only available on the player bot.
 
 ## Hidden Tags

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -2136,13 +2136,9 @@ function formatAuxFilename(filename: string): string {
 }
 
 function downloadUniverse() {
-    const state = getBotState();
-    return addAction(
-        download(
-            JSON.stringify(getDownloadState(state)),
-            `${getCurrentUniverse()}.aux`,
-            'application/json'
-        )
+    return downloadBots(
+        getBots(bySpace('shared')),
+        `${getCurrentUniverse()}.aux`
     );
 }
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -674,6 +674,8 @@ export const KNOWN_PORTALS: string[] = [
     'auxSheetPortal',
     'auxInventoryPortal',
     'auxMenuPortal',
+    'auxLeftWristPortal',
+    'auxRightWristPortal',
 ];
 
 /**

--- a/src/aux-common/bots/BotCalculationContextFactories.ts
+++ b/src/aux-common/bots/BotCalculationContextFactories.ts
@@ -341,10 +341,20 @@ function createScriptBot(calc: BotCalculationContext, bot: Bot): ScriptBot {
     };
 
     Object.defineProperty(script, 'toJSON', {
-        value: () => ({
-            id: bot.id,
-            tags: tagsProxy,
-        }),
+        value: () => {
+            if ('space' in bot) {
+                return {
+                    id: bot.id,
+                    space: bot.space,
+                    tags: tagsProxy,
+                };
+            } else {
+                return {
+                    id: bot.id,
+                    tags: tagsProxy,
+                };
+            }
+        },
         writable: false,
         enumerable: false,
 

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -4273,7 +4273,7 @@ export function botActionsTests(
             });
         });
 
-        describe('toast()', () => {
+        describe('player.toast()', () => {
             it('should emit a ShowToastAction', () => {
                 const state: BotsState = {
                     thisBot: {
@@ -5124,6 +5124,70 @@ export function botActionsTests(
                         JSON.stringify({
                             version: 1,
                             state: state,
+                        }),
+                        'channel.aux',
+                        'application/json'
+                    ),
+                ]);
+            });
+
+            it('should only include bots in the shared space', () => {
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: '@player.downloadUniverse()',
+                        },
+                    },
+                    thatBot: {
+                        id: 'thatBot',
+                        space: 'shared',
+                        tags: {
+                            name: 'that',
+                        },
+                    },
+                    userBot: {
+                        id: 'userBot',
+                        space: 'tempLocal',
+                        tags: {
+                            auxUniverse: 'channel',
+                        },
+                    },
+                    otherBot: {
+                        id: 'otherBot',
+                        space: 'local',
+                        tags: {
+                            name: 'other',
+                        },
+                    },
+                    historyBot: {
+                        id: 'historyBot',
+                        space: 'history',
+                        tags: {
+                            name: 'history',
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot'], 'userBot');
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([
+                    download(
+                        JSON.stringify({
+                            version: 1,
+                            state: {
+                                thatBot: state.thatBot,
+                                thisBot: state.thisBot,
+                            },
                         }),
                         'channel.aux',
                         'application/json'

--- a/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
@@ -64,17 +64,17 @@ import {
 } from '../../shared/scene/SceneUtils';
 import { DebugObjectManager } from '../../shared/scene/debugobjectmanager/DebugObjectManager';
 
-const DEFAULT_RIGHT_WRIST_POSITION_OFFSET = new Vector3(-0.025, 0.1, 0.1);
+const DEFAULT_RIGHT_WRIST_POSITION_OFFSET = new Vector3(0.05, 0.1, 0.1);
 const DEFAULT_RIGHT_WRIST_ROTATION_OFFSET = new Euler(
-    30 * ThreeMath.DEG2RAD,
-    0,
-    90 * ThreeMath.DEG2RAD
-);
-const DEFAULT_LEFT_WRIST_POSITION_OFFSET = new Vector3(0.025, 0.1, 0.1);
-const DEFAULT_LEFT_WRIST_ROTATION_OFFSET = new Euler(
-    30 * ThreeMath.DEG2RAD,
+    -120 * ThreeMath.DEG2RAD,
     0,
     -90 * ThreeMath.DEG2RAD
+);
+const DEFAULT_LEFT_WRIST_POSITION_OFFSET = new Vector3(-0.05, 0.1, 0.1);
+const DEFAULT_LEFT_WRIST_ROTATION_OFFSET = new Euler(
+    -120 * ThreeMath.DEG2RAD,
+    0,
+    90 * ThreeMath.DEG2RAD
 );
 
 /**


### PR DESCRIPTION
### Changes:

-   :rocket: Improvements

    -   Improved `@onPlayerPortalChanged` to support `auxLeftWristPortal` and `auxRightWristPortal`.
    -   Moved the left and right wrist portals to the top of the wrist instead of the bottom.

-   :book: Documentation

    -   Added documentation for the wrist portals and their related config bot tags.

-   :bug: Bug Fixes
    -   Fixed `player.downloadUniverse()` to only include bots from the shared space.