### PR TITLE
Add LOD triggers based on virtual distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
             -   They are numbers between 0 and 1 representing the percentage of the screen that the bot needs to occupy.
             -   The Max LOD is entered when the bot occupies a larger percentage of the screen than the max threshold value.
             -   The Min LOD is entered when the bot occupies a smaller percentage of the screen than the min threshold value.
+        -   Only active on bots that specify a listener or threshold value for LODs.
 
 ## V1.0.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # AUX Changelog
 
+## V1.0.18
+
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+
+    -   Added LOD triggers based on virtual distance.
+        -   `@onMaxLODEnter`, `@onMinLODEnter`, `@onMaxLODExit`, `@onMinLODExit` are new listeners that are called when the Max and Min Level-Of-Detail states are entered and exited. There are also "any" versions of these listeners.
+            -   `that` is an object with the following properties:
+                -   `bot` - The bot that entered/exited the LOD.
+                -   `dimension` - The dimension that the LOD was entered/exited in.
+        -   The `#auxMaxLODThreshold` and `#auxMinLODThreshold` tags can be used to control when the LODs are entered/exited.
+            -   They are numbers between 0 and 1 representing the percentage of the screen that the bot needs to occupy.
+            -   The Max LOD is entered when the bot occupies a larger percentage of the screen than the max threshold value.
+            -   The Min LOD is entered when the bot occupies a smaller percentage of the screen than the min threshold value.
+
 ## V1.0.17
 
 ### Date: 3/17/2020

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -256,6 +256,54 @@ let that: {
 };
 ```
 
+### `@onMaxLODEnter`
+
+A whisper that is sent whenever a bot enters its maximum Level-Of-Detail.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
+### `@onMinLODEnter`
+
+A whisper that is sent whenever a bot enters its minimum Level-Of-Detail.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
+### `@onMaxLODExit`
+
+A whisper that is sent whenever a bot exits its maximum Level-Of-Detail.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
+### `@onMinLODExit`
+
+A whisper that is sent whenever a bot exits its minimum Level-Of-Detail.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
 ### `@[groupName][stateName]OnEnter`
 
 A whisper that is sent whenever the `[groupName]` tag is set to `[stateName]` via the <ActionLink action='changeState(bot, stateName, groupName?)'/> function.
@@ -598,6 +646,66 @@ let that: {
   targets: Bot[],
   listeners: Bot[],
   responses: any[]
+};
+```
+
+### `@onAnyMaxLODEnter`
+
+A shout that is sent whenever a bot enters its maximum Level-Of-Detail.
+Only sent for bots that have one of <ActionLink action='onMaxLODEnter'/>, 
+<ActionLink action='onMaxLODExit'/>, <ActionLink action='onMinLODEnter'/>,  <ActionLink action='onMinLODExit'/> 
+<TagLink tag='auxMaxLODThreshold'/> or <TagLink tag='auxMinLODThreshold'/> specified.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
+### `@onAnyMinLODEnter`
+
+A shout that is sent whenever a bot enters its minimum Level-Of-Detail.
+Only sent for bots that have one of <ActionLink action='onMaxLODEnter'/>, 
+<ActionLink action='onMaxLODExit'/>, <ActionLink action='onMinLODEnter'/>,  <ActionLink action='onMinLODExit'/> 
+<TagLink tag='auxMaxLODThreshold'/> or <TagLink tag='auxMinLODThreshold'/> specified.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
+### `@onAnyMaxLODExit`
+
+A shout that is sent whenever a bot exits its maximum Level-Of-Detail.
+Only sent for bots that have one of <ActionLink action='onMaxLODEnter'/>, 
+<ActionLink action='onMaxLODExit'/>, <ActionLink action='onMinLODEnter'/>,  <ActionLink action='onMinLODExit'/> 
+<TagLink tag='auxMaxLODThreshold'/> or <TagLink tag='auxMinLODThreshold'/> specified.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
+### `@onAnyMinLODExit`
+
+A shout that is sent whenever a bot exits its minimum Level-Of-Detail.
+Only sent for bots that have one of <ActionLink action='onMaxLODEnter'/>, 
+<ActionLink action='onMaxLODExit'/>, <ActionLink action='onMinLODEnter'/>,  <ActionLink action='onMinLODExit'/> 
+<TagLink tag='auxMaxLODThreshold'/> or <TagLink tag='auxMinLODThreshold'/> specified.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
 };
 ```
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -566,6 +566,36 @@ The mode that determines how the bot automatically rotates.
   </PossibleValueCode>
 </PossibleValuesTable>
 
+### `auxMaxLODThreshold`
+
+The minimum percentage of the screen that the bot form should take up in order to enter the maximum Level-Of-Detail.
+When the maximum LOD is entered the <ActionLink tag='onMaxLODEnter'/> listener is triggered.
+When the maximum LOD is exited the <ActionLink tag='onMaxLODExit'/> listener is triggered.
+
+<PossibleValuesTable>
+  <PossibleValueCode value='0.03'>
+    The bot enters the maximum LOD when it takes up 3% of the screen space. (default)
+  </PossibleValueCode>
+  <PossibleValue value='Numbers > 0 and < 1'>
+    The bot enters the maximum LOD when it takes up more screen space than the value.
+  </PossibleValue>
+</PossibleValuesTable>
+
+### `auxMinLODThreshold`
+
+The maximum percentage of the screen that the bot form should take up in order to enter the minimum Level-Of-Detail.
+When the minimum LOD is entered the <ActionLink tag='onMinLODEnter'/> listener is triggered.
+When the minimum LOD is exited the <ActionLink tag='onMinLODExit'/> listener is triggered.
+
+<PossibleValuesTable>
+  <PossibleValueCode value='0.0005'>
+    The bot enters the minimum LOD when it takes up 0.05% of the screen space. (default)
+  </PossibleValueCode>
+  <PossibleValue value='Numbers > 0 and < 1'>
+    The bot enters the minimum LOD when it takes up less screen space than the value.
+  </PossibleValue>
+</PossibleValuesTable>
+
 ## Dimension Tags
 
 ### `[dimension]`

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -329,6 +329,11 @@ export type BackupType = 'github' | 'download';
 export type DimensionVisualizeMode = true | false | 'surface';
 
 /**
+ * The possible LODs for a bot.
+ */
+export type BotLOD = 'normal' | 'min' | 'max';
+
+/**
  * The default bot shape.
  */
 export const DEFAULT_BOT_SHAPE: BotShape = 'cube';
@@ -464,6 +469,21 @@ export const DEFAULT_WRIST_PORTAL_WIDTH = 6;
  * The default grid scale for wrist portals.
  */
 export const DEFAULT_WRIST_PORTAL_GRID_SCALE = 0.025;
+
+/**
+ * The default bot LOD.
+ */
+export const DEFAULT_BOT_LOD: BotLOD = 'normal';
+
+/**
+ * The default minimum LOD threshold.
+ */
+export const DEFAULT_BOT_LOD_MIN_THRESHOLD = 0.0005;
+
+/**
+ * The default maximum LOD threshold.
+ */
+export const DEFAULT_BOT_LOD_MAX_THRESHOLD = 0.03;
 
 /**
  * The ID of the global configuration bot.
@@ -690,6 +710,46 @@ export const ON_CHAT_ACTION_NAME: string = 'onChat';
 export const ON_PASTE_ACTION_NAME: string = 'onPaste';
 
 /**
+ * The name of the event that is triggered when the maximum LOD is entered.
+ */
+export const ON_MAX_LOD_ENTER_ACTION_NAME: string = 'onMaxLODEnter';
+
+/**
+ * The name of the event that is triggered when the minimum LOD is entered.
+ */
+export const ON_MIN_LOD_ENTER_ACTION_NAME: string = 'onMinLODEnter';
+
+/**
+ * The name of the event that is triggered when the maximum LOD is exited.
+ */
+export const ON_MAX_LOD_EXIT_ACTION_NAME: string = 'onMaxLODExit';
+
+/**
+ * The name of the event that is triggered when the minimum LOD is exited.
+ */
+export const ON_MIN_LOD_EXIT_ACTION_NAME: string = 'onMinLODExit';
+
+/**
+ * The name of the event that is triggered when the maximum LOD is entered.
+ */
+export const ON_ANY_MAX_LOD_ENTER_ACTION_NAME: string = 'onAnyMaxLODEnter';
+
+/**
+ * The name of the event that is triggered when the minimum LOD is entered.
+ */
+export const ON_ANY_MIN_LOD_ENTER_ACTION_NAME: string = 'onAnyMinLODEnter';
+
+/**
+ * The name of the event that is triggered when the maximum LOD is exited.
+ */
+export const ON_ANY_MAX_LOD_EXIT_ACTION_NAME: string = 'onAnyMaxLODExit';
+
+/**
+ * The name of the event that is triggered when the minimum LOD is exited.
+ */
+export const ON_ANY_MIN_LOD_EXIT_ACTION_NAME: string = 'onAnyMinLODExit';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -796,6 +856,8 @@ export const KNOWN_TAGS: string[] = [
     'auxProgressBarColor',
     'auxProgressBarBackgroundColor',
     'auxProgressBarPosition',
+    'auxMaxLODThreshold',
+    'auxMinLODThreshold',
     'auxUniverseConnectedSessions',
 
     'auxTaskOutput',
@@ -870,6 +932,14 @@ export const KNOWN_TAGS: string[] = [
     ON_CHAT_TYPING_ACTION_NAME,
     ON_CHAT_ACTION_NAME,
     ON_PASTE_ACTION_NAME,
+    ON_MAX_LOD_ENTER_ACTION_NAME,
+    ON_MIN_LOD_ENTER_ACTION_NAME,
+    ON_MAX_LOD_EXIT_ACTION_NAME,
+    ON_MIN_LOD_EXIT_ACTION_NAME,
+    ON_ANY_MAX_LOD_ENTER_ACTION_NAME,
+    ON_ANY_MIN_LOD_ENTER_ACTION_NAME,
+    ON_ANY_MAX_LOD_EXIT_ACTION_NAME,
+    ON_ANY_MIN_LOD_EXIT_ACTION_NAME,
 ];
 
 export function onClickArg(face: string, dimension: string) {
@@ -945,6 +1015,13 @@ export function onChatArg(message: string) {
 export function onPasteArg(text: string) {
     return {
         text,
+    };
+}
+
+export function onLODArg(bot: Bot, dimension: string) {
+    return {
+        bot,
+        dimension,
     };
 }
 

--- a/src/aux-common/bots/BotCalculations.spec.ts
+++ b/src/aux-common/bots/BotCalculations.spec.ts
@@ -27,6 +27,8 @@ import {
     getBotTag,
     getPortalTag,
     getUploadState,
+    botHasLOD,
+    calculateBotLOD,
 } from './BotCalculations';
 import { Bot, BotsState } from './Bot';
 import { createCalculationContext } from './BotCalculationContextFactories';
@@ -195,6 +197,55 @@ describe('BotCalculations', () => {
                 expect(tag).toBe(expected);
             }
         );
+    });
+
+    describe('botHasLOD()', () => {
+        const lodListeners = [
+            ['onMaxLODEnter'],
+            ['onMaxLODExit'],
+            ['onMinLODEnter'],
+            ['onMinLODExit'],
+            ['auxMaxLODThreshold'],
+            ['auxMinLODThreshold'],
+        ];
+
+        describe.each(lodListeners)('%s', (tag: string) => {
+            it('should return true if the bot has a script', () => {
+                const bot = createBot('test', {
+                    [tag]: '@abc',
+                });
+
+                const calc = createCalculationContext([bot]);
+                const hasLod = botHasLOD(calc, bot);
+
+                expect(hasLod).toBe(true);
+            });
+
+            it('should return false if it does not have a script', () => {
+                const bot = createBot('test', {
+                    [tag]: 'abc',
+                });
+
+                const calc = createCalculationContext([bot]);
+                const hasLod = botHasLOD(calc, bot);
+
+                expect(hasLod).toBe(false);
+            });
+        });
+    });
+
+    describe('calculateBotLOD()', () => {
+        it('should return normal when the virtual distance is between the min and max', () => {
+            expect(calculateBotLOD(0.5, 0.1, 0.9)).toBe('normal');
+        });
+
+        it('should return max when the virtual distance is above the max', () => {
+            expect(calculateBotLOD(1, 0.1, 0.9)).toBe('max');
+        });
+
+        it('should return min when the virtual distance is below the min', () => {
+            expect(calculateBotLOD(0, 0.1, 0.9)).toBe('min');
+        });
     });
 
     describe('calculateStateDiff()', () => {

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -33,6 +33,7 @@ import {
     DEFAULT_ANCHOR_POINT,
     PortalPointerDragMode,
     DEFAULT_PORTAL_POINTER_DRAG_MODE,
+    BotLOD,
 } from './Bot';
 
 import {
@@ -1375,6 +1376,48 @@ export function getAnchorPointOffset(
             z: -z,
         };
     }
+}
+
+const lodTags = new Set([
+    'onMaxLODEnter',
+    'onMaxLODExit',
+    'onMinLODEnter',
+    'onMinLODExit',
+    'auxMaxLODThreshold',
+    'auxMinLODThreshold',
+] as const);
+
+/**
+ * Gets whether the bot has a tag to enable LODs.
+ * @param calc The calculation context.
+ * @param bot The bot.
+ */
+export function botHasLOD(calc: BotCalculationContext, bot: Bot): boolean {
+    for (let tag of lodTags.values()) {
+        const val = calculateBotValue(calc, bot, tag);
+        if (isScript(val)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Calcualtes the LOD that a bot should be in based on the virtual distance, minimum threshold, and maximum threshold.
+ * @param virtualDistance The percentage of the screen that the bot takes up.
+ * @param minThreshold The minimum LOD threshold.
+ * @param maxThreshold The maximum LOD threshold.
+ */
+export function calculateBotLOD(
+    virtualDistance: number,
+    minThreshold: number,
+    maxThreshold: number
+): BotLOD {
+    return virtualDistance < minThreshold
+        ? 'min'
+        : virtualDistance > maxThreshold
+        ? 'max'
+        : 'normal';
 }
 
 /**

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.spec.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.spec.ts
@@ -2,7 +2,17 @@ import {
     createBot,
     createCalculationContext,
 } from '@casual-simulation/aux-common';
-import { calculateScale } from './SceneUtils';
+import { calculateScale, createCube, percentOfScreen } from './SceneUtils';
+import {
+    Box3,
+    PerspectiveCamera,
+    OrthographicCamera,
+    Sphere,
+    Camera,
+    Mesh,
+    Vector3,
+} from 'three';
+import flatMap from 'lodash/flatMap';
 
 describe('SceneUtils', () => {
     describe('calculateScale()', () => {
@@ -18,6 +28,96 @@ describe('SceneUtils', () => {
             expect(scale.x).toEqual(4);
             expect(scale.y).toEqual(8);
             expect(scale.z).toEqual(6);
+        });
+    });
+
+    describe('percentOfScreen()', () => {
+        describe('orthographic', () => {
+            let cube: Mesh;
+            let camera: Camera;
+
+            const cubeSize = 1;
+            const left = -10;
+            const right = 10;
+            const top = 10;
+            const bottom = -10;
+            const near = -10;
+            const far = 10;
+            const width = right - left;
+            const height = top - bottom;
+            const depth = far - near;
+            const areaOfScreen = width * height;
+
+            const boxArea2D = cubeSize * cubeSize;
+            const cameraPosition = new Vector3(0, 0, 0);
+
+            beforeEach(() => {
+                cube = createCube(cubeSize);
+                camera = new OrthographicCamera(
+                    left,
+                    right,
+                    top,
+                    bottom,
+                    near,
+                    far
+                );
+                camera.position.copy(cameraPosition);
+            });
+
+            it('should return the approximate size of the given bounding box on the screen', () => {
+                const box = new Box3().setFromObject(cube);
+
+                const percent = percentOfScreen(camera, box);
+
+                expect(percent).toBeCloseTo(boxArea2D / areaOfScreen, 6);
+            });
+
+            describe('clipping', () => {
+                const leftEdge = new Vector3(left, 0, 0);
+                const rightEdge = new Vector3(right, 0, 0);
+                const topEdge = new Vector3(0, top, 0);
+                const bottomEdge = new Vector3(0, bottom, 0);
+
+                const namedEdges = [
+                    ['left', leftEdge],
+                    ['right', rightEdge],
+                    ['top', topEdge],
+                    ['bottom', bottomEdge],
+                ] as const;
+
+                const singleEdgeCases = namedEdges.map(([name, pos]) => [
+                    `${name} edge`,
+                    pos,
+                    boxArea2D / 2,
+                ]);
+
+                const edgePairs = [
+                    ['left and top', leftEdge, topEdge],
+                    ['right and top', rightEdge, topEdge],
+                    ['left and bottom', leftEdge, bottomEdge],
+                    ['right and bottom', rightEdge, bottomEdge],
+                ] as const;
+
+                const twoEdgeCases = edgePairs.map(([name, p1, p2]) => [
+                    `${name} edges`,
+                    p1.clone().add(p2),
+                    boxArea2D / 4,
+                ]);
+
+                const clippingCases = [...singleEdgeCases, ...twoEdgeCases];
+
+                it.each(clippingCases)(
+                    'should handle clipping the %s of the projection',
+                    (desc: string, pos: Vector3, area: number) => {
+                        cube.position.copy(pos);
+                        const box = new Box3().setFromObject(cube);
+
+                        const percent = percentOfScreen(camera, box);
+
+                        expect(percent).toBeCloseTo(area / areaOfScreen, 6);
+                    }
+                );
+            });
         });
     });
 });

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -29,6 +29,8 @@ import {
     Ray,
     Quaternion,
     MeshBasicMaterial,
+    Camera,
+    Sphere,
 } from 'three';
 import flatMap from 'lodash/flatMap';
 import {
@@ -605,4 +607,30 @@ export function objectDirectionRay(direction: Vector3, obj: Object3D): Ray {
  */
 export function objectForwardRay(obj: Object3D): Ray {
     return objectDirectionRay(new Vector3(0, 0, -1), obj);
+}
+
+// The width and height of clip space
+// See https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_model_view_projection
+const clipWidth = 2;
+const clipHeight = 2;
+const clipArea = clipWidth * clipHeight;
+const clipAreaRatio = 1 / clipArea;
+const clipBox = new Box3().set(new Vector3(-1, -1, -1), new Vector3(1, 1, 1));
+
+let _boxSize = new Vector3();
+/**
+ * Calculates the percentage of the screen that the given sphere takes up.
+ * @param camera The camera to use.
+ * @param boundingSphere The sphere to use. Should be in world space.
+ */
+export function percentOfScreen(camera: Camera, boundingBox: Box3): number {
+    const box = boundingBox.clone();
+    box.applyMatrix4(camera.matrixWorldInverse).applyMatrix4(
+        camera.projectionMatrix
+    );
+
+    box.intersect(clipBox);
+    box.getSize(_boxSize);
+
+    return _boxSize.x * _boxSize.y * clipAreaRatio;
 }

--- a/src/aux-server/aux-web/shared/scene/decorators/AuxBot3DDecoratorFactory.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/AuxBot3DDecoratorFactory.ts
@@ -15,6 +15,7 @@ import { TextureDecorator } from './TextureDecorator';
 import { UpdateMaxtrixDecorator } from './UpdateMatrixDecorator';
 import { Simulation3D } from '../Simulation3D';
 import { Game } from '../Game';
+import { BotLODDecorator } from './BotLODDecorator';
 
 export class AuxBot3DDecoratorFactory {
     public game: Game;
@@ -75,7 +76,8 @@ export class AuxBot3DDecoratorFactory {
                 new UpdateMaxtrixDecorator(bot3d),
                 labelDecorator,
                 wordBubbleDecorator,
-                new LineToDecorator(bot3d, this.simulation)
+                new LineToDecorator(bot3d, this.simulation),
+                new BotLODDecorator(bot3d)
             );
         }
 

--- a/src/aux-server/aux-web/shared/scene/decorators/BotLODDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotLODDecorator.ts
@@ -1,0 +1,174 @@
+import { AuxBot3DDecorator, AuxBot3DDecoratorBase } from '../AuxBot3DDecorator';
+import { AuxBot3D } from '../AuxBot3D';
+import {
+    BotCalculationContext,
+    calculateGridScale,
+    getBuilderDimensionGrid,
+    DEFAULT_WORKSPACE_GRID_SCALE,
+    botHasLOD,
+    BotLOD,
+    DEFAULT_BOT_LOD,
+    calculateNumericalTagValue,
+    DEFAULT_BOT_LOD_MIN_THRESHOLD,
+    DEFAULT_BOT_LOD_MAX_THRESHOLD,
+    calculateBotLOD,
+    onLODArg,
+    ON_MAX_LOD_ENTER_ACTION_NAME,
+    ON_MIN_LOD_ENTER_ACTION_NAME,
+    ON_MIN_LOD_EXIT_ACTION_NAME,
+    ON_ANY_MIN_LOD_EXIT_ACTION_NAME,
+    ShoutAction,
+    ON_MAX_LOD_EXIT_ACTION_NAME,
+    ON_ANY_MAX_LOD_EXIT_ACTION_NAME,
+    ON_ANY_MIN_LOD_ENTER_ACTION_NAME,
+    ON_ANY_MAX_LOD_ENTER_ACTION_NAME,
+} from '@casual-simulation/aux-common';
+import { Text3D } from '../Text3D';
+import { calculateScale, percentOfScreen } from '../SceneUtils';
+import { Camera } from 'three';
+import { Simulation } from '@casual-simulation/aux-vm';
+
+export class BotLODDecorator extends AuxBot3DDecoratorBase {
+    private _currentLOD: BotLOD = DEFAULT_BOT_LOD;
+    private _minThreshold: number;
+    private _maxThreshold: number;
+    private _camera: Camera;
+    private _simulation: Simulation;
+
+    constructor(bot3D: AuxBot3D) {
+        super(bot3D);
+        if (this.bot3D.dimensionGroup) {
+            this._camera = this.bot3D.dimensionGroup.simulation3D.getMainCameraRig().mainCamera;
+            this._simulation = this.bot3D.dimensionGroup.simulation3D.simulation;
+        }
+    }
+
+    frameUpdate?(calc: BotCalculationContext): void;
+
+    botUpdated(calc: BotCalculationContext): void {
+        if (!this._camera) {
+            return;
+        }
+        const hasLOD = botHasLOD(calc, this.bot3D.bot);
+        this._minThreshold = calculateNumericalTagValue(
+            calc,
+            this.bot3D.bot,
+            'auxMinLODThreshold',
+            DEFAULT_BOT_LOD_MIN_THRESHOLD
+        );
+        this._maxThreshold = calculateNumericalTagValue(
+            calc,
+            this.bot3D.bot,
+            'auxMaxLODThreshold',
+            DEFAULT_BOT_LOD_MAX_THRESHOLD
+        );
+        if (hasLOD && !this.frameUpdate) {
+            this.frameUpdate = this._frameUpdate;
+            this.bot3D.updateFrameUpdateList();
+        } else if (!hasLOD && this.frameUpdate) {
+            this.frameUpdate = null;
+            this.bot3D.updateFrameUpdateList();
+        }
+
+        this._updateLOD(calc);
+    }
+
+    dispose(): void {}
+
+    private _frameUpdate(calc: BotCalculationContext): void {
+        if (!this._camera) {
+            return;
+        }
+        this._updateLOD(calc);
+    }
+
+    private _updateLOD(calc: BotCalculationContext) {
+        const percent = percentOfScreen(this._camera, this.bot3D.boundingBox);
+        const nextLOD = calculateBotLOD(
+            percent,
+            this._minThreshold,
+            this._maxThreshold
+        );
+
+        if (this._currentLOD !== nextLOD) {
+            this._sendLODEvents(nextLOD);
+        }
+
+        this._currentLOD = nextLOD;
+    }
+
+    private _sendLODEvents(nextLOD: string) {
+        const arg = onLODArg(this.bot3D.bot, this.bot3D.dimension);
+        let actions = [] as ShoutAction[];
+        if (this._currentLOD === 'min') {
+            // send min exit event
+            actions.push(
+                ...this._simulation.helper.actions([
+                    {
+                        eventName: ON_MIN_LOD_EXIT_ACTION_NAME,
+                        bots: [this.bot3D.bot],
+                        arg,
+                    },
+                    {
+                        eventName: ON_ANY_MIN_LOD_EXIT_ACTION_NAME,
+                        bots: null,
+                        arg,
+                    },
+                ])
+            );
+        } else if (this._currentLOD === 'max') {
+            // send max exit event
+            actions.push(
+                ...this._simulation.helper.actions([
+                    {
+                        eventName: ON_MAX_LOD_EXIT_ACTION_NAME,
+                        bots: [this.bot3D.bot],
+                        arg,
+                    },
+                    {
+                        eventName: ON_ANY_MAX_LOD_EXIT_ACTION_NAME,
+                        bots: null,
+                        arg,
+                    },
+                ])
+            );
+        }
+        if (nextLOD === 'min') {
+            // send min enter event
+            actions.push(
+                ...this._simulation.helper.actions([
+                    {
+                        eventName: ON_MIN_LOD_ENTER_ACTION_NAME,
+                        bots: [this.bot3D.bot],
+                        arg,
+                    },
+                    {
+                        eventName: ON_ANY_MIN_LOD_ENTER_ACTION_NAME,
+                        bots: null,
+                        arg,
+                    },
+                ])
+            );
+        } else if (nextLOD === 'max') {
+            // send max enter event
+            // send min enter event
+            actions.push(
+                ...this._simulation.helper.actions([
+                    {
+                        eventName: ON_MAX_LOD_ENTER_ACTION_NAME,
+                        bots: [this.bot3D.bot],
+                        arg,
+                    },
+                    {
+                        eventName: ON_ANY_MAX_LOD_ENTER_ACTION_NAME,
+                        bots: null,
+                        arg,
+                    },
+                ])
+            );
+        }
+        if (actions.length > 0) {
+            this._simulation.helper.transaction(...actions);
+        }
+    }
+}


### PR DESCRIPTION
-   :rocket: Improvements

    -   Added LOD triggers based on virtual distance.
        -   `@onMaxLODEnter`, `@onMinLODEnter`, `@onMaxLODExit`, `@onMinLODExit` are new listeners that are called when the Max and Min Level-Of-Detail states are entered and exited. There are also "any" versions of these listeners.
            -   `that` is an object with the following properties:
                -   `bot` - The bot that entered/exited the LOD.
                -   `dimension` - The dimension that the LOD was entered/exited in.
        -   The `#auxMaxLODThreshold` and `#auxMinLODThreshold` tags can be used to control when the LODs are entered/exited.
            -   They are numbers between 0 and 1 representing the percentage of the screen that the bot needs to occupy.
            -   The Max LOD is entered when the bot occupies a larger percentage of the screen than the max threshold value.
            -   The Min LOD is entered when the bot occupies a smaller percentage of the screen than the min threshold value.
        -   Only active on bots that specify a listener or threshold value for LODs.