### PR TITLE
Add the ability to collide with other bots when dragging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@
                 -   `billboard` - The bot rotates automatically to face the player.
                 -   `billboardX` - The bot rotates left and right automatically to face the player.
                 -   `billboardZ` - The bot rotates up and down automatically to face the player.
+    -   Improved drag and drop interactions to calculate intersections with other bots instead of just using grid positioning.
+        -   This makes it easier drop a bot onto another specific bot.
+        -   Can be controlled with the `#auxPortalPointerCollisionMode` tag on a portal config.
+            -   Possible values are:
+                -   `world` - The mouse pointer collides with other bots in the world when being dragged. (Default)
+                -   `grid` - The mouse pointer ignores other bots in the world when being dragged.
 
 -   :book: Documentation
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -828,6 +828,20 @@ The scale of surfaces.
   </PossibleValue>
 </PossibleValuesTable>
 
+### `auxPortalPointerDragMode`
+
+The mode that specifies how the mouse pointer/controller drags bots in the portal.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValue value='world'>
+    Specifies that the pointer should use the other bots in the portal for positioning the dragged bot(s). (Default)
+  </PossibleValue>
+  <PossibleValue value='grid'>
+    Specifies that the pointer should ignore other bots in the portal for positioning the dragged bot(s).
+  </PossibleValue>
+</PossibleValuesTable>
+
 ### `auxInventoryPortalHeight`
 
 Sets the initial height of the inventory viewport for the portal.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -188,7 +188,7 @@ export interface BotTags {
     [`auxPortalZoomableMin`]?: number | null;
     [`auxPortalZoomableMax`]?: number | null;
     ['auxPortalRotatable']?: number | null;
-    ['auxPortalRaycastMode']?: PortalRaycastMode;
+    ['auxPortalPointerDragMode']?: PortalPointerDragMode;
     ['auxInventoryPortalHeight']?: unknown;
     ['auxInventoryPortalResizable']?: boolean;
     ['auxWristPortalHeight']?: number;
@@ -307,7 +307,7 @@ export type BotAnchorPoint = 'center' | 'bottom';
 /**
  * Defines the possible portal raycast modes.
  */
-export type PortalRaycastMode = 'grid' | 'world';
+export type PortalPointerDragMode = 'grid' | 'world';
 
 /**
  * Defines the possible backup types.
@@ -346,7 +346,7 @@ export const DEFAULT_ANCHOR_POINT: BotAnchorPoint = 'bottom';
 /**
  * The default portal raycast mode.
  */
-export const DEFAULT_PORTAL_RAYCAST_MODE: PortalRaycastMode = 'world';
+export const DEFAULT_PORTAL_POINTER_DRAG_MODE: PortalPointerDragMode = 'world';
 
 /**
  * The default height for workspaces.
@@ -746,7 +746,7 @@ export const KNOWN_TAGS: string[] = [
     `auxPortalPlayerZoom`,
     `auxPortalPlayerRotationX`,
     `auxPortalPlayerRotationY`,
-    'auxPortalRaycastMode',
+    'auxPortalPointerDragMode',
     'auxInventoryPortalHeight',
     'auxInventoryPortalResizable',
     'auxWristPortalHeight',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -188,6 +188,7 @@ export interface BotTags {
     [`auxPortalZoomableMin`]?: number | null;
     [`auxPortalZoomableMax`]?: number | null;
     ['auxPortalRotatable']?: number | null;
+    ['auxPortalRaycastMode']?: PortalRaycastMode;
     ['auxInventoryPortalHeight']?: unknown;
     ['auxInventoryPortalResizable']?: boolean;
     ['auxWristPortalHeight']?: number;
@@ -304,6 +305,11 @@ export type BotOrientationMode =
 export type BotAnchorPoint = 'center' | 'bottom';
 
 /**
+ * Defines the possible portal raycast modes.
+ */
+export type PortalRaycastMode = 'grid' | 'world';
+
+/**
  * Defines the possible backup types.
  */
 export type BackupType = 'github' | 'download';
@@ -336,6 +342,11 @@ export const DEFAULT_ORIENTATION_MODE: BotOrientationMode = 'absolute';
  * The default bot orientation mode.
  */
 export const DEFAULT_ANCHOR_POINT: BotAnchorPoint = 'bottom';
+
+/**
+ * The default portal raycast mode.
+ */
+export const DEFAULT_PORTAL_RAYCAST_MODE: PortalRaycastMode = 'world';
 
 /**
  * The default height for workspaces.
@@ -735,6 +746,7 @@ export const KNOWN_TAGS: string[] = [
     `auxPortalPlayerZoom`,
     `auxPortalPlayerRotationX`,
     `auxPortalPlayerRotationY`,
+    'auxPortalRaycastMode',
     'auxInventoryPortalHeight',
     'auxInventoryPortalResizable',
     'auxWristPortalHeight',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -31,6 +31,8 @@ import {
     DEFAULT_ORIENTATION_MODE,
     BotAnchorPoint,
     DEFAULT_ANCHOR_POINT,
+    PortalRaycastMode,
+    DEFAULT_PORTAL_RAYCAST_MODE,
 } from './Bot';
 
 import {
@@ -1324,6 +1326,29 @@ export function getBotAnchorPoint(
 }
 
 /**
+ * Calculates the portal raycast mode that the given bot has set.
+ * @param calc The calculation context.
+ * @param bot The portal config bot.
+ */
+export function calculatePortalRaycastMode(
+    calc: BotCalculationContext,
+    bot: Bot
+): PortalRaycastMode {
+    const mode = <PortalRaycastMode>(
+        calculateStringTagValue(
+            calc,
+            bot,
+            'auxPortalRaycastMode',
+            DEFAULT_PORTAL_RAYCAST_MODE
+        )
+    );
+    if (mode === 'grid' || mode === 'world') {
+        return mode;
+    }
+    return DEFAULT_PORTAL_RAYCAST_MODE;
+}
+
+/**
  * Determines if the given bot is a config bot for the given dimension.
  * @param calc The calculation context.
  * @param bot The bot to check.
@@ -1725,11 +1750,7 @@ export function calculateBotDragStackPosition(
         f => f.id
     );
 
-    const canMerge =
-        objs.length >= 1 &&
-        bots.length === 1 &&
-        isBotTags(bots[0]) &&
-        isMergeable(calc, objs[0]);
+    const canMerge = canMergeBots(calc, objs, bots);
 
     const firstBot = bots[0];
 
@@ -1749,6 +1770,19 @@ export function calculateBotDragStackPosition(
         other: objs[0],
         index: index,
     };
+}
+
+function canMergeBots(
+    calc: BotCalculationContext,
+    objs: Bot[],
+    bots: (Bot | BotTags)[]
+) {
+    return (
+        objs.length >= 1 &&
+        bots.length === 1 &&
+        isBotTags(bots[0]) &&
+        isMergeable(calc, objs[0])
+    );
 }
 
 /**

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -31,8 +31,8 @@ import {
     DEFAULT_ORIENTATION_MODE,
     BotAnchorPoint,
     DEFAULT_ANCHOR_POINT,
-    PortalRaycastMode,
-    DEFAULT_PORTAL_RAYCAST_MODE,
+    PortalPointerDragMode,
+    DEFAULT_PORTAL_POINTER_DRAG_MODE,
 } from './Bot';
 
 import {
@@ -1330,22 +1330,22 @@ export function getBotAnchorPoint(
  * @param calc The calculation context.
  * @param bot The portal config bot.
  */
-export function calculatePortalRaycastMode(
+export function calculatePortalPointerDragMode(
     calc: BotCalculationContext,
     bot: Bot
-): PortalRaycastMode {
-    const mode = <PortalRaycastMode>(
+): PortalPointerDragMode {
+    const mode = <PortalPointerDragMode>(
         calculateStringTagValue(
             calc,
             bot,
-            'auxPortalRaycastMode',
-            DEFAULT_PORTAL_RAYCAST_MODE
+            'auxPortalPointerDragMode',
+            DEFAULT_PORTAL_POINTER_DRAG_MODE
         )
     );
     if (mode === 'grid' || mode === 'world') {
         return mode;
     }
-    return DEFAULT_PORTAL_RAYCAST_MODE;
+    return DEFAULT_PORTAL_POINTER_DRAG_MODE;
 }
 
 /**

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -57,6 +57,7 @@ import {
     getBotSubShape,
     getBotOrientationMode,
     getBotAnchorPoint,
+    calculatePortalRaycastMode,
 } from '../BotCalculations';
 import {
     Bot,
@@ -3545,6 +3546,28 @@ export function botCalculationContextTests(
             const shape = getBotAnchorPoint(calc, bot);
 
             expect(shape).toBe('bottom');
+        });
+    });
+
+    describe('calculatePortalRaycastMode()', () => {
+        const cases = [['grid'], ['world']];
+        it.each(cases)('should return %s', (mode: string) => {
+            const bot = createBot('test', {
+                auxPortalRaycastMode: <any>mode,
+            });
+
+            const calc = createCalculationContext([bot]);
+
+            expect(calculatePortalRaycastMode(calc, bot)).toBe(mode);
+        });
+
+        it('should default to world', () => {
+            const bot = createBot();
+
+            const calc = createCalculationContext([bot]);
+            const shape = calculatePortalRaycastMode(calc, bot);
+
+            expect(shape).toBe('world');
         });
     });
 

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -57,7 +57,7 @@ import {
     getBotSubShape,
     getBotOrientationMode,
     getBotAnchorPoint,
-    calculatePortalRaycastMode,
+    calculatePortalPointerDragMode,
 } from '../BotCalculations';
 import {
     Bot,
@@ -3549,23 +3549,23 @@ export function botCalculationContextTests(
         });
     });
 
-    describe('calculatePortalRaycastMode()', () => {
+    describe('calculatePortalPointerDragMode()', () => {
         const cases = [['grid'], ['world']];
         it.each(cases)('should return %s', (mode: string) => {
             const bot = createBot('test', {
-                auxPortalRaycastMode: <any>mode,
+                auxPortalPointerDragMode: <any>mode,
             });
 
             const calc = createCalculationContext([bot]);
 
-            expect(calculatePortalRaycastMode(calc, bot)).toBe(mode);
+            expect(calculatePortalPointerDragMode(calc, bot)).toBe(mode);
         });
 
         it('should default to world', () => {
             const bot = createBot();
 
             const calc = createCalculationContext([bot]);
-            const shape = calculatePortalRaycastMode(calc, bot);
+            const shape = calculatePortalPointerDragMode(calc, bot);
 
             expect(shape).toBe('world');
         });

--- a/src/aux-server/aux-web/aux-player/scene/PlayerSimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerSimulation3D.ts
@@ -150,6 +150,16 @@ export class PlayerSimulation3D extends Simulation3D {
         return null;
     }
 
+    getPortalConfigForGrid(grid: Grid3D): PortalConfig {
+        for (let portal of this.portals) {
+            if (portal.grid3D === grid) {
+                return portal;
+            }
+        }
+
+        return null;
+    }
+
     init() {
         super.init();
         this._watchDimensionBot();

--- a/src/aux-server/aux-web/aux-player/scene/PortalConfig.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PortalConfig.ts
@@ -10,9 +10,9 @@ import {
     calculateBooleanTagValue,
     calculateNumericalTagValue,
     DEFAULT_PORTAL_ROTATABLE,
-    PortalRaycastMode,
-    DEFAULT_PORTAL_RAYCAST_MODE,
-    calculatePortalRaycastMode,
+    PortalPointerDragMode,
+    DEFAULT_PORTAL_POINTER_DRAG_MODE,
+    calculatePortalPointerDragMode,
 } from '@casual-simulation/aux-common';
 import { Color } from 'three';
 import {
@@ -43,7 +43,7 @@ export class PortalConfig implements SubscriptionLike {
     private _playerRotationX: number = null;
     private _playerRotationY: number = null;
     private _gridScale: number;
-    private _raycastMode: PortalRaycastMode = null;
+    private _raycastMode: PortalPointerDragMode = null;
     private _grid3D: BoundedGrid3D;
 
     private _onGridScaleUpdated: Subject<void>;
@@ -208,7 +208,7 @@ export class PortalConfig implements SubscriptionLike {
         if (this._raycastMode != null) {
             return this._raycastMode;
         } else {
-            return DEFAULT_PORTAL_RAYCAST_MODE;
+            return DEFAULT_PORTAL_POINTER_DRAG_MODE;
         }
     }
 
@@ -366,7 +366,7 @@ export class PortalConfig implements SubscriptionLike {
             `auxPortalPlayerRotationY`,
             null
         );
-        this._raycastMode = calculatePortalRaycastMode(calc, bot);
+        this._raycastMode = calculatePortalPointerDragMode(calc, bot);
         this.gridScale = calculateGridScale(calc, bot);
 
         // TODO:

--- a/src/aux-server/aux-web/aux-player/scene/PortalConfig.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PortalConfig.ts
@@ -10,6 +10,9 @@ import {
     calculateBooleanTagValue,
     calculateNumericalTagValue,
     DEFAULT_PORTAL_ROTATABLE,
+    PortalRaycastMode,
+    DEFAULT_PORTAL_RAYCAST_MODE,
+    calculatePortalRaycastMode,
 } from '@casual-simulation/aux-common';
 import { Color } from 'three';
 import {
@@ -26,20 +29,21 @@ import { BoundedGrid3D } from '../BoundedGrid3D';
 export class PortalConfig implements SubscriptionLike {
     private _sub: Subscription;
     private _portalTag: string;
-    private _dimensionBackground: Color;
-    private _pannable: boolean;
-    private _panMinX: number;
-    private _panMaxX: number;
-    private _panMaxY: number;
-    private _panMinY: number;
-    private _zoomable: boolean;
-    private _zoomMin: number;
-    private _zoomMax: number;
-    private _rotatable: boolean;
-    private _playerZoom: number;
-    private _playerRotationX: number;
-    private _playerRotationY: number;
+    private _dimensionBackground: Color = null;
+    private _pannable: boolean = null;
+    private _panMinX: number = null;
+    private _panMaxX: number = null;
+    private _panMaxY: number = null;
+    private _panMinY: number = null;
+    private _zoomable: boolean = null;
+    private _zoomMin: number = null;
+    private _zoomMax: number = null;
+    private _rotatable: boolean = null;
+    private _playerZoom: number = null;
+    private _playerRotationX: number = null;
+    private _playerRotationY: number = null;
     private _gridScale: number;
+    private _raycastMode: PortalRaycastMode = null;
     private _grid3D: BoundedGrid3D;
 
     private _onGridScaleUpdated: Subject<void>;
@@ -200,6 +204,14 @@ export class PortalConfig implements SubscriptionLike {
         this._onGridScaleUpdated.next();
     }
 
+    get raycastMode() {
+        if (this._raycastMode != null) {
+            return this._raycastMode;
+        } else {
+            return DEFAULT_PORTAL_RAYCAST_MODE;
+        }
+    }
+
     get grid3D() {
         return this._grid3D;
     }
@@ -262,6 +274,7 @@ export class PortalConfig implements SubscriptionLike {
         this._playerZoom = null;
         this._playerRotationX = null;
         this._playerRotationY = null;
+        this._raycastMode = null;
         this.gridScale = this._getDefaultGridScale();
     }
 
@@ -353,6 +366,7 @@ export class PortalConfig implements SubscriptionLike {
             `auxPortalPlayerRotationY`,
             null
         );
+        this._raycastMode = calculatePortalRaycastMode(calc, bot);
         this.gridScale = calculateGridScale(calc, bot);
 
         // TODO:

--- a/src/aux-server/aux-web/shared/interaction/BaseInteractionManager.ts
+++ b/src/aux-server/aux-web/shared/interaction/BaseInteractionManager.ts
@@ -38,6 +38,7 @@ import { CameraRigControls } from './CameraRigControls';
 import { Game } from '../scene/Game';
 import { DimensionGroup3D } from '../scene/DimensionGroup3D';
 import { DebugObjectManager } from '../scene/debugobjectmanager/DebugObjectManager';
+import { Viewport } from '../scene/Viewport';
 
 interface HoveredBot {
     /**
@@ -549,7 +550,11 @@ export abstract class BaseInteractionManager {
      * Find the first game object that is being pointed at by the given ray.
      * @param ray The ray.
      */
-    findHoveredGameObjectFromRay(ray: Ray) {
+    findHoveredGameObjectFromRay(
+        ray: Ray,
+        hitFilter: (hit: Intersection) => boolean = null,
+        viewport: Viewport = null
+    ) {
         const draggableGroups = this.getDraggableGroups();
 
         let hit: Intersection = null;
@@ -561,8 +566,12 @@ export abstract class BaseInteractionManager {
             const objects = group.objects;
             const camera = group.camera;
 
+            if (viewport && group.viewport !== viewport) {
+                continue;
+            }
+
             const raycastResult = Physics.raycast(ray, objects, camera);
-            hit = Physics.firstRaycastHit(raycastResult);
+            hit = Physics.firstRaycastHit(raycastResult, hitFilter);
             hitObject = hit ? this.findGameObjectForHit(hit) : null;
 
             if (hitObject) {

--- a/src/aux-server/aux-web/shared/interaction/DragOperation/BaseBotDragOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/DragOperation/BaseBotDragOperation.ts
@@ -54,7 +54,6 @@ export abstract class BaseBotDragOperation implements IOperation {
     protected _lastGridPos: Vector2;
     protected _lastIndex: number;
     protected _lastVRControllerPose: Object3D;
-    protected _merge: boolean;
     protected _other: Bot;
     protected _dimension: string;
     protected _previousDimension: string;

--- a/src/aux-server/aux-web/shared/scene/Physics.ts
+++ b/src/aux-server/aux-web/shared/scene/Physics.ts
@@ -126,8 +126,16 @@ export namespace Physics {
 
     /**
      * Returns the first intersection from the raycast test. If none exist, then null is returned.
+     * @param result The raycast result.
+     * @param hitFilter The filter that should be used for intersections. Should return true for the hit that should be returned.
      */
-    export function firstRaycastHit(result: RaycastResult) {
+    export function firstRaycastHit(
+        result: RaycastResult,
+        hitFilter: (hit: Intersection) => boolean = null
+    ) {
+        if (hitFilter) {
+            return result.intersects.find(i => hitFilter(i)) || null;
+        }
         return result.intersects.length > 0 ? result.intersects[0] : null;
     }
 }


### PR DESCRIPTION
-   :rocket: Improvements
    -   Improved drag and drop interactions to calculate intersections with other bots instead of just using grid positioning.
        -   This makes it easier drop a bot onto another specific bot.
        -   Can be controlled with the `#auxPortalPointerCollisionMode` tag on a portal config.
            -   Possible values are:
                -   `world` - The mouse pointer collides with other bots in the world when being dragged. (Default)
                -   `grid` - The mouse pointer ignores other bots in the world when being dragged.