### PR TITLE
auxAnchorPoint cleanup and additional billboarding changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Changes:
 
+-   :boom: Breaking Changes
+
+    -   Renamed and removed several `auxAnchorPoint` values.
+        -   Renamed `centerFront` to `front`.
+        -   Renamed `centerBack` to `back`.
+
 -   :bug: Bug Fixes
     -   Fixed `billboardZ` to rotate with the Y axis of the bot facing upwards.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # AUX Changelog
 
+## V1.0.17
+
+### Date: TBD
+
+### Changes:
+
+-   :bug: Bug Fixes
+    -   Fixed `billboardZ` to rotate with the Y axis of the bot facing upwards.
+
 ## V1.0.16
 
 ### Date: 3/16/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     -   Renamed and removed several `auxAnchorPoint` values.
         -   Renamed `centerFront` to `front`.
         -   Renamed `centerBack` to `back`.
+        -   Removed `bottomFront`, `bottomBack`, `topFront`, and `topBack`.
 
 -   :bug: Bug Fixes
     -   Fixed `billboardZ` to rotate with the Y axis of the bot facing upwards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
         -   Renamed `centerBack` to `back`.
         -   Removed `bottomFront`, `bottomBack`, `topFront`, and `topBack`.
 
+-   :rocket: Improvements
+
+    -   Added the ability to specify an array of 3 numbers as the `#auxAnchorPoint` to use a custom offset.
+
 -   :bug: Bug Fixes
     -   Fixed `billboardZ` to rotate with the Y axis of the bot facing upwards.
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -535,9 +535,6 @@ The position that the bot should rotate and scale around.
   <PossibleValueCode value='top'>
     The bot rotates and scales around its top point.
   </PossibleValueCode>
-  <PossibleValueCode value='topBack'>
-    The bot rotates and scales around the point at the top of the Bot's back face.
-  </PossibleValueCode>
 </PossibleValuesTable>
 
 ### `auxOrientationMode`

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -515,7 +515,7 @@ The anchor position for the progress bar.
 
 ### `auxAnchorPoint`
 
-The position that the bot should rotate and scale around.
+The position that the bot form should rotate and scale around.
 
 #### Possible values are:
 
@@ -534,6 +534,17 @@ The position that the bot should rotate and scale around.
   </PossibleValueCode>
   <PossibleValueCode value='top'>
     The bot rotates and scales around its top point.
+  </PossibleValueCode>
+  <PossibleValueCode value='left'>
+    The bot rotates and scales around the point at the center of the Bot's left face.
+  </PossibleValueCode>
+  <PossibleValueCode value='right'>
+    The bot rotates and scales around the point at the center of the Bot's right face.
+  </PossibleValueCode>
+  <PossibleValueCode value='[x,y,z]'>
+    The bot rotates and scales around the specified point.
+    Should be an array of 3 numbers representing X, Y, and Z respectively.
+    Numbers between 0.5 and -0.5 map to the edges of the bot.
   </PossibleValueCode>
 </PossibleValuesTable>
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -523,9 +523,6 @@ The position that the bot should rotate and scale around.
   <PossibleValueCode value='bottom'>
     The bot rotates and scales around its bottom point. (default)
   </PossibleValueCode>
-  <PossibleValueCode value='bottomBack'>
-    The bot rotates and scales around the point at the bottom of the Bot's back face.
-  </PossibleValueCode>
   <PossibleValueCode value='center'>
     The bot rotates and scales around its center point.
   </PossibleValueCode>

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -532,10 +532,10 @@ The position that the bot should rotate and scale around.
   <PossibleValueCode value='center'>
     The bot rotates and scales around its center point.
   </PossibleValueCode>
-  <PossibleValueCode value='centerFront'>
+  <PossibleValueCode value='front'>
     The bot rotates and scales around the point at the center of the Bot's front face.
   </PossibleValueCode>
-  <PossibleValueCode value='centerBack'>
+  <PossibleValueCode value='back'>
     The bot rotates and scales around the point at the center of the Bot's back face.
   </PossibleValueCode>
   <PossibleValueCode value='top'>

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -535,9 +535,6 @@ The position that the bot should rotate and scale around.
   <PossibleValueCode value='top'>
     The bot rotates and scales around its top point.
   </PossibleValueCode>
-  <PossibleValueCode value='topFront'>
-    The bot rotates and scales around the point at the top of the Bot's front face.
-  </PossibleValueCode>
   <PossibleValueCode value='topBack'>
     The bot rotates and scales around the point at the top of the Bot's back face.
   </PossibleValueCode>

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -523,9 +523,6 @@ The position that the bot should rotate and scale around.
   <PossibleValueCode value='bottom'>
     The bot rotates and scales around its bottom point. (default)
   </PossibleValueCode>
-  <PossibleValueCode value='bottomFront'>
-    The bot rotates and scales around the point at the bottom of the Bot's front face.
-  </PossibleValueCode>
   <PossibleValueCode value='bottomBack'>
     The bot rotates and scales around the point at the bottom of the Bot's back face.
   </PossibleValueCode>

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -301,8 +301,8 @@ export type BotOrientationMode = 'absolute' | 'billboard' | 'billboardZ';
  */
 export type BotAnchorPoint =
     | 'center'
-    | 'centerFront'
-    | 'centerBack'
+    | 'front'
+    | 'back'
     | 'bottom'
     | 'bottomFront'
     | 'bottomBack'

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -299,13 +299,7 @@ export type BotOrientationMode = 'absolute' | 'billboard' | 'billboardZ';
 /**
  * Defines the possible bot anchor points.
  */
-export type BotAnchorPoint =
-    | 'center'
-    | 'front'
-    | 'back'
-    | 'bottom'
-    | 'top'
-    | 'topBack';
+export type BotAnchorPoint = 'center' | 'front' | 'back' | 'bottom' | 'top';
 
 /**
  * Defines the possible portal raycast modes.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -304,7 +304,6 @@ export type BotAnchorPoint =
     | 'front'
     | 'back'
     | 'bottom'
-    | 'bottomBack'
     | 'top'
     | 'topFront'
     | 'topBack';

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -299,7 +299,15 @@ export type BotOrientationMode = 'absolute' | 'billboard' | 'billboardZ';
 /**
  * Defines the possible bot anchor points.
  */
-export type BotAnchorPoint = 'center' | 'front' | 'back' | 'bottom' | 'top';
+export type BotAnchorPoint =
+    | 'top'
+    | 'front'
+    | 'back'
+    | 'left'
+    | 'right'
+    | 'bottom'
+    | 'center'
+    | [number, number, number];
 
 /**
  * Defines the possible portal raycast modes.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -304,7 +304,6 @@ export type BotAnchorPoint =
     | 'front'
     | 'back'
     | 'bottom'
-    | 'bottomFront'
     | 'bottomBack'
     | 'top'
     | 'topFront'

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -305,7 +305,6 @@ export type BotAnchorPoint =
     | 'back'
     | 'bottom'
     | 'top'
-    | 'topFront'
     | 'topBack';
 
 /**

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1299,8 +1299,8 @@ export function getBotOrientationMode(
 
 const possibleAnchorPoints = new Set([
     'center',
-    'centerFront',
-    'centerBack',
+    'front',
+    'back',
     'bottom',
     'bottomFront',
     'bottomBack',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1303,7 +1303,6 @@ const possibleAnchorPoints = new Set([
     'back',
     'bottom',
     'top',
-    'topFront',
     'topBack',
 ] as const);
 

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1302,7 +1302,6 @@ const possibleAnchorPoints = new Set([
     'front',
     'back',
     'bottom',
-    'bottomBack',
     'top',
     'topFront',
     'topBack',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1302,7 +1302,6 @@ const possibleAnchorPoints = new Set([
     'front',
     'back',
     'bottom',
-    'bottomFront',
     'bottomBack',
     'top',
     'topFront',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1303,7 +1303,6 @@ const possibleAnchorPoints = new Set([
     'back',
     'bottom',
     'top',
-    'topBack',
 ] as const);
 
 /**

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3529,7 +3529,6 @@ export function botCalculationContextTests(
             ['back'],
             ['bottom'],
             ['top'],
-            ['topFront'],
             ['topBack'],
         ];
 

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3528,7 +3528,6 @@ export function botCalculationContextTests(
             ['front'],
             ['back'],
             ['bottom'],
-            ['bottomBack'],
             ['top'],
             ['topFront'],
             ['topBack'],

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -58,6 +58,7 @@ import {
     getBotOrientationMode,
     getBotAnchorPoint,
     calculatePortalPointerDragMode,
+    getAnchorPointOffset,
 } from '../BotCalculations';
 import {
     Bot,
@@ -3523,16 +3524,25 @@ export function botCalculationContextTests(
     });
 
     describe('getBotAnchorPoint()', () => {
-        const cases = [['center'], ['front'], ['back'], ['bottom'], ['top']];
+        const cases = [
+            ['center', 'center'],
+            ['front', 'front'],
+            ['back', 'back'],
+            ['bottom', 'bottom'],
+            ['top', 'top'],
+            ['left', 'left'],
+            ['right', 'right'],
+            ['[1, 2, 3]', [1, 2, 3]],
+        ];
 
-        it.each(cases)('should return %s', (mode: string) => {
+        it.each(cases)('should support %s', (mode: string, expected: any) => {
             const bot = createBot('test', {
                 auxAnchorPoint: <any>mode,
             });
 
             const calc = createCalculationContext([bot]);
 
-            expect(getBotAnchorPoint(calc, bot)).toBe(mode);
+            expect(getBotAnchorPoint(calc, bot)).toEqual(expected);
         });
 
         it('should default to bottom', () => {
@@ -3542,6 +3552,44 @@ export function botCalculationContextTests(
             const shape = getBotAnchorPoint(calc, bot);
 
             expect(shape).toBe('bottom');
+        });
+    });
+
+    describe('getAnchorPointOffset()', () => {
+        const cases = [
+            ['center', { x: 0, y: 0, z: 0 }],
+            ['front', { x: 0, y: -0.5, z: 0 }],
+            ['back', { x: 0, y: 0.5, z: 0 }],
+            ['bottom', { x: 0, y: 0, z: 0.5 }],
+            ['top', { x: 0, y: 0, z: -0.5 }],
+            ['left', { x: 0.5, y: 0, z: 0 }],
+            ['right', { x: -0.5, y: 0, z: 0 }],
+
+            // Should mirror the coordinates when using literals
+            ['[1, 2, 3]', { x: -1, y: -2, z: -3 }],
+        ];
+
+        it.each(cases)('should support %s', (mode: string, expected: any) => {
+            const bot = createBot('test', {
+                auxAnchorPoint: <any>mode,
+            });
+
+            const calc = createCalculationContext([bot]);
+
+            expect(getAnchorPointOffset(calc, bot)).toEqual(expected);
+        });
+
+        it('should default to bottom', () => {
+            const bot = createBot();
+
+            const calc = createCalculationContext([bot]);
+            const offset = getAnchorPointOffset(calc, bot);
+
+            expect(offset).toEqual({
+                x: 0,
+                y: 0,
+                z: 0.5,
+            });
         });
     });
 

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3525,8 +3525,8 @@ export function botCalculationContextTests(
     describe('getBotAnchorPoint()', () => {
         const cases = [
             ['center'],
-            ['centerFront'],
-            ['centerBack'],
+            ['front'],
+            ['back'],
             ['bottom'],
             ['bottomFront'],
             ['bottomBack'],

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3528,7 +3528,6 @@ export function botCalculationContextTests(
             ['front'],
             ['back'],
             ['bottom'],
-            ['bottomFront'],
             ['bottomBack'],
             ['top'],
             ['topFront'],

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3523,14 +3523,7 @@ export function botCalculationContextTests(
     });
 
     describe('getBotAnchorPoint()', () => {
-        const cases = [
-            ['center'],
-            ['front'],
-            ['back'],
-            ['bottom'],
-            ['top'],
-            ['topBack'],
-        ];
+        const cases = [['center'], ['front'], ['back'], ['bottom'], ['top']];
 
         it.each(cases)('should return %s', (mode: string) => {
             const bot = createBot('test', {

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -271,7 +271,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
                         this._rotationObj.quaternion,
                         'YXZ'
                     );
-                    euler.x = 0;
+                    euler.x = ThreeMath.degToRad(90);
                     euler.z = 0;
                     this._rotationObj.setRotationFromEuler(euler);
                 }

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -19,6 +19,7 @@ import {
     BotOrientationMode,
     getBotIndex,
     getBotScale,
+    getAnchorPointOffset,
 } from '@casual-simulation/aux-common';
 import {
     Vector3,
@@ -58,7 +59,6 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
     private _nextRot: { x: number; y: number; z: number };
     private _lastHeight: number;
     private _orientationMode: BotOrientationMode;
-    private _anchorPoint: BotAnchorPoint;
     private _rotationObj: Object3D;
     private _game: Game;
 
@@ -74,34 +74,20 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
 
     botUpdated(calc: BotCalculationContext): void {
         const nextOrientationMode = getBotOrientationMode(calc, this.bot3D.bot);
-        const nextAnchorPoint = getBotAnchorPoint(calc, this.bot3D.bot);
+        const anchorPointOffset = getAnchorPointOffset(calc, this.bot3D.bot);
         const gridScale = this.bot3D.gridScale;
 
         this._orientationMode = nextOrientationMode;
-        this._anchorPoint = nextAnchorPoint;
         this._rotationObj = this.bot3D.container;
 
         // Update the offset for the display container
         // so that it rotates around the specified
         // point
-        let displayOffset = new Vector3();
-
-        if (this._anchorPoint.startsWith('center')) {
-        } else if (this._anchorPoint.startsWith('top')) {
-            displayOffset.y = -0.5;
-        } else if (this._anchorPoint.startsWith('bottom')) {
-            displayOffset.y = 0.5;
-        } else {
-            displayOffset.y = 0.5;
-        }
-        if (this._anchorPoint.endsWith('Front')) {
-            displayOffset.z = -0.5;
-        } else if (this._anchorPoint.endsWith('Back')) {
-            displayOffset.z = 0.5;
-        } else {
-            displayOffset.z = 0;
-        }
-        this.bot3D.display.position.copy(displayOffset);
+        this.bot3D.display.position.set(
+            anchorPointOffset.x,
+            anchorPointOffset.z,
+            anchorPointOffset.y
+        );
 
         const userDimension = this.bot3D.dimension;
         if (userDimension) {


### PR DESCRIPTION
-   :boom: Breaking Changes

    -   Renamed and removed several `auxAnchorPoint` values.
        -   Renamed `centerFront` to `front`.
        -   Renamed `centerBack` to `back`.
        -   Removed `bottomFront`, `bottomBack`, `topFront`, and `topBack`.

-   :rocket: Improvements

    -   Added the ability to specify an array of 3 numbers as the `#auxAnchorPoint` to use a custom offset.

-   :bug: Bug Fixes
    -   Fixed `billboardZ` to rotate with the Y axis of the bot facing upwards.