### PR TITLE
Fix a bunch of auxAnchorPoint and auxOrientationMode issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
         -   Now, only the bot form is moved to ensure the correctness of the resulting scale and rotation calculations.
     -   `#auxOrientationMode`
         -   Renamed the `billboardX` option to `billboardZ`.
+    -   Changed iframes forms to not support strokes.
 
 -   :rocket: Improvements
 
@@ -30,6 +31,7 @@
     -   Fixed issues with scale and rotation when `#auxAnchorPoint` is set to `center`.
     -   Fixed sprite billboarding issues when looking straight down at them.
     -   Fixed an issue where the wrong Z position tag of a bot was used for calculating how bots stack.
+    -   Fixed an issue where the bot stroke was being considered for collision detection. This caused bots with strokes to have a much larger hit box than they should have had.
 
 ## V1.0.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # AUX Changelog
 
+## V1.0.16
+
+### Date: TBD
+
+### Changes:
+
+-   :boom: Breaking Changes
+
+    -   Both sprites and iframes now face upwards by default.
+    -   `#auxAnchorPoint` has been changed to move the bot form inside of its virtual spacing box.
+        -   Previously, both the virtual box and the bot form was moved to try and preserve the absolute positioning of the bot form when changing anchor points.
+        -   Now, only the bot form is moved to ensure the correctness of the resulting scale and rotation calculations.
+    -   `#auxOrientationMode`
+        -   Renamed the `billboardX` option to `billboardZ`.
+
+-   :rocket: Improvements
+
+    -   Added the following options for `#auxAnchorPoint`
+        -   `centerFront` - Positions the bot form such that the center of the form's front face is at the center of the virtual bot.
+        -   `centerBack` - Positions the bot form such that the center of the form's back face is at the center of the virtual bot.
+        -   `bottomFront` - Positions the bot form such that the bottom of the form's front face is at the center of the virtual bot.
+        -   `bottomBack` - Positions the bot form such that the bottom of the form's back face is at the center of the virtual bot.
+        -   `top` - Positions the bot form such that the top of the form is at the center of the virtual bot.
+        -   `topFront` - Positions the bot form such that the top of the form's front face is at the center of the virtual bot.
+        -   `topBack` - Positions the bot form such that the top of the form's back face is at the center of the virtual bot.
+
+-   :bug: Bug Fixes
+    -   Fixed issues with scale and rotation when `#auxAnchorPoint` is set to `center`.
+    -   Fixed sprite billboarding issues when looking straight down at them.
+    -   Fixed an issue where the wrong Z position tag of a bot was used for calculating how bots stack.
+
 ## V1.0.15
 
 ### Date: 3/13/2020

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -544,9 +544,6 @@ The mode that determines how the bot automatically rotates.
   <PossibleValueCode value='billboardX'>
     The bot rotates left and right automatically to face the player.
   </PossibleValueCode>
-  <PossibleValueCode value='billboardZ'>
-    The bot rotates up and down automatically to face the player.
-  </PossibleValueCode>
 </PossibleValuesTable>
 
 ## Dimension Tags

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -541,7 +541,7 @@ The mode that determines how the bot automatically rotates.
   <PossibleValueCode value='billboard'>
     The bot rotates left, right, up, and down automatically to face the player.
   </PossibleValueCode>
-  <PossibleValueCode value='billboardX'>
+  <PossibleValueCode value='billboardZ'>
     The bot rotates left and right automatically to face the player.
   </PossibleValueCode>
 </PossibleValuesTable>

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -425,19 +425,19 @@ The name of the animation that the mesh should play.
 Only works for mesh forms.
 
 <PossibleValuesTable>
-  <PossibleValueCode value='Nothing'>
+  <PossibleValueCode value='null'>
     Play the first animation.
   </PossibleValueCode>
   <PossibleValueCode value='false'>
     Stops animating the mesh.
   </PossibleValueCode>
-  <PossibleValueCode value='Any String'>
+  <PossibleValue value='Any String'>
     Play the animation with the given name.
-  </PossibleValueCode>
-  <PossibleValueCode value='Any Integer >= 0'>
+  </PossibleValue>
+  <PossibleValue value='Any Integer >= 0'>
     Play the animation at the given index.
     Useful for exploring possible animations if you don't have the name.
-  </PossibleValueCode>
+  </PossibleValue>
 </PossibleValuesTable>
 
 ### `auxGLTFVersion`
@@ -450,10 +450,10 @@ The GLTF specification version that should be used to load a GLTF model.
   <PossibleValueCode value='2'>
     Load the GLTF model with version 2 of the specification. (default)
   </PossibleValueCode>
-  <PossibleValueCode value='Numbers < 2'>
+  <PossibleValue value='Numbers < 2'>
     Load the GLTF Model with version 1 of the specification.
     This is useful for loading meshes from <a href="https://poly.google.com">poly.google.com</a>.
-  </PossibleValueCode>
+  </PossibleValue>
 </PossibleValuesTable>
 
 ### `auxProgressBar`

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -526,8 +526,8 @@ The position that the bot should rotate and scale around.
   <PossibleValueCode value='bottomFront'>
     The bot rotates and scales around the point at the bottom of the Bot's front face.
   </PossibleValueCode>
-  <PossibleValueCode value='bottomRear'>
-    The bot rotates and scales around the point at the bottom of the Bot's rear face.
+  <PossibleValueCode value='bottomBack'>
+    The bot rotates and scales around the point at the bottom of the Bot's back face.
   </PossibleValueCode>
   <PossibleValueCode value='center'>
     The bot rotates and scales around its center point.
@@ -535,8 +535,8 @@ The position that the bot should rotate and scale around.
   <PossibleValueCode value='centerFront'>
     The bot rotates and scales around the point at the center of the Bot's front face.
   </PossibleValueCode>
-  <PossibleValueCode value='centerRear'>
-    The bot rotates and scales around the point at the center of the Bot's rear face.
+  <PossibleValueCode value='centerBack'>
+    The bot rotates and scales around the point at the center of the Bot's back face.
   </PossibleValueCode>
   <PossibleValueCode value='top'>
     The bot rotates and scales around its top point.
@@ -544,8 +544,8 @@ The position that the bot should rotate and scale around.
   <PossibleValueCode value='topFront'>
     The bot rotates and scales around the point at the top of the Bot's front face.
   </PossibleValueCode>
-  <PossibleValueCode value='topRear'>
-    The bot rotates and scales around the point at the top of the Bot's rear face.
+  <PossibleValueCode value='topBack'>
+    The bot rotates and scales around the point at the top of the Bot's back face.
   </PossibleValueCode>
 </PossibleValuesTable>
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -523,8 +523,29 @@ The position that the bot should rotate and scale around.
   <PossibleValueCode value='bottom'>
     The bot rotates and scales around its bottom point. (default)
   </PossibleValueCode>
+  <PossibleValueCode value='bottomFront'>
+    The bot rotates and scales around the point at the bottom of the Bot's front face.
+  </PossibleValueCode>
+  <PossibleValueCode value='bottomRear'>
+    The bot rotates and scales around the point at the bottom of the Bot's rear face.
+  </PossibleValueCode>
   <PossibleValueCode value='center'>
     The bot rotates and scales around its center point.
+  </PossibleValueCode>
+  <PossibleValueCode value='centerFront'>
+    The bot rotates and scales around the point at the center of the Bot's front face.
+  </PossibleValueCode>
+  <PossibleValueCode value='centerRear'>
+    The bot rotates and scales around the point at the center of the Bot's rear face.
+  </PossibleValueCode>
+  <PossibleValueCode value='top'>
+    The bot rotates and scales around its top point.
+  </PossibleValueCode>
+  <PossibleValueCode value='topFront'>
+    The bot rotates and scales around the point at the top of the Bot's front face.
+  </PossibleValueCode>
+  <PossibleValueCode value='topRear'>
+    The bot rotates and scales around the point at the top of the Bot's rear face.
   </PossibleValueCode>
 </PossibleValuesTable>
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -294,7 +294,7 @@ export type BotLabelAnchor =
 /**
  * Defines the possible bot orientation modes.
  */
-export type BotOrientationMode = 'absolute' | 'billboard' | 'billboardX';
+export type BotOrientationMode = 'absolute' | 'billboard' | 'billboardZ';
 
 /**
  * Defines the possible bot anchor points.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -302,13 +302,13 @@ export type BotOrientationMode = 'absolute' | 'billboard' | 'billboardZ';
 export type BotAnchorPoint =
     | 'center'
     | 'centerFront'
-    | 'centerRear'
+    | 'centerBack'
     | 'bottom'
     | 'bottomFront'
-    | 'bottomRear'
+    | 'bottomBack'
     | 'top'
     | 'topFront'
-    | 'topRear';
+    | 'topBack';
 
 /**
  * Defines the possible portal raycast modes.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -299,7 +299,16 @@ export type BotOrientationMode = 'absolute' | 'billboard' | 'billboardZ';
 /**
  * Defines the possible bot anchor points.
  */
-export type BotAnchorPoint = 'center' | 'bottom';
+export type BotAnchorPoint =
+    | 'center'
+    | 'centerFront'
+    | 'centerRear'
+    | 'bottom'
+    | 'bottomFront'
+    | 'bottomRear'
+    | 'top'
+    | 'topFront'
+    | 'topRear';
 
 /**
  * Defines the possible portal raycast modes.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -294,11 +294,7 @@ export type BotLabelAnchor =
 /**
  * Defines the possible bot orientation modes.
  */
-export type BotOrientationMode =
-    | 'absolute'
-    | 'billboard'
-    | 'billboardX'
-    | 'billboardZ';
+export type BotOrientationMode = 'absolute' | 'billboard' | 'billboardX';
 
 /**
  * Defines the possible bot anchor points.

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1297,6 +1297,18 @@ export function getBotOrientationMode(
     return DEFAULT_ORIENTATION_MODE;
 }
 
+const possibleAnchorPoints = new Set([
+    'center',
+    'centerFront',
+    'centerRear',
+    'bottom',
+    'bottomFront',
+    'bottomRear',
+    'top',
+    'topFront',
+    'topRear',
+] as const);
+
 /**
  * Gets the orientation mode for the given bot.
  * @param calc The calculation context.
@@ -1314,7 +1326,8 @@ export function getBotAnchorPoint(
             DEFAULT_ANCHOR_POINT
         )
     );
-    if (mode === 'center' || mode === 'bottom') {
+
+    if (possibleAnchorPoints.has(mode)) {
         return mode;
     }
     return DEFAULT_ANCHOR_POINT;

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1291,7 +1291,7 @@ export function getBotOrientationMode(
             DEFAULT_ORIENTATION_MODE
         )
     );
-    if (mode === 'absolute' || mode === 'billboard' || mode === 'billboardX') {
+    if (mode === 'absolute' || mode === 'billboard' || mode === 'billboardZ') {
         return mode;
     }
     return DEFAULT_ORIENTATION_MODE;

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1300,13 +1300,13 @@ export function getBotOrientationMode(
 const possibleAnchorPoints = new Set([
     'center',
     'centerFront',
-    'centerRear',
+    'centerBack',
     'bottom',
     'bottomFront',
-    'bottomRear',
+    'bottomBack',
     'top',
     'topFront',
-    'topRear',
+    'topBack',
 ] as const);
 
 /**

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1291,12 +1291,7 @@ export function getBotOrientationMode(
             DEFAULT_ORIENTATION_MODE
         )
     );
-    if (
-        mode === 'absolute' ||
-        mode === 'billboard' ||
-        mode === 'billboardX' ||
-        mode === 'billboardZ'
-    ) {
+    if (mode === 'absolute' || mode === 'billboard' || mode === 'billboardX') {
         return mode;
     }
     return DEFAULT_ORIENTATION_MODE;

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3523,7 +3523,18 @@ export function botCalculationContextTests(
     });
 
     describe('getBotAnchorPoint()', () => {
-        const cases = [['center'], ['bottom']];
+        const cases = [
+            ['center'],
+            ['centerFront'],
+            ['centerRear'],
+            ['bottom'],
+            ['bottomFront'],
+            ['bottomRear'],
+            ['top'],
+            ['topFront'],
+            ['topRear'],
+        ];
+
         it.each(cases)('should return %s', (mode: string) => {
             const bot = createBot('test', {
                 auxAnchorPoint: <any>mode,

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3501,7 +3501,7 @@ export function botCalculationContextTests(
     });
 
     describe('getBotOrientationMode()', () => {
-        const cases = [['absolute'], ['billboard'], ['billboardX']];
+        const cases = [['absolute'], ['billboard'], ['billboardZ']];
         it.each(cases)('should return %s', (mode: string) => {
             const bot = createBot('test', {
                 auxOrientationMode: <any>mode,

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3526,13 +3526,13 @@ export function botCalculationContextTests(
         const cases = [
             ['center'],
             ['centerFront'],
-            ['centerRear'],
+            ['centerBack'],
             ['bottom'],
             ['bottomFront'],
-            ['bottomRear'],
+            ['bottomBack'],
             ['top'],
             ['topFront'],
-            ['topRear'],
+            ['topBack'],
         ];
 
         it.each(cases)('should return %s', (mode: string) => {

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3501,12 +3501,7 @@ export function botCalculationContextTests(
     });
 
     describe('getBotOrientationMode()', () => {
-        const cases = [
-            ['absolute'],
-            ['billboard'],
-            ['billboardX'],
-            ['billboardZ'],
-        ];
+        const cases = [['absolute'], ['billboard'], ['billboardX']];
         it.each(cases)('should return %s', (mode: string) => {
             const bot = createBot('test', {
                 auxOrientationMode: <any>mode,

--- a/src/aux-server/aux-web/shared/interaction/BaseInteractionManager.ts
+++ b/src/aux-server/aux-web/shared/interaction/BaseInteractionManager.ts
@@ -74,6 +74,7 @@ export abstract class BaseInteractionManager {
 
     private _operations: IOperation[];
     private _overHtmlMixerIFrame: boolean;
+    private _cameraControlsEnabled: boolean;
 
     // A map for input methods to the bot that they're directly interacting with.
     private _inputMethodMap: Map<string, AuxBot3D>;
@@ -89,6 +90,7 @@ export abstract class BaseInteractionManager {
         this._maxTapCodeLength = 4;
         this._hoveredBots = [];
         this._inputMethodMap = new Map();
+        this._cameraControlsEnabled = true;
 
         // Bind event handlers to this instance of the class.
         this._handleBotAdded = this._handleBotAdded.bind(this);
@@ -116,6 +118,20 @@ export abstract class BaseInteractionManager {
 
     get overHtmlMixerIFrame() {
         return this._overHtmlMixerIFrame;
+    }
+
+    /**
+     * Gets whether the camera controls should be enabled.
+     */
+    get cameraControlsEnabled() {
+        return this._cameraControlsEnabled;
+    }
+
+    /**
+     * Sets whether the camera controls should be enabled.
+     */
+    set cameraControlsEnabled(value: boolean) {
+        this._cameraControlsEnabled = value;
     }
 
     /**
@@ -182,7 +198,7 @@ export abstract class BaseInteractionManager {
 
         if (this._operations.length === 0) {
             // Enable camera controls when there are no more operations.
-            this.setCameraControlsEnabled(true);
+            this.setCameraControlsEnabled(this._cameraControlsEnabled);
         }
 
         this._cameraRigControllers.forEach(rigControls =>
@@ -268,7 +284,7 @@ export abstract class BaseInteractionManager {
                 input.isMouseButtonDownOnElement(this._game.gameView.gameView)
             ) {
                 // Always allow camera control with middle clicks.
-                this.setCameraControlsEnabled(true);
+                this.setCameraControlsEnabled(this._cameraControlsEnabled);
             }
         }
 
@@ -347,7 +363,7 @@ export abstract class BaseInteractionManager {
             this._operations.push(emptyClickOperation);
         }
         if (inputMethod.type !== 'controller') {
-            this.setCameraControlsEnabled(true);
+            this.setCameraControlsEnabled(this._cameraControlsEnabled);
         }
     }
 

--- a/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
@@ -36,6 +36,11 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
     container: Group;
 
     /**
+     * The container that applies scales to the bot.
+     */
+    scaleContainer: Group;
+
+    /**
      * The things that are displayed by this bot.
      */
     display: Group;
@@ -94,8 +99,10 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
         this.dimension = dimension;
         this.container = new Group();
         this.display = new Group();
+        this.scaleContainer = new Group();
         this.add(this.container);
-        this.container.add(this.display);
+        this.container.add(this.scaleContainer);
+        this.scaleContainer.add(this.display);
 
         this.decorators = decoratorFactory.loadDecorators(this);
         this.updateFrameUpdateList();

--- a/src/aux-server/aux-web/shared/scene/Game.ts
+++ b/src/aux-server/aux-web/shared/scene/Game.ts
@@ -23,6 +23,7 @@ import { ArgEvent } from '@casual-simulation/aux-common/Events';
 import {
     Bot,
     DEFAULT_SCENE_BACKGROUND_COLOR,
+    hasValue,
 } from '@casual-simulation/aux-common';
 import {
     CameraRig,
@@ -52,6 +53,7 @@ import { DebugObjectManager } from './debugobjectmanager/DebugObjectManager';
 import Bowser from 'bowser';
 import { AuxBot3D } from './AuxBot3D';
 import { supportsXR } from '../SharedUtils';
+import merge from 'lodash/merge';
 
 export const PREFERRED_XR_REFERENCE_SPACE = 'local-floor';
 
@@ -93,6 +95,12 @@ export abstract class Game implements AuxBotVisualizerFinder {
 
     constructor(gameView: IGameView) {
         this.gameView = gameView;
+
+        if (hasValue(window)) {
+            merge((<any>window).aux || {}, {
+                getGame: () => this,
+            });
+        }
     }
 
     async setup() {

--- a/src/aux-server/aux-web/shared/scene/decorators/AuxBot3DDecoratorFactory.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/AuxBot3DDecoratorFactory.ts
@@ -61,7 +61,7 @@ export class AuxBot3DDecoratorFactory {
 
         decorators.push(
             new ScaleDecorator(bot3d),
-            new DimensionPositionDecorator(bot3d, { lerp: isUser })
+            new DimensionPositionDecorator(bot3d, this.game, { lerp: isUser })
         );
 
         if (!!this.game) {

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -367,6 +367,7 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         });
 
         this.container.add(this._iframe.object3d);
+        this.container.rotation.set(ThreeMath.degToRad(-90), 0, 0);
 
         this._createCube();
         this.mesh.scale.set(1, 0.01, 0.05);

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -34,6 +34,7 @@ import {
     AnimationMixer,
     SkinnedMesh,
     AnimationAction,
+    MathUtils as ThreeMath,
 } from 'three';
 import {
     createCube,
@@ -440,6 +441,7 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
 
     private _createSprite() {
         this.mesh = this.collider = createSprite();
+        this.mesh.rotation.set(ThreeMath.degToRad(-90), 0, 0);
         this.container.add(this.mesh);
         this.bot3D.colliders.push(this.collider);
         this.stroke = null;

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -171,11 +171,11 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         const hasStroke = typeof strokeColorValue !== 'undefined';
         if (hasStroke && !this.stroke) {
             this.stroke = createStroke();
-            this.mesh.add(this.stroke);
+            this.container.add(this.stroke);
         } else if (!hasStroke) {
             if (this.stroke) {
                 disposeMesh(this.stroke);
-                this.mesh.remove(this.stroke);
+                this.container.remove(this.stroke);
 
                 this.stroke = null;
             }
@@ -372,6 +372,7 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         this._createCube();
         this.mesh.scale.set(1, 0.01, 0.05);
         this.mesh.position.set(0, -0.5, 0);
+        this._canHaveStroke = false;
 
         return true;
     }

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -19,7 +19,15 @@ import {
     BotOrientationMode,
     getBotIndex,
 } from '@casual-simulation/aux-common';
-import { Vector3, Quaternion, Euler, Vector2, Object3D } from 'three';
+import {
+    Vector3,
+    Quaternion,
+    Euler,
+    Vector2,
+    Object3D,
+    MathUtils as ThreeMath,
+    Matrix4,
+} from 'three';
 import { calculateGridTileLocalCenter } from '../grid/Grid';
 import { realPosToGridPos, Axial, posToKey } from '../hex';
 import { BuilderGroup3D } from '../BuilderGroup3D';
@@ -62,33 +70,41 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
     botUpdated(calc: BotCalculationContext): void {
         const nextOrientationMode = getBotOrientationMode(calc, this.bot3D.bot);
         const nextAnchorPoint = getBotAnchorPoint(calc, this.bot3D.bot);
+        const gridScale = this.bot3D.gridScale;
+        const botScale = calculateScale(calc, this.bot3D.bot, gridScale);
 
         if (nextOrientationMode !== this._orientationMode) {
             this.bot3D.display.rotation.set(0, 0, 0);
         }
         this._orientationMode = nextOrientationMode;
         this._anchorPoint = nextAnchorPoint;
+        this._rotationObj = this.bot3D.container;
 
         // Update the offsets for the center vs bottom
         // anchor positions so that the bot is above the grid and
         // not in it
-        if (this._anchorPoint === 'center') {
-            this.bot3D.display.position.set(0, 0, 0);
-            if (this._rotationObj) {
-                this._rotationObj.rotation.set(0, 0, 0);
-            }
-            this._rotationObj = this.bot3D.display;
+
+        let displayOffset = new Vector3();
+
+        if (this._anchorPoint.startsWith('center')) {
+        } else if (this._anchorPoint.startsWith('top')) {
+            displayOffset.y = -0.5;
+        } else if (this._anchorPoint.startsWith('bottom')) {
+            displayOffset.y = 0.5;
         } else {
-            this.bot3D.display.position.set(0, 0.5, 0);
-            if (this._rotationObj) {
-                this._rotationObj.rotation.set(0, 0, 0);
-            }
-            this._rotationObj = this.bot3D.container;
+            displayOffset.y = 0.5;
         }
+        if (this._anchorPoint.endsWith('Front')) {
+            displayOffset.z = -0.5;
+        } else if (this._anchorPoint.endsWith('Rear')) {
+            displayOffset.z = 0.5;
+        } else {
+            displayOffset.z = 0;
+        }
+        this.bot3D.display.position.copy(displayOffset);
 
         const userDimension = this.bot3D.dimension;
         if (userDimension) {
-            const scale = this.bot3D.gridScale;
             const currentGridPos = getBotPosition(
                 calc,
                 this.bot3D.bot,
@@ -98,7 +114,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
                 calc,
                 this.bot3D.bot,
                 this.bot3D.dimension,
-                scale
+                gridScale
             );
             const currentSortOrder = getBotIndex(
                 calc,
@@ -108,18 +124,8 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
             this._nextPos = calculateObjectPositionInGrid(
                 calc,
                 this.bot3D,
-                scale
+                gridScale
             );
-
-            // Offset the container so that the bot still
-            // is above the grid
-            if (this._anchorPoint === 'center') {
-                this._nextPos.add(
-                    new Vector3(0, 0.5, 0).multiplyScalar(
-                        this.bot3D.container.scale.x
-                    )
-                );
-            }
 
             if (
                 this._positionUpdated(currentGridPos, currentSortOrder) ||
@@ -157,7 +163,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
             this._atPosition = false;
             this._atRotation = false;
             if (!this._lerp) {
-                this.bot3D.container.position.copy(this._nextPos);
+                this.bot3D.position.copy(this._nextPos);
                 this._rotationObj.rotation.set(
                     this._nextRot.x,
                     this._nextRot.z,
@@ -204,10 +210,8 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
     frameUpdate(calc: BotCalculationContext): void {
         if (this._lerp && this._nextPos && this._nextRot) {
             if (!this._atPosition) {
-                this.bot3D.container.position.lerp(this._nextPos, 0.1);
-                const distance = this.bot3D.container.position.distanceTo(
-                    this._nextPos
-                );
+                this.bot3D.position.lerp(this._nextPos, 0.1);
+                const distance = this.bot3D.position.distanceTo(this._nextPos);
                 this._atPosition = distance < 0.01;
             }
 
@@ -226,7 +230,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
             }
 
             if (!this._atPosition || !this._atRotation) {
-                this.bot3D.container.updateMatrixWorld(true);
+                this.bot3D.updateMatrixWorld(true);
             }
         } else {
             let update = false;
@@ -246,6 +250,15 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
 
                 this._rotationObj.up = cameraUp;
                 this._rotationObj.lookAt(cameraWorld);
+
+                // Rotate the object 90 degrees around its X axis
+                // so that the top of the bot is facing the camera.
+                const rotationOffset = new Quaternion().setFromAxisAngle(
+                    new Vector3(1, 0, 0),
+                    ThreeMath.degToRad(90)
+                );
+                this._rotationObj.quaternion.multiply(rotationOffset);
+
                 update = true;
                 if (this._orientationMode === 'billboardZ') {
                     const euler = new Euler().setFromQuaternion(

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -18,6 +18,7 @@ import {
     BotAnchorPoint,
     BotOrientationMode,
     getBotIndex,
+    getBotScale,
 } from '@casual-simulation/aux-common';
 import {
     Vector3,
@@ -71,19 +72,14 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
         const nextOrientationMode = getBotOrientationMode(calc, this.bot3D.bot);
         const nextAnchorPoint = getBotAnchorPoint(calc, this.bot3D.bot);
         const gridScale = this.bot3D.gridScale;
-        const botScale = calculateScale(calc, this.bot3D.bot, gridScale);
 
-        if (nextOrientationMode !== this._orientationMode) {
-            this.bot3D.display.rotation.set(0, 0, 0);
-        }
         this._orientationMode = nextOrientationMode;
         this._anchorPoint = nextAnchorPoint;
         this._rotationObj = this.bot3D.container;
 
-        // Update the offsets for the center vs bottom
-        // anchor positions so that the bot is above the grid and
-        // not in it
-
+        // Update the offset for the display container
+        // so that it rotates around the specified
+        // point
         let displayOffset = new Vector3();
 
         if (this._anchorPoint.startsWith('center')) {

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -23,7 +23,7 @@ import { Vector3, Quaternion, Euler, Vector2, Object3D } from 'three';
 import { calculateGridTileLocalCenter } from '../grid/Grid';
 import { realPosToGridPos, Axial, posToKey } from '../hex';
 import { BuilderGroup3D } from '../BuilderGroup3D';
-import { calculateScale } from '../SceneUtils';
+import { calculateScale, objectForwardRay } from '../SceneUtils';
 
 /**
  * Defines an interface that contains possible options for DimensionPositionDecorator objects.
@@ -238,6 +238,14 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
                 cameraWorld.setFromMatrixPosition(
                     cameraRig.mainCamera.matrixWorld
                 );
+                const cameraRotation = new Quaternion().setFromRotationMatrix(
+                    cameraRig.mainCamera.matrixWorld
+                );
+                const cameraUp = new Vector3(0, 1, 0);
+                const cameraRight = new Vector3(0, 1, 0);
+                cameraUp.applyQuaternion(cameraRotation);
+
+                this._rotationObj.up = cameraUp;
                 this._rotationObj.lookAt(cameraWorld);
                 update = true;
                 if (this._orientationMode === 'billboardX') {

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -92,7 +92,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
         }
         if (this._anchorPoint.endsWith('Front')) {
             displayOffset.z = -0.5;
-        } else if (this._anchorPoint.endsWith('Rear')) {
+        } else if (this._anchorPoint.endsWith('Back')) {
             displayOffset.z = 0.5;
         } else {
             displayOffset.z = 0;

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -366,7 +366,7 @@ export function calculateVerticalHeight(
             const offset = calculateNumericalTagValue(
                 calc,
                 bot,
-                `${dimension}.z`,
+                `${dimension}Z`,
                 0
             );
 

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -231,7 +231,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
         } else {
             let update = false;
             if (
-                ['billboard', 'billboardX'].indexOf(this._orientationMode) >= 0
+                ['billboard', 'billboardZ'].indexOf(this._orientationMode) >= 0
             ) {
                 const cameraRig = this.bot3D.dimensionGroup.simulation3D.getMainCameraRig();
                 const cameraWorld = new Vector3();
@@ -242,13 +242,12 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
                     cameraRig.mainCamera.matrixWorld
                 );
                 const cameraUp = new Vector3(0, 1, 0);
-                const cameraRight = new Vector3(0, 1, 0);
                 cameraUp.applyQuaternion(cameraRotation);
 
                 this._rotationObj.up = cameraUp;
                 this._rotationObj.lookAt(cameraWorld);
                 update = true;
-                if (this._orientationMode === 'billboardX') {
+                if (this._orientationMode === 'billboardZ') {
                     const euler = new Euler().setFromQuaternion(
                         this._rotationObj.quaternion,
                         'YXZ'

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -231,9 +231,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
         } else {
             let update = false;
             if (
-                ['billboard', 'billboardX', 'billboardZ'].indexOf(
-                    this._orientationMode
-                ) >= 0
+                ['billboard', 'billboardX'].indexOf(this._orientationMode) >= 0
             ) {
                 const cameraRig = this.bot3D.dimensionGroup.simulation3D.getMainCameraRig();
                 const cameraWorld = new Vector3();
@@ -242,15 +240,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
                 );
                 this._rotationObj.lookAt(cameraWorld);
                 update = true;
-                if (this._orientationMode === 'billboardZ') {
-                    const euler = new Euler().setFromQuaternion(
-                        this._rotationObj.quaternion,
-                        'XYZ'
-                    );
-                    euler.y = 0;
-                    euler.z = 0;
-                    this._rotationObj.setRotationFromEuler(euler);
-                } else if (this._orientationMode === 'billboardX') {
+                if (this._orientationMode === 'billboardX') {
                     const euler = new Euler().setFromQuaternion(
                         this._rotationObj.quaternion,
                         'YXZ'

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -33,6 +33,7 @@ import { calculateGridTileLocalCenter } from '../grid/Grid';
 import { realPosToGridPos, Axial, posToKey } from '../hex';
 import { BuilderGroup3D } from '../BuilderGroup3D';
 import { calculateScale, objectForwardRay } from '../SceneUtils';
+import { Game } from '../Game';
 
 /**
  * Defines an interface that contains possible options for DimensionPositionDecorator objects.
@@ -59,12 +60,15 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
     private _orientationMode: BotOrientationMode;
     private _anchorPoint: BotAnchorPoint;
     private _rotationObj: Object3D;
+    private _game: Game;
 
     constructor(
         bot3D: AuxBot3D,
+        game: Game,
         options: DimensionPositionDecoratorOptions = {}
     ) {
         super(bot3D);
+        this._game = game;
         this._lerp = !!options.lerp;
     }
 
@@ -238,13 +242,19 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
                 cameraWorld.setFromMatrixPosition(
                     cameraRig.mainCamera.matrixWorld
                 );
-                const cameraRotation = new Quaternion().setFromRotationMatrix(
-                    cameraRig.mainCamera.matrixWorld
-                );
-                const cameraUp = new Vector3(0, 1, 0);
-                cameraUp.applyQuaternion(cameraRotation);
 
-                this._rotationObj.up = cameraUp;
+                if (this._game && !!this._game.xrSession) {
+                    this._rotationObj.up = new Vector3(0, 1, 0);
+                } else {
+                    const cameraRotation = new Quaternion().setFromRotationMatrix(
+                        cameraRig.mainCamera.matrixWorld
+                    );
+                    const cameraUp = new Vector3(0, 1, 0);
+                    cameraUp.applyQuaternion(cameraRotation);
+
+                    this._rotationObj.up = cameraUp;
+                }
+
                 this._rotationObj.lookAt(cameraWorld);
 
                 // Rotate the object 90 degrees around its X axis

--- a/src/aux-server/aux-web/shared/scene/decorators/LabelDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/LabelDecorator.ts
@@ -74,7 +74,7 @@ export class LabelDecorator extends AuxBot3DDecoratorBase
                 // Parent the labels directly to the bot.
                 // Labels do all kinds of weird stuff with their transforms, so this makes it easier to let them do that
                 // without worrying about what the AuxBot3D scale is etc.
-                this.bot3D.add(this.text3D);
+                this.bot3D.container.add(this.text3D);
             }
 
             // Update label text content.
@@ -140,7 +140,7 @@ export class LabelDecorator extends AuxBot3DDecoratorBase
     disposeText3D(): void {
         if (this.text3D) {
             this.text3D.dispose();
-            this.bot3D.remove(this.text3D);
+            this.bot3D.container.remove(this.text3D);
             this.text3D = null;
         }
     }

--- a/src/aux-server/aux-web/shared/scene/decorators/ScaleDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/ScaleDecorator.ts
@@ -17,7 +17,7 @@ export class ScaleDecorator extends AuxBot3DDecoratorBase {
     botUpdated(calc: BotCalculationContext): void {
         const gridScale = this.bot3D.gridScale;
         const scale = calculateScale(calc, this.bot3D.bot, gridScale);
-        this.bot3D.container.scale.set(scale.x, scale.y, scale.z);
+        this.bot3D.scaleContainer.scale.set(scale.x, scale.y, scale.z);
     }
 
     dispose(): void {}

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -403,6 +403,11 @@ export class CausalRepoServer {
         device: DeviceConnection<Connection>,
         branch: string
     ) {
+        console.log(
+            `[CausalRepoServer] Device ${
+                device.id
+            } connected to branch: ${branch}`
+        );
         const info = devicesInfo();
         const devices = this._deviceManager.getConnectedDevices(info);
         sendToDevices(devices, DEVICE_CONNECTED_TO_BRANCH, {
@@ -415,6 +420,11 @@ export class CausalRepoServer {
         device: DeviceConnection<Connection>,
         branch: string
     ) {
+        console.log(
+            `[CausalRepoServer] Device ${
+                device.id
+            } disconnected from branch: ${branch}`
+        );
         const info = devicesInfo();
         const devices = this._deviceManager.getConnectedDevices(info);
         sendToDevices(devices, DEVICE_DISCONNECTED_FROM_BRANCH, {
@@ -431,6 +441,7 @@ export class CausalRepoServer {
     }
 
     private async _unloadBranch(branch: string) {
+        console.log(`[CausalRepoServer] Unloading branch: ${branch}`);
         const repo = this._repos.get(branch);
         if (repo && repo.hasChanges()) {
             console.log(
@@ -448,6 +459,7 @@ export class CausalRepoServer {
         let repo = this._repos.get(branch);
 
         if (!repo) {
+            console.log(`[CausalRepoServer] Loading branch: ${branch}`);
             repo = new CausalRepo(this._store);
             await repo.checkout(branch, {
                 createIfDoesntExist: createBranch


### PR DESCRIPTION
-   :boom: Breaking Changes

    -   Both sprites and iframes now face upwards by default.
    -   `#auxAnchorPoint` has been changed to move the bot form inside of its virtual spacing box.
        -   Previously, both the virtual box and the bot form was moved to try and preserve the absolute positioning of the bot form when changing anchor points.
        -   Now, only the bot form is moved to ensure the correctness of the resulting scale and rotation calculations.
    -   `#auxOrientationMode`
        -   Renamed the `billboardX` option to `billboardZ`.
    -   Changed iframes forms to not support strokes.

-   :rocket: Improvements

    -   Added the following options for `#auxAnchorPoint`
        -   `centerFront` - Positions the bot form such that the center of the form's front face is at the center of the virtual bot.
        -   `centerBack` - Positions the bot form such that the center of the form's back face is at the center of the virtual bot.
        -   `bottomFront` - Positions the bot form such that the bottom of the form's front face is at the center of the virtual bot.
        -   `bottomBack` - Positions the bot form such that the bottom of the form's back face is at the center of the virtual bot.
        -   `top` - Positions the bot form such that the top of the form is at the center of the virtual bot.
        -   `topFront` - Positions the bot form such that the top of the form's front face is at the center of the virtual bot.
        -   `topBack` - Positions the bot form such that the top of the form's back face is at the center of the virtual bot.

-   :bug: Bug Fixes
    -   Fixed issues with scale and rotation when `#auxAnchorPoint` is set to `center`.
    -   Fixed sprite billboarding issues when looking straight down at them.
    -   Fixed an issue where the wrong Z position tag of a bot was used for calculating how bots stack.
    -   Fixed an issue where the bot stroke was being considered for collision detection. This caused bots with strokes to have a much larger hit box than they should have had.