### PR TITLE
Improve LODs, add onGridUp/Down, onFileUpload, and additional script improvements

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -7,13 +7,11 @@ jobs:
         name: Test
         strategy:
             matrix:
-                os: [ubuntu-latest, macOS-latest, windows-latest]
+                os: [ubuntu-latest, macOS-latest]
                 node-version: [12.x]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v2
-              with:
-                  path: 'cs-aux'
+            - uses: actions/checkout@v1
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v1
               with:
@@ -29,13 +27,11 @@ jobs:
         name: Build AUX
         strategy:
             matrix:
-                os: [ubuntu-latest, macOS-latest, windows-latest]
+                os: [ubuntu-latest, macOS-latest]
                 node-version: [12.x]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v2
-              with:
-                  path: 'cs-aux'
+            - uses: actions/checkout@v1
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v1
               with:
@@ -51,13 +47,11 @@ jobs:
         name: Build Docs
         strategy:
             matrix:
-                os: [ubuntu-latest, macOS-latest, windows-latest]
+                os: [ubuntu-latest, macOS-latest]
                 node-version: [12.x]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v2
-              with:
-                  path: 'cs-aux'
+            - uses: actions/checkout@v1
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v1
               with:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -7,11 +7,13 @@ jobs:
         name: Test
         strategy:
             matrix:
-                os: [ubuntu-latest, macOS-latest]
+                os: [ubuntu-latest, macOS-latest, windows-latest]
                 node-version: [12.x]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
+              with:
+                  path: 'cs-aux'
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v1
               with:
@@ -27,11 +29,13 @@ jobs:
         name: Build AUX
         strategy:
             matrix:
-                os: [ubuntu-latest, macOS-latest]
+                os: [ubuntu-latest, macOS-latest, windows-latest]
                 node-version: [12.x]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
+              with:
+                  path: 'cs-aux'
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v1
               with:
@@ -47,11 +51,13 @@ jobs:
         name: Build Docs
         strategy:
             matrix:
-                os: [ubuntu-latest, macOS-latest]
+                os: [ubuntu-latest, macOS-latest, windows-latest]
                 node-version: [12.x]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
+              with:
+                  path: 'cs-aux'
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v1
               with:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -56,10 +56,10 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
-            - name: npm install and build docs
+            - name: yarn install and build docs
               run: |
-                  npm ci
-                  npm run bootstrap
-                  npm run build:docs
+                  cd docs
+                  yarn
+                  yarn build
               env:
                   CI: true

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,7 +24,7 @@ jobs:
               env:
                   CI: true
     build:
-        name: Build
+        name: Build AUX
         strategy:
             matrix:
                 os: [ubuntu-latest, macOS-latest]
@@ -41,5 +41,25 @@ jobs:
                   npm ci
                   npm run bootstrap
                   npm run build
+              env:
+                  CI: true
+    docs:
+        name: Build Docs
+        strategy:
+            matrix:
+                os: [ubuntu-latest, macOS-latest]
+                node-version: [12.x]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v1
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: npm install and build docs
+              run: |
+                  npm ci
+                  npm run bootstrap
+                  npm run build:docs
               env:
                   CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
     -   Changed the Level-Of-Detail calculations to use the apparent size of a bot instead of its on-screen size.
         -   Apparent size is the size the bot would appear if it was fully on screen.
         -   Under the new system, the LOD of a that is on screen bot will only change due to zooming the camera. Bots that are fully off screen will always have the minimum LOD.
+    -   Added the `@onFileUpload` listener.
+        -   `that` is an object with the following properties:
+            -   `file` is an object with the following properties:
+                -   `name` - The name of the file.
+                -   `size` - The size of the file in bytes.
+                -   `data` - The data contained in the file.
 
 -   :bug: Bug Fixes
     -   Fixed an issue where the camera matrix was being used before it was updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
         -   `that` is an object with the following properties:
             -   `dimension` - The dimension that the grid was clicked in.
             -   `position` - The X and Y position that was clicked.
+    -   Changed the Level-Of-Detail calculations to use the apparent size of a bot instead of its on-screen size.
+        -   Apparent size is the size the bot would appear if it was fully on screen.
+        -   Under the new system, the LOD of a that is on screen bot will only change due to zooming the camera. Bots that are fully off screen will always have the minimum LOD.
+
+-   :bug: Bug Fixes
+    -   Fixed an issue where the camera matrix was being used before it was updated.
 
 ## V1.0.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # AUX Changelog
 
+## V1.0.19
+
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+
+    -   Added the ability to modify tags directly on bots in `that`/`data` values in listeners.
+        -   Allows doing `that.bot.tags.abc = 123` instead of `setTag(that.bot, "abc", 123)`.
+
 ## V1.0.18
 
 ### Date: 3/18/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
                 -   `name` - The name of the file.
                 -   `size` - The size of the file in bytes.
                 -   `data` - The data contained in the file.
+        -   See the documentation for more information.
+    -   Improved the `player.importAux()` function to support importing directly from JSON.
+        -   If given a URL, then `player.importAux()` will behave the same as before (download and import).
+        -   If given JSON, then `player.importAux()` will simply import it directly.
 
 -   :bug: Bug Fixes
     -   Fixed an issue where the camera matrix was being used before it was updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
     -   Added the ability to modify tags directly on bots in `that`/`data` values in listeners.
         -   Allows doing `that.bot.tags.abc = 123` instead of `setTag(that.bot, "abc", 123)`.
+    -   Added the `@onGridUp` and `@onGridDown` listeners.
+        -   `that` is an object with the following properties:
+            -   `dimension` - The dimension that the grid was clicked in.
+            -   `position` - The X and Y position that was clicked.
 
 ## V1.0.18
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -19,6 +19,8 @@ Make sure you have all the prerequisite tools installed:
 
 1. Clone the repository.
     - `git clone https://github.com/casual-simulation/aux.git`
+    - On Windows you should clone to a custom folder since `aux` is a reserved file/folder name.
+        - e.g. `git clone https://github.com/casual-simulation/aux.git cs-aux`
 2. Make sure Lerna is installed.
     - `npm install -g lerna`
 3. Bootstrap the project.

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -1801,15 +1801,18 @@ if (player.inSheet()) {
 }
 ```
 
-### `player.importAUX(url)`
+### `player.importAUX(urlOrJSON)`
 
 <FunctionCode name='importAUX' />
 
-Downloads and imports the AUX file from the given [URL](https://en.wikipedia.org/wiki/URL).
+Imports an AUX file from the given string.
+
+If the string contains JSON, then the JSON will be imported as if it was a .aux file.
+If the string is a [URL](https://en.wikipedia.org/wiki/URL), then it will be downloaded and imported.
 
 This is useful to quickly download a AUX file and load it into the current universe from a site such as https://gist.github.com/.
 
-The **first parameter** is the URL that the AUX file should be downloaded from.
+The **first parameter** is the JSON or URL that the AUX file should be imported from.
 
 #### Examples:
 
@@ -1817,6 +1820,21 @@ The **first parameter** is the URL that the AUX file should be downloaded from.
 ```typescript
 const path = '/drives/myFile.aux';
 player.importAUX(path);
+```
+
+2. Import an AUX file from JSON.
+```typescript
+player.importAUX(`{
+    "version": 1,
+    "state": {
+        "079847e4-6a58-423d-9a86-8d4ef8be5970": {
+            "id": "079847e4-6a58-423d-9a86-8d4ef8be5970",
+            "tags": {
+                "auxColor": "red"
+            }
+        }
+    }
+}`);
 ```
 
 ### `player.version()`

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -409,6 +409,36 @@ let that: {
 };
 ```
 
+### `@onGridDown`
+
+A shout that is sent to all bots when the user starts clicking on empty space.
+
+#### Arguments:
+```typescript
+let that: {
+  position: {
+    x: number,
+    y: number
+  },
+  dimension: string
+};
+```
+
+### `@onGridUp`
+
+A shout that is sent to all bots when the user stops clicking on empty space.
+
+#### Arguments:
+```typescript
+let that: {
+  position: {
+    x: number,
+    y: number
+  },
+  dimension: string
+};
+```
+
 ### `@onPlayerPortalChanged`
 
 A shout that is sent to all bots when a portal changes on the player.

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -394,6 +394,38 @@ let that: {
 };
 ```
 
+### `@onFileUpload`
+
+A shout that is sent to all bots when the user drags a file into the window.
+
+#### Arguments:
+```typescript
+let that: {
+  file: {
+    // The name of the file. Includes the file extension.
+    name: string;
+
+    // The size of the file in bytes.
+    size: number;
+
+    // The data in the file.
+    // If the file is a text file, the data will be a string.
+    // If the file is not a text file, then the data will be an ArrayBuffer.
+    //
+    // Text files have one of the following extensions:
+    // .txt
+    // .json
+    // .md
+    // .aux
+    // .html
+    // .js
+    // .ts
+    // All the other file extensions map to an ArrayBuffer
+    data: string | ArrayBuffer;
+  }
+};
+```
+
 ### `@onGridClick`
 
 A shout that is sent to all bots when the user clicks on empty space.

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -87,6 +87,7 @@ import {
     isScriptBot,
     getBotSpace,
     getPortalTag,
+    getOriginalObject,
 } from '../bots/BotCalculations';
 
 import '../polyfill/Array.first.polyfill';
@@ -860,7 +861,7 @@ function perform(action: any) {
  * @param action The action to reject.
  */
 function reject(action: any) {
-    const event = calcReject(action);
+    const event = calcReject(getOriginalObject(action));
     return addAction(event);
 }
 

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -65,6 +65,7 @@ import {
     showJoinCode as calcShowJoinCode,
     requestFullscreen,
     exitFullscreen,
+    addState,
 } from '../bots/BotEvents';
 import {
     calculateActionResultsUsingContext,
@@ -88,6 +89,7 @@ import {
     getBotSpace,
     getPortalTag,
     getOriginalObject,
+    getUploadState,
 } from '../bots/BotCalculations';
 
 import '../polyfill/Array.first.polyfill';
@@ -2186,12 +2188,21 @@ function unloadUniverse(id: string) {
 }
 
 /**
- * Imports the AUX at the given URL.
- * @param url The URL to load.
+ * Imports the AUX from the given URL or JSON
+ * @param urlOrJSON The URL or JSON to load.
+ *                  If given JSON, then it will be imported as if it was a .aux file.
+ *                  If given a URL, then it will be downloaded and then imported.
  */
-function importAUX(url: string) {
-    const event = calcImportAUX(url);
-    return addAction(event);
+function importAUX(urlOrJSON: string) {
+    try {
+        const data = JSON.parse(urlOrJSON);
+        const state = getUploadState(data);
+        const event = addState(state);
+        return addAction(event);
+    } catch {
+        const event = calcImportAUX(urlOrJSON);
+        return addAction(event);
+    }
 }
 
 function unwrapBotOrMod(botOrMod: Mod) {

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -765,6 +765,11 @@ export const ON_GRID_UP_ACTION_NAME: string = 'onGridUp';
 export const ON_GRID_DOWN_ACTION_NAME: string = 'onGridDown';
 
 /**
+ * The name of the event that is triggered when a file is uploaded.
+ */
+export const ON_FILE_UPLOAD_ACTION_NAME: string = 'onFileUpload';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -957,6 +962,7 @@ export const KNOWN_TAGS: string[] = [
     ON_ANY_MIN_LOD_ENTER_ACTION_NAME,
     ON_ANY_MAX_LOD_EXIT_ACTION_NAME,
     ON_ANY_MIN_LOD_EXIT_ACTION_NAME,
+    ON_FILE_UPLOAD_ACTION_NAME,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -750,6 +750,21 @@ export const ON_ANY_MAX_LOD_EXIT_ACTION_NAME: string = 'onAnyMaxLODExit';
 export const ON_ANY_MIN_LOD_EXIT_ACTION_NAME: string = 'onAnyMinLODExit';
 
 /**
+ * The name of the event that is triggered when the grid is clicked.
+ */
+export const ON_GRID_CLICK_ACTION_NAME: string = 'onGridClick';
+
+/**
+ * The name of the event that is triggered when the grid starts getting pressed.
+ */
+export const ON_GRID_UP_ACTION_NAME: string = 'onGridUp';
+
+/**
+ * The name of the event that is triggered when the grid stops getting pressed.
+ */
+export const ON_GRID_DOWN_ACTION_NAME: string = 'onGridDown';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -920,7 +935,9 @@ export const KNOWN_TAGS: string[] = [
     ON_PLAYER_PORTAL_CHANGED_ACTION_NAME,
     'onKeyDown',
     'onKeyUp',
-    'onGridClick',
+    ON_GRID_CLICK_ACTION_NAME,
+    ON_GRID_UP_ACTION_NAME,
+    ON_GRID_DOWN_ACTION_NAME,
     'onCheckout',
     'onPaymentSuccessful',
     'onPaymentFailed',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -2655,6 +2655,24 @@ export function getScriptBot(context: BotSandboxContext, bot: Bot) {
     return context.sandbox.interface.getBot(bot.id);
 }
 
+/**
+ * Defines a symbol for a property that contains the original object that
+ * a value was transformed from.
+ */
+export const ORIGINAL_OBJECT = Symbol('ORIGINAL_OBJECT');
+
+/**
+ * Gets the original object that the given object was constructed from.
+ * Returns the object if there is no original object.
+ * @param obj The object.
+ */
+export function getOriginalObject(obj: any): any {
+    if (ORIGINAL_OBJECT in obj) {
+        return obj[ORIGINAL_OBJECT];
+    }
+    return obj;
+}
+
 function _calculateFormulaValue(
     context: BotSandboxContext,
     object: Bot,

--- a/src/aux-common/bots/BotsChannel.ts
+++ b/src/aux-common/bots/BotsChannel.ts
@@ -263,6 +263,7 @@ function mapBotsToScriptBots(context: BotSandboxContext, value: any): any {
     } else if (
         hasValue(value) &&
         !Array.isArray(value) &&
+        !(value instanceof ArrayBuffer) &&
         typeof value === 'object'
     ) {
         return transform(

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -50,6 +50,7 @@ import {
     requestFullscreen,
     exitFullscreen,
     RejectAction,
+    addState,
 } from '../BotEvents';
 import {
     createBot,
@@ -5609,7 +5610,7 @@ export function botActionsTests(
         });
 
         describe('loadAUX()', () => {
-            it('should emit a ImportdAUXEvent', () => {
+            it('should emit a ImportAUXEvent', () => {
                 const state: BotsState = {
                     thisBot: {
                         id: 'thisBot',
@@ -5631,6 +5632,42 @@ export function botActionsTests(
                 expect(result.hasUserDefinedEvents).toBe(true);
 
                 expect(result.events).toEqual([importAUX('abc')]);
+            });
+
+            it('should emit a AddStateEvent if given JSON', () => {
+                const uploadState: BotsState = {
+                    uploadBot: {
+                        id: 'uploadBot',
+                        tags: {
+                            abc: 'def',
+                        },
+                    },
+                };
+                const json = JSON.stringify({
+                    version: 1,
+                    state: uploadState,
+                });
+                const state: BotsState = {
+                    thisBot: {
+                        id: 'thisBot',
+                        tags: {
+                            test: `@player.importAUX('${json}')`,
+                        },
+                    },
+                };
+
+                // specify the UUID to use next
+                uuidMock.mockReturnValue('uuid-0');
+                const botAction = action('test', ['thisBot']);
+                const result = calculateActionEvents(
+                    state,
+                    botAction,
+                    createSandbox
+                );
+
+                expect(result.hasUserDefinedEvents).toBe(true);
+
+                expect(result.events).toEqual([addState(uploadState)]);
             });
         });
 

--- a/src/aux-common/bots/test/BotActionsTests.ts
+++ b/src/aux-common/bots/test/BotActionsTests.ts
@@ -2071,6 +2071,8 @@ export function botActionsTests(
                 ['undefined', undefined],
                 ['*empty string*', ''],
                 ['*filled string*', 'a'],
+                ['*array buffer*', new ArrayBuffer(255)],
+                // ['*typed array*', new Int8Array([1, 2, 3])],
             ];
             it.each(ignoreCases)(
                 'should not convert the argument if it is %s',

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -79,6 +79,7 @@ import BotChat from '../../shared/vue-components/BotChat/BotChat';
 import { SimulationInfo, createSimulationInfo } from '../../shared/RouterUtils';
 import BotSheet from '../../shared/vue-components/BotSheet/BotSheet';
 import { BotRenderer, getRenderer } from '../../shared/scene/BotRenderer';
+import UploadFiles from '../../shared/vue-components/UploadFiles/UploadFiles';
 
 @Component({
     components: {
@@ -95,6 +96,7 @@ import { BotRenderer, getRenderer } from '../../shared/scene/BotRenderer';
         'clipboard-modal': ClipboardModal,
         'bot-chat': BotChat,
         'bot-sheet': BotSheet,
+        'upload-files': UploadFiles,
         console: Console,
         tagline: Tagline,
         checkout: Checkout,
@@ -187,6 +189,11 @@ export default class PlayerApp extends Vue {
      * Whether to show the authorize account popup.
      */
     showAuthorize: boolean = false;
+
+    /**
+     * Whether to show the "Upload file" indicator when a file is being dropped into the application.
+     */
+    showUploadIndicator: boolean = false;
 
     authorized: boolean = false;
 

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -1,6 +1,7 @@
 <template>
     <div id="app">
         <load-app>
+            <upload-files></upload-files>
             <md-toolbar v-if="showChatBar">
                 <div class="md-toolbar-section-start">
                     <bot-chat
@@ -10,7 +11,6 @@
                     ></bot-chat>
                 </div>
             </md-toolbar>
-
             <checkout></checkout>
             <bot-sheet></bot-sheet>
 

--- a/src/aux-server/aux-web/shared/AppManager.ts
+++ b/src/aux-server/aux-web/shared/AppManager.ts
@@ -4,7 +4,7 @@ import Axios from 'axios';
 import Vue from 'vue';
 import { BehaviorSubject, Observable, SubscriptionLike } from 'rxjs';
 import { map, scan } from 'rxjs/operators';
-import { downloadAuxState, readFileJson } from './DownloadHelpers';
+import { downloadAuxState, readFileText } from './DownloadHelpers';
 import {
     ProgressMessage,
     remapProgressPercent,
@@ -157,7 +157,7 @@ export class AppManager {
      * @param file The file to upload.
      */
     async uploadState(file: File): Promise<void> {
-        const json = await readFileJson(file);
+        const json = await readFileText(file);
         const stored: StoredAux = JSON.parse(json);
         const value = await getBotsStateFromStoredAux(stored);
         await this.simulationManager.primary.helper.addState(value);

--- a/src/aux-server/aux-web/shared/DownloadHelpers.ts
+++ b/src/aux-server/aux-web/shared/DownloadHelpers.ts
@@ -15,7 +15,7 @@ export function downloadFile(data: Blob, filename: string, mimeType: string) {
     return download(data, filename, mimeType);
 }
 
-export function readFileJson(data: File): Promise<string> {
+export function readFileText(data: File): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         try {
             const reader = new FileReader();
@@ -33,6 +33,30 @@ export function readFileJson(data: File): Promise<string> {
             };
 
             reader.readAsText(data);
+        } catch (ex) {
+            reject(ex);
+        }
+    });
+}
+
+export function readFileArrayBuffer(data: File): Promise<ArrayBuffer> {
+    return new Promise<ArrayBuffer>((resolve, reject) => {
+        try {
+            const reader = new FileReader();
+
+            reader.onerror = e => {
+                reject(reader.error);
+            };
+
+            reader.onabort = e => {
+                reject(new Error('The file read operation was aborted.'));
+            };
+
+            reader.onload = e => {
+                resolve(<ArrayBuffer>reader.result);
+            };
+
+            reader.readAsArrayBuffer(data);
         } catch (ex) {
             reject(ex);
         }

--- a/src/aux-server/aux-web/shared/interaction/CameraControls.ts
+++ b/src/aux-server/aux-web/shared/interaction/CameraControls.ts
@@ -925,6 +925,8 @@ export class CameraControls {
             lastQuaternion.copy(this._camera.quaternion);
             this.zoomChanged = false;
         }
+
+        this._camera.updateMatrixWorld(true);
     }
 }
 

--- a/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseEmptyClickOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseEmptyClickOperation.ts
@@ -24,6 +24,7 @@ export abstract class BaseEmptyClickOperation implements IOperation {
     protected _interaction: BaseInteractionManager;
     protected _game: Game;
     protected _finished: boolean;
+    protected _sentDownEvent: boolean;
     protected _controller: ControllerData;
 
     protected _startScreenPos: Vector2;
@@ -57,6 +58,11 @@ export abstract class BaseEmptyClickOperation implements IOperation {
     public update(calc: BotCalculationContext): void {
         if (this._finished) return;
 
+        if (!this._sentDownEvent) {
+            this._performDown(calc);
+            this._sentDownEvent = true;
+        }
+
         const input = this._game.getInput();
         const buttonHeld: boolean = this._controller
             ? input.getControllerPrimaryButtonHeld(this._controller)
@@ -77,6 +83,8 @@ export abstract class BaseEmptyClickOperation implements IOperation {
                 this._performClick(calc);
             }
 
+            this._performUp(calc);
+
             // Button has been released. This click operation is finished.
             this._finished = true;
         }
@@ -88,5 +96,21 @@ export abstract class BaseEmptyClickOperation implements IOperation {
 
     public dispose(): void {}
 
+    /**
+     * Sends the empty click event. (onGridClick)
+     * @param calc
+     */
     protected abstract _performClick(calc: BotCalculationContext): void;
+
+    /**
+     * Sends the empty up event. (onGridUp)
+     * @param calc
+     */
+    protected abstract _performUp(calc: BotCalculationContext): void;
+
+    /**
+     * Sends the empty down event. (onGridDown)
+     * @param calc
+     */
+    protected abstract _performDown(calc: BotCalculationContext): void;
 }

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -617,20 +617,29 @@ const clipArea = clipWidth * clipHeight;
 const clipAreaRatio = 1 / clipArea;
 const clipBox = new Box3().set(new Vector3(-1, -1, -1), new Vector3(1, 1, 1));
 
-let _boxSize = new Vector3();
 /**
- * Calculates the percentage of the screen that the given sphere takes up.
+ * Calculates the apparent size of the given sphere viewed by the camera.
+ * If the sphere is off screen, 0 is returned. Otherwise it is the percentage that the sphere takes on the screen.
+ *
  * @param camera The camera to use.
  * @param boundingSphere The sphere to use. Should be in world space.
  */
-export function percentOfScreen(camera: Camera, boundingBox: Box3): number {
-    const box = boundingBox.clone();
-    box.applyMatrix4(camera.matrixWorldInverse).applyMatrix4(
-        camera.projectionMatrix
-    );
+export function percentOfScreen(
+    camera: Camera,
+    boundingSphere: Sphere
+): number {
+    const sphere = boundingSphere.clone();
+    sphere
+        .applyMatrix4(camera.matrixWorldInverse)
+        .applyMatrix4(camera.projectionMatrix);
 
-    box.intersect(clipBox);
-    box.getSize(_boxSize);
-
-    return _boxSize.x * _boxSize.y * clipAreaRatio;
+    if (sphere.intersectsBox(clipBox)) {
+        // Spheres are uniform so we can ignore the Z axis
+        // and only consider the area of a circle when comparing to
+        // the screen area.
+        const circleArea = Math.PI * sphere.radius * sphere.radius;
+        return circleArea * clipAreaRatio;
+    } else {
+        return 0;
+    }
 }

--- a/src/aux-server/aux-web/shared/scene/decorators/BotLODDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotLODDecorator.ts
@@ -27,6 +27,7 @@ import { Text3D } from '../Text3D';
 import { calculateScale, percentOfScreen } from '../SceneUtils';
 import { Camera } from 'three';
 import { Simulation } from '@casual-simulation/aux-vm';
+import { DebugObjectManager } from '../debugobjectmanager/DebugObjectManager';
 
 export class BotLODDecorator extends AuxBot3DDecoratorBase {
     private _currentLOD: BotLOD = DEFAULT_BOT_LOD;
@@ -83,7 +84,10 @@ export class BotLODDecorator extends AuxBot3DDecoratorBase {
     }
 
     private _updateLOD(calc: BotCalculationContext) {
-        const percent = percentOfScreen(this._camera, this.bot3D.boundingBox);
+        const percent = percentOfScreen(
+            this._camera,
+            this.bot3D.boundingSphere
+        );
         const nextLOD = calculateBotLOD(
             percent,
             this._minThreshold,

--- a/src/aux-server/aux-web/shared/vue-components/UploadFiles/UploadFiles.css
+++ b/src/aux-server/aux-web/shared/vue-components/UploadFiles/UploadFiles.css
@@ -1,0 +1,25 @@
+.upload-files {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    z-index: 4;
+}
+
+.upload-files-content {
+    text-align: center;
+}
+
+.upload-files-text {
+    font-size: 22px;
+}
+
+.icon-white {
+    color: #fff !important;
+}

--- a/src/aux-server/aux-web/shared/vue-components/UploadFiles/UploadFiles.ts
+++ b/src/aux-server/aux-web/shared/vue-components/UploadFiles/UploadFiles.ts
@@ -165,9 +165,15 @@ export default class UploadFiles extends Vue {
     }
 }
 
-const jsonFileExtensions = new Set(['.aux', '.json']);
-
-const textFileExtensions = new Set([...jsonFileExtensions.values(), '.txt']);
+const textFileExtensions = new Set([
+    '.aux',
+    '.json',
+    '.txt',
+    '.md',
+    '.html',
+    '.js',
+    '.ts',
+]);
 
 async function getFileData(file: File): Promise<string | ArrayBuffer | object> {
     try {
@@ -180,17 +186,6 @@ async function getFileData(file: File): Promise<string | ArrayBuffer | object> {
         }
 
         if (textData !== null) {
-            try {
-                for (let jsonExt of jsonFileExtensions) {
-                    if (file.name.endsWith(jsonExt)) {
-                        return JSON.parse(textData);
-                    }
-                }
-            } catch (err) {
-                // JSON parsing failed, return just the string data
-                return textData;
-            }
-
             return textData;
         }
     } catch {

--- a/src/aux-server/aux-web/shared/vue-components/UploadFiles/UploadFiles.ts
+++ b/src/aux-server/aux-web/shared/vue-components/UploadFiles/UploadFiles.ts
@@ -1,0 +1,201 @@
+import Vue, { ComponentOptions } from 'vue';
+import Component from 'vue-class-component';
+import { Provide, Prop, Inject, Watch } from 'vue-property-decorator';
+import {
+    Bot,
+    hasValue,
+    BotTags,
+    BotAction,
+    ShoutAction,
+    ON_FILE_UPLOAD_ACTION_NAME,
+} from '@casual-simulation/aux-common';
+import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
+import { appManager } from '../../AppManager';
+import BotTable from '../BotTable/BotTable';
+import { SubscriptionLike, Subscription } from 'rxjs';
+import { Input } from '../../scene/Input';
+import { readFileArrayBuffer, readFileText } from '../../DownloadHelpers';
+
+@Component({
+    components: {},
+})
+export default class UploadFiles extends Vue {
+    showUploadFiles: boolean = false;
+
+    private _counter: number = 0;
+    private _subscriptions: SubscriptionLike[];
+
+    created() {
+        this._subscriptions = [];
+        this._counter = 0;
+    }
+
+    mounted() {
+        const dragEnterListener = (event: DragEvent) => this.onDragEnter(event);
+        const dragLeaveListener = (event: DragEvent) => this.onDragLeave(event);
+        const dragOverListener = (event: DragEvent) => this.onDragOver(event);
+        const dropListener = (event: DragEvent) => this.onDrop(event);
+
+        document.addEventListener('dragenter', dragEnterListener, false);
+        document.addEventListener('dragleave', dragLeaveListener, false);
+        document.addEventListener('dragover', dragOverListener, false);
+        document.addEventListener('drop', dropListener, false);
+
+        this._subscriptions.push(
+            new Subscription(() => {
+                document.removeEventListener('dragenter', dragEnterListener);
+                document.removeEventListener('dragleave', dragLeaveListener);
+                document.removeEventListener('dragover', dragOverListener);
+                document.removeEventListener('drop', dropListener);
+            })
+        );
+    }
+
+    beforeDestroy() {
+        for (let sub of this._subscriptions) {
+            sub.unsubscribe();
+        }
+    }
+
+    onDragEnter(event: DragEvent) {
+        if (this._counter < 0) {
+            this._counter = 0;
+        }
+        if (
+            Input.isElementContainedByOrEqual(
+                <Element>event.target,
+                this.$parent.$el
+            )
+        ) {
+            if (event.dataTransfer.types.indexOf('Files') >= 0) {
+                this.showUploadFiles = true;
+                event.dataTransfer.dropEffect = 'copy';
+                event.preventDefault();
+                this._counter += 1;
+            }
+        }
+    }
+
+    onDragOver(event: DragEvent) {
+        if (
+            Input.isElementContainedByOrEqual(
+                <Element>event.target,
+                this.$parent.$el
+            )
+        ) {
+            if (event.dataTransfer.types.indexOf('Files') >= 0) {
+                this.showUploadFiles = true;
+                event.dataTransfer.dropEffect = 'copy';
+                event.preventDefault();
+                event.stopPropagation();
+            }
+        }
+    }
+
+    onDragLeave(event: DragEvent) {
+        if (
+            Input.isElementContainedByOrEqual(
+                <Element>event.target,
+                this.$parent.$el
+            )
+        ) {
+            this._counter -= 1;
+        }
+
+        if (this._counter <= 0) {
+            this.showUploadFiles = false;
+        }
+    }
+
+    async onDrop(event: DragEvent) {
+        this.showUploadFiles = false;
+        this._counter = 0;
+
+        if (
+            Input.isElementContainedByOrEqual(
+                <Element>event.target,
+                this.$parent.$el
+            )
+        ) {
+            event.preventDefault();
+
+            let files: File[] = [];
+            if (event.dataTransfer.items) {
+                for (let i = 0; i < event.dataTransfer.items.length; i++) {
+                    const item = event.dataTransfer.items[i];
+                    if (item.kind === 'file') {
+                        const file = item.getAsFile();
+                        files.push(file);
+                    }
+                }
+            } else {
+                for (let i = 0; i < event.dataTransfer.files.length; i++) {
+                    const file = event.dataTransfer.files.item(i);
+                    files.push(file);
+                }
+            }
+
+            if (files.length > 0) {
+                const finalFiles = await Promise.all(
+                    files.map(async f => {
+                        const data = await getFileData(f);
+                        return {
+                            name: f.name,
+                            size: f.size,
+                            data: data,
+                        };
+                    })
+                );
+
+                for (let sim of appManager.simulationManager.simulations.values()) {
+                    let actions: ShoutAction[] = sim.helper.actions(
+                        finalFiles.map(f => ({
+                            bots: null,
+                            eventName: ON_FILE_UPLOAD_ACTION_NAME,
+                            arg: {
+                                file: f,
+                            },
+                        }))
+                    );
+
+                    sim.helper.transaction(...actions);
+                }
+            }
+        }
+    }
+}
+
+const jsonFileExtensions = new Set(['.aux', '.json']);
+
+const textFileExtensions = new Set([...jsonFileExtensions.values(), '.txt']);
+
+async function getFileData(file: File): Promise<string | ArrayBuffer | object> {
+    try {
+        let textData: string = null;
+        for (let textExt of textFileExtensions) {
+            if (file.name.endsWith(textExt)) {
+                textData = await readFileText(file);
+                break;
+            }
+        }
+
+        if (textData !== null) {
+            try {
+                for (let jsonExt of jsonFileExtensions) {
+                    if (file.name.endsWith(jsonExt)) {
+                        return JSON.parse(textData);
+                    }
+                }
+            } catch (err) {
+                // JSON parsing failed, return just the string data
+                return textData;
+            }
+
+            return textData;
+        }
+    } catch {
+        return await readFileArrayBuffer(file);
+    }
+
+    return await readFileArrayBuffer(file);
+}

--- a/src/aux-server/aux-web/shared/vue-components/UploadFiles/UploadFiles.vue
+++ b/src/aux-server/aux-web/shared/vue-components/UploadFiles/UploadFiles.vue
@@ -1,0 +1,10 @@
+<template>
+    <div v-if="showUploadFiles" class="upload-files">
+        <div class="upload-files-content">
+            <md-icon class="icon-white md-size-4x">cloud_upload</md-icon>
+            <p class="upload-files-text">Drop to upload</p>
+        </div>
+    </div>
+</template>
+<script src="./UploadFiles.ts"></script>
+<style src="./UploadFiles.css" scoped></style>

--- a/src/aux-server/server/modules/WebhooksModule2.spec.ts
+++ b/src/aux-server/server/modules/WebhooksModule2.spec.ts
@@ -99,9 +99,9 @@ describe('WebhooksModule2', () => {
 
                 expect(simulation.helper.botsState['test'].tags).toEqual({
                     onResponse: '@setTag(this, "data", that.response.data)',
-                    data: {
+                    data: expect.objectContaining({
                         test: true,
-                    },
+                    }),
                 });
             });
 
@@ -140,9 +140,9 @@ describe('WebhooksModule2', () => {
 
                 expect(simulation.helper.botsState['test'].tags).toEqual({
                     onResponse: '@setTag(this, "data", that.response.data)',
-                    data: {
+                    data: expect.objectContaining({
                         test: true,
-                    },
+                    }),
                 });
             });
         });


### PR DESCRIPTION
-   :rocket: Improvements

    -   Added the ability to modify tags directly on bots in `that`/`data` values in listeners.
        -   Allows doing `that.bot.tags.abc = 123` instead of `setTag(that.bot, "abc", 123)`.
    -   Added the `@onGridUp` and `@onGridDown` listeners.
        -   `that` is an object with the following properties:
            -   `dimension` - The dimension that the grid was clicked in.
            -   `position` - The X and Y position that was clicked.
    -   Changed the Level-Of-Detail calculations to use the apparent size of a bot instead of its on-screen size.
        -   Apparent size is the size the bot would appear if it was fully on screen.
        -   Under the new system, the LOD of a that is on screen bot will only change due to zooming the camera. Bots that are fully off screen will always have the minimum LOD.
    -   Added the `@onFileUpload` listener.
        -   `that` is an object with the following properties:
            -   `file` is an object with the following properties:
                -   `name` - The name of the file.
                -   `size` - The size of the file in bytes.
                -   `data` - The data contained in the file.
        -   See the documentation for more information.
    -   Improved the `player.importAux()` function to support importing directly from JSON.
        -   If given a URL, then `player.importAux()` will behave the same as before (download and import).
        -   If given JSON, then `player.importAux()` will simply import it directly.

-   :bug: Bug Fixes
    -   Fixed an issue where the camera matrix was being used before it was updated.