### PR TITLE
Added focus events, the nothing form, auxPointable, and LOD and panning fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
         -   Does exactly what it seems. A bot with the `nothing` form has no shape and is unable to be clicked, hovered, or focused.
         -   Labels still work though which makes it convienent for adding extra labels around the dimension.
 
+-   :bug: Bug Fixes
+
+    -   Fixed an issue where LODs would flicker upon changing the bot form by ensuring consistent sizing for the related bounding boxes.
+
 ## V1.0.19
 
 ### Date: 3/19/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   :bug: Bug Fixes
 
     -   Fixed an issue where LODs would flicker upon changing the bot form by ensuring consistent sizing for the related bounding boxes.
+    -   Fixed an issue with panning that would cause the camera orbiting position to be moved off the ground.
 
 ## V1.0.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
     -   Added the `nothing` aux form.
         -   Does exactly what it seems. A bot with the `nothing` form has no shape and is unable to be clicked, hovered, or focused.
         -   Labels still work though which makes it convienent for adding extra labels around the dimension.
+    -   Added the `#auxPortalShowFocusPoint` tag.
+        -   Shows a small sphere in the portal where the portal camera will orbit around.
 
 -   :bug: Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # AUX Changelog
 
+## V1.0.20
+
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+
+    -   Added the `#auxPointable` tag to determine whether a bot can interact with pointers.
+        -   Defaults to `true`.
+        -   When `false`, the bot won't be clickable or hoverable and will not receive drop events.
+        -   Depending on the `#auxPositioningMode` it is still possible to stack bots on top of it though.
+    -   Added the `@onFocusEnter`, `@onFocusExit`, `@onAnyFocusEnter` and `@onAnyFocusExit` listen tags.
+        -   These are triggered when a bot is directly in the center of the screen.
+        -   Uses the `#auxFocusable` tag to determine whether a bot is focusable.
+        -   `that` is an object with the following properties:
+            -   `dimension` - The dimension that the the bot was (un)focused in.
+            -   `bot` - The bot that was (un)focused.
+    -   Added the `nothing` aux form.
+        -   Does exactly what it seems. A bot with the `nothing` form has no shape and is unable to be clicked, hovered, or focused.
+        -   Labels still work though which makes it convienent for adding extra labels around the dimension.
+
 ## V1.0.19
 
 ### Date: 3/19/2020

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -304,6 +304,36 @@ let that: {
 };
 ```
 
+### `@onFocusEnter`
+
+A whisper that is sent whenever a bot starts being focused by the player.
+
+Focus is when the bot is in the center of the screen.
+
+Only sent if <TagLink tag='auxFocusable'/> is true.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
+### `@onFocusExit`
+
+A whisper that is sent whenever a bot stops being focused by the player.
+
+Focus is when the bot is in the center of the screen.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
 ### `@[groupName][stateName]OnEnter`
 
 A whisper that is sent whenever the `[groupName]` tag is set to `[stateName]` via the <ActionLink action='changeState(bot, stateName, groupName?)'/> function.
@@ -758,6 +788,36 @@ let that: {
 A shout that is sent whenever a bot exits its minimum Level-Of-Detail.
 
 Only sent for bots that have one of <TagLink tag='@onMaxLODEnter'/>, <TagLink tag='@onMaxLODExit'/>, <TagLink tag='@onMinLODEnter'/>, <TagLink tag='@onMinLODExit'/>, <TagLink tag='auxMaxLODThreshold'/> or <TagLink tag='auxMinLODThreshold'/> specified.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
+### `@onAnyFocusEnter`
+
+A shout that is sent whenever a bot starts being focused by the player.
+
+Focus is when the bot is in the center of the screen.
+
+Only sent if <TagLink tag='auxFocusable'/> is true.
+
+#### Arguments:
+```typescript
+let that: {
+  bot: Bot,
+  dimension: string
+};
+```
+
+### `@onAnyFocusExit`
+
+A shout that is sent whenever a bot stops being focused by the player.
+
+Focus is when the bot is in the center of the screen.
 
 #### Arguments:
 ```typescript

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -944,6 +944,24 @@ The mode that specifies how the mouse pointer/controller drags bots in the porta
   </PossibleValue>
 </PossibleValuesTable>
 
+### `auxPortalShowFocusPoint`
+
+Whether the focus point of the portal camera should be shown as a small sphere.
+
+The focus point is the position that the camera orbits (rotates) around and is always facing.
+
+When a bot is between the focus point and the camera, then focus events will trigger.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValue value='false'>
+    Don't show an indicator for the focus point. (Default)
+  </PossibleValue>
+  <PossibleValue value='true'>
+    Show an indicator for the focus point.
+  </PossibleValue>
+</PossibleValuesTable>
+
 ### `auxInventoryPortalHeight`
 
 Sets the initial height of the inventory viewport for the portal.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -135,6 +135,23 @@ The positioning mode that the bot uses.
   </PossibleValueCode>
 </PossibleValuesTable>
 
+### `auxPointable`
+
+Whether the bot interacts with the pointer.
+
+Bots that are pointable can receive clicks, pointer enter/exit, and drop events.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='true'>
+    The bot interacts with the pointer. (default)
+  </PossibleValueCode>
+  <PossibleValueCode value='false'>
+    The bot does not interact with the pointer.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
 ### `auxDestroyable`
 
 Whether the bot is able to be destroyed in AUXPlayer. The bot can still be destroyed in Channel Designer.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -152,6 +152,23 @@ Bots that are pointable can receive clicks, pointer enter/exit, and drop events.
   </PossibleValueCode>
 </PossibleValuesTable>
 
+### `auxFocusable`
+
+Whether the bot is able to be focused.
+
+Bots that are focusable can receive focus events like <TagLink tag='@onFocusEnter'/>.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='true'>
+    The bot is focusable. (default)
+  </PossibleValueCode>
+  <PossibleValueCode value='false'>
+    The bot is not focusable.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
 ### `auxDestroyable`
 
 Whether the bot is able to be destroyed in AUXPlayer. The bot can still be destroyed in Channel Designer.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -137,6 +137,7 @@ export interface BotTags {
     ['auxProgressBarBackgroundColor']?: unknown;
     ['auxProgressBarPosition']?: unknown;
     ['auxPointable']?: unknown;
+    ['auxFocusable']?: unknown;
 
     // User tags
     ['auxPlayerActive']?: boolean;
@@ -771,6 +772,26 @@ export const ON_GRID_DOWN_ACTION_NAME: string = 'onGridDown';
 export const ON_FILE_UPLOAD_ACTION_NAME: string = 'onFileUpload';
 
 /**
+ * The name of the event that is triggerd when a bot gains camera focus.
+ */
+export const ON_FOCUS_ENTER_ACTION_NAME: string = 'onFocusEnter';
+
+/**
+ * The name of the event that is triggerd when a bot loses camera focus.
+ */
+export const ON_FOCUS_EXIT_ACTION_NAME: string = 'onFocusExit';
+
+/**
+ * The name of the event that is triggerd when a bot gains camera focus.
+ */
+export const ON_ANY_FOCUS_ENTER_ACTION_NAME: string = 'onAnyFocusEnter';
+
+/**
+ * The name of the event that is triggerd when a bot loses camera focus.
+ */
+export const ON_ANY_FOCUS_EXIT_ACTION_NAME: string = 'onAnyFocusExit';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -881,6 +902,7 @@ export const KNOWN_TAGS: string[] = [
     'auxMinLODThreshold',
     'auxUniverseConnectedSessions',
     'auxPointable',
+    'auxFocusable',
 
     'auxTaskOutput',
     'auxTaskError',
@@ -965,6 +987,11 @@ export const KNOWN_TAGS: string[] = [
     ON_ANY_MAX_LOD_EXIT_ACTION_NAME,
     ON_ANY_MIN_LOD_EXIT_ACTION_NAME,
     ON_FILE_UPLOAD_ACTION_NAME,
+
+    ON_FOCUS_ENTER_ACTION_NAME,
+    ON_FOCUS_EXIT_ACTION_NAME,
+    ON_ANY_FOCUS_ENTER_ACTION_NAME,
+    ON_ANY_FOCUS_EXIT_ACTION_NAME,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -136,6 +136,7 @@ export interface BotTags {
     ['auxProgressBarColor']?: unknown;
     ['auxProgressBarBackgroundColor']?: unknown;
     ['auxProgressBarPosition']?: unknown;
+    ['auxPointable']?: unknown;
 
     // User tags
     ['auxPlayerActive']?: boolean;
@@ -879,6 +880,7 @@ export const KNOWN_TAGS: string[] = [
     'auxMaxLODThreshold',
     'auxMinLODThreshold',
     'auxUniverseConnectedSessions',
+    'auxPointable',
 
     'auxTaskOutput',
     'auxTaskError',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -257,7 +257,13 @@ export interface WorkspaceHex {
 /**
  * Defines the possible shapes that a bot can appear as.
  */
-export type BotShape = 'cube' | 'sphere' | 'sprite' | 'mesh' | 'iframe';
+export type BotShape =
+    | 'cube'
+    | 'sphere'
+    | 'sprite'
+    | 'mesh'
+    | 'iframe'
+    | 'nothing';
 
 /**
  * Defines the possible subtypes for shapes that a bot can appear as.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -192,6 +192,7 @@ export interface BotTags {
     [`auxPortalZoomableMax`]?: number | null;
     ['auxPortalRotatable']?: number | null;
     ['auxPortalPointerDragMode']?: PortalPointerDragMode;
+    ['auxPortalShowFocusPoint']?: boolean | null;
     ['auxInventoryPortalHeight']?: unknown;
     ['auxInventoryPortalResizable']?: boolean;
     ['auxWristPortalHeight']?: number;
@@ -452,6 +453,11 @@ export const DEFAULT_PORTAL_ROTATABLE = true;
  * Whether portals are zoomable by default.
  */
 export const DEFAULT_PORTAL_ZOOMABLE = true;
+
+/**
+ * Whether portals should show their focus point.
+ */
+export const DEFAULT_PORTAL_SHOW_FOCUS_POINT = false;
 
 /**
  * Whether inventory portals are resizable by default.
@@ -860,6 +866,7 @@ export const KNOWN_TAGS: string[] = [
     `auxPortalPlayerRotationX`,
     `auxPortalPlayerRotationY`,
     'auxPortalPointerDragMode',
+    'auxPortalShowFocusPoint',
     'auxInventoryPortalHeight',
     'auxInventoryPortalResizable',
     'auxWristPortalHeight',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1239,7 +1239,8 @@ export function getBotShape(calc: BotCalculationContext, bot: Bot): BotShape {
         shape === 'sphere' ||
         shape === 'sprite' ||
         shape === 'mesh' ||
-        shape === 'iframe'
+        shape === 'iframe' ||
+        shape === 'nothing'
     ) {
         return shape;
     }

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -225,6 +225,15 @@ export function getUploadState(data: any): BotsState {
 }
 
 /**
+ * Gets whether the bot is pointable.
+ * @param calc The calculation context.
+ * @param bot The bot.
+ */
+export function isBotPointable(calc: BotCalculationContext, bot: Bot): boolean {
+    return calculateBooleanTagValue(calc, bot, 'auxPointable', true);
+}
+
+/**
  * Gets a list of tags that the given bots contain.
  *
  * @param bots The array of bots that the list of tags should be retrieved

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -234,6 +234,15 @@ export function isBotPointable(calc: BotCalculationContext, bot: Bot): boolean {
 }
 
 /**
+ * Gets whether the bot is focusable.
+ * @param calc The calculation context.
+ * @param bot The bot.
+ */
+export function isBotFocusable(calc: BotCalculationContext, bot: Bot): boolean {
+    return calculateBooleanTagValue(calc, bot, 'auxFocusable', true);
+}
+
+/**
  * Gets a list of tags that the given bots contain.
  *
  * @param bots The array of bots that the list of tags should be retrieved

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -59,6 +59,7 @@ import {
     getBotAnchorPoint,
     calculatePortalPointerDragMode,
     getAnchorPointOffset,
+    isBotPointable,
 } from '../BotCalculations';
 import {
     Bot,
@@ -4581,6 +4582,19 @@ export function botCalculationContextTests(
 
             const calc = createCalculationContext([thisBot]);
             const result = isBotInDimension(calc, thisBot, 'dimension');
+
+            expect(result).toBe(expected);
+        });
+    });
+
+    describe('isBotPointable()', () => {
+        booleanTagValueTests(true, (given, expected) => {
+            const thisBot = createBot('thisBot', {
+                auxPointable: given,
+            });
+
+            const calc = createCalculationContext([thisBot]);
+            const result = isBotPointable(calc, thisBot);
 
             expect(result).toBe(expected);
         });

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -60,6 +60,7 @@ import {
     calculatePortalPointerDragMode,
     getAnchorPointOffset,
     isBotPointable,
+    isBotFocusable,
 } from '../BotCalculations';
 import {
     Bot,
@@ -4607,7 +4608,7 @@ export function botCalculationContextTests(
             });
 
             const calc = createCalculationContext([thisBot]);
-            const result = isBotPointable(calc, thisBot);
+            const result = isBotFocusable(calc, thisBot);
 
             expect(result).toBe(expected);
         });

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -4600,6 +4600,19 @@ export function botCalculationContextTests(
         });
     });
 
+    describe('isBotFocusable()', () => {
+        booleanTagValueTests(true, (given, expected) => {
+            const thisBot = createBot('thisBot', {
+                auxFocusable: given,
+            });
+
+            const calc = createCalculationContext([thisBot]);
+            const result = isBotPointable(calc, thisBot);
+
+            expect(result).toBe(expected);
+        });
+    });
+
     describe('getUserBotColor()', () => {
         const defaultCases = [
             [DEFAULT_BUILDER_USER_COLOR, 'builder'],

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3450,7 +3450,14 @@ export function botCalculationContextTests(
     });
 
     describe('getBotShape()', () => {
-        const cases = [['cube'], ['sphere'], ['sprite'], ['mesh'], ['iframe']];
+        const cases = [
+            ['cube'],
+            ['sphere'],
+            ['sprite'],
+            ['mesh'],
+            ['iframe'],
+            ['nothing'],
+        ];
         it.each(cases)('should return %s', (shape: string) => {
             const bot = createBot('test', {
                 auxForm: <any>shape,

--- a/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerBotDragOperation.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerBotDragOperation.ts
@@ -190,10 +190,9 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
                 hit,
             } = this._interaction.findHoveredGameObjectFromRay(
                 inputRay,
-                hit => {
-                    const obj = this._interaction.findGameObjectForHit(hit);
+                obj => {
                     return (
-                        obj &&
+                        obj.pointable &&
                         obj instanceof AuxBot3D &&
                         !this._bots.find(b => b.id === obj.bot.id)
                     );

--- a/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerModDragOperation.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerModDragOperation.ts
@@ -102,7 +102,7 @@ export class PlayerModDragOperation extends BaseModDragOperation {
                 hit,
             } = this._interaction.findHoveredGameObjectFromRay(
                 inputRay,
-                null,
+                obj => obj.pointable,
                 viewport
             );
             if (gameObject instanceof AuxBot3D) {

--- a/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
@@ -1,6 +1,13 @@
 import { Vector3, Intersection, Object3D, OrthographicCamera } from 'three';
 import { ContextMenuAction } from '../../shared/interaction/ContextMenuEvent';
-import { Bot, BotCalculationContext } from '@casual-simulation/aux-common';
+import {
+    Bot,
+    BotCalculationContext,
+    ON_FOCUS_EXIT_ACTION_NAME,
+    ON_FOCUS_ENTER_ACTION_NAME,
+    ON_ANY_FOCUS_ENTER_ACTION_NAME,
+    ON_ANY_FOCUS_EXIT_ACTION_NAME,
+} from '@casual-simulation/aux-common';
 import { IOperation } from '../../shared/interaction/IOperation';
 import { BaseInteractionManager } from '../../shared/interaction/BaseInteractionManager';
 import { GameObject } from '../../shared/scene/GameObject';
@@ -182,6 +189,30 @@ export class PlayerInteractionManager extends BaseInteractionManager {
             dimension: [...bot3D.dimensionGroup.dimensions.values()][0],
             bot: bot,
         });
+    }
+
+    handleFocusEnter(bot3D: AuxBot3D, bot: Bot, simulation: Simulation): void {
+        const arg = {
+            dimension: [...bot3D.dimensionGroup.dimensions.values()][0],
+            bot: bot,
+        };
+        const actions = simulation.helper.actions([
+            { eventName: ON_FOCUS_ENTER_ACTION_NAME, bots: [bot], arg },
+            { eventName: ON_ANY_FOCUS_ENTER_ACTION_NAME, bots: null, arg },
+        ]);
+        simulation.helper.transaction(...actions);
+    }
+
+    handleFocusExit(bot3D: AuxBot3D, bot: Bot, simulation: Simulation): void {
+        const arg = {
+            dimension: [...bot3D.dimensionGroup.dimensions.values()][0],
+            bot: bot,
+        };
+        const actions = simulation.helper.actions([
+            { eventName: ON_FOCUS_EXIT_ACTION_NAME, bots: [bot], arg },
+            { eventName: ON_ANY_FOCUS_EXIT_ACTION_NAME, bots: null, arg },
+        ]);
+        simulation.helper.transaction(...actions);
     }
 
     createEmptyClickOperation(inputMethod: InputMethod): IOperation {

--- a/src/aux-server/aux-web/aux-player/scene/InventorySimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/InventorySimulation3D.ts
@@ -152,6 +152,13 @@ export class InventorySimulation3D extends PlayerSimulation3D {
         return this.inventoryConfig.height;
     }
 
+    /**
+     * Gets whether to show the camera focus point.
+     */
+    get showFocusPoint() {
+        return this.inventoryConfig.showFocusPoint;
+    }
+
     constructor(game: Game, simulation: BrowserSimulation) {
         super('auxInventoryPortal', game, simulation);
     }

--- a/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
@@ -61,6 +61,7 @@ import {
     objectForwardRay,
     objectDirectionRay,
     objectWorldDirectionRay,
+    cameraForwardRay,
 } from '../../shared/scene/SceneUtils';
 import { DebugObjectManager } from '../../shared/scene/debugobjectmanager/DebugObjectManager';
 
@@ -217,10 +218,7 @@ export class PlayerPageSimulation3D extends PlayerSimulation3D {
             );
 
             const cameraRig = this.getMainCameraRig();
-            const cameraRay = objectWorldDirectionRay(
-                new Vector3(0, 0, -1),
-                cameraRig.mainCamera
-            );
+            const cameraRay = cameraForwardRay(cameraRig.mainCamera);
 
             const dot = cameraRay.direction.dot(gridRay.direction);
             // If the grid's up direction is pointing towards the camera's forward direction

--- a/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
@@ -202,6 +202,13 @@ export class PlayerPageSimulation3D extends PlayerSimulation3D {
         return this.pageConfig.playerRotationY;
     }
 
+    /**
+     * Gets whether to show the camera focus point.
+     */
+    get showFocusPoint() {
+        return this.pageConfig.showFocusPoint;
+    }
+
     protected _frameUpdateCore(calc: BotCalculationContext) {
         super._frameUpdateCore(calc);
         const input = this.game.getInput();

--- a/src/aux-server/aux-web/aux-player/scene/PortalConfig.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PortalConfig.ts
@@ -13,6 +13,7 @@ import {
     PortalPointerDragMode,
     DEFAULT_PORTAL_POINTER_DRAG_MODE,
     calculatePortalPointerDragMode,
+    DEFAULT_PORTAL_SHOW_FOCUS_POINT,
 } from '@casual-simulation/aux-common';
 import { Color } from 'three';
 import {
@@ -42,6 +43,7 @@ export class PortalConfig implements SubscriptionLike {
     private _playerZoom: number = null;
     private _playerRotationX: number = null;
     private _playerRotationY: number = null;
+    private _showFocusPoint: boolean = null;
     private _gridScale: number;
     private _raycastMode: PortalPointerDragMode = null;
     private _grid3D: BoundedGrid3D;
@@ -191,6 +193,14 @@ export class PortalConfig implements SubscriptionLike {
         }
     }
 
+    get showFocusPoint() {
+        if (this._showFocusPoint !== null) {
+            return this._showFocusPoint;
+        } else {
+            return null;
+        }
+    }
+
     get gridScale() {
         return this._gridScale;
     }
@@ -275,6 +285,7 @@ export class PortalConfig implements SubscriptionLike {
         this._playerRotationX = null;
         this._playerRotationY = null;
         this._raycastMode = null;
+        this._showFocusPoint = null;
         this.gridScale = this._getDefaultGridScale();
     }
 
@@ -367,6 +378,12 @@ export class PortalConfig implements SubscriptionLike {
             null
         );
         this._raycastMode = calculatePortalPointerDragMode(calc, bot);
+        this._showFocusPoint = calculateBooleanTagValue(
+            calc,
+            bot,
+            `auxPortalShowFocusPoint`,
+            null
+        );
         this.gridScale = calculateGridScale(calc, bot);
 
         // TODO:

--- a/src/aux-server/aux-web/shared/interaction/BaseInteractionManager.ts
+++ b/src/aux-server/aux-web/shared/interaction/BaseInteractionManager.ts
@@ -207,9 +207,7 @@ export abstract class BaseInteractionManager {
             this.setCameraControlsEnabled(this._cameraControlsEnabled);
         }
 
-        this._cameraRigControllers.forEach(rigControls =>
-            rigControls.controls.update()
-        );
+        this._updateCameraControls();
 
         // Detect left click.
         this._handleMouseInput(input);
@@ -221,6 +219,16 @@ export abstract class BaseInteractionManager {
 
         this._updateHoveredBots();
         this._updateFocusedBots();
+    }
+
+    protected _updateCameraControls() {
+        for (let controller of this._cameraRigControllers) {
+            this._updateCameraController(controller);
+        }
+    }
+
+    protected _updateCameraController(controller: CameraRigControls) {
+        controller.controls.update();
     }
 
     private _handleCameraInput() {

--- a/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
@@ -5,6 +5,7 @@ import {
     BotCalculationContext,
     calculateGridScale,
     isBotPointable,
+    isBotFocusable,
 } from '@casual-simulation/aux-common';
 import { AuxBot3DDecorator } from './AuxBot3DDecorator';
 import { DimensionGroup3D } from './DimensionGroup3D';
@@ -156,6 +157,7 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
                 this._boundingSphere = null;
 
                 this.pointable = isBotPointable(calc, this.bot);
+                this.focusable = isBotFocusable(calc, this.bot);
             }
             for (let i = 0; i < this.decorators.length; i++) {
                 this.decorators[i].botUpdated(calc);

--- a/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
@@ -4,6 +4,7 @@ import {
     Bot,
     BotCalculationContext,
     calculateGridScale,
+    isBotPointable,
 } from '@casual-simulation/aux-common';
 import { AuxBot3DDecorator } from './AuxBot3DDecorator';
 import { DimensionGroup3D } from './DimensionGroup3D';
@@ -153,6 +154,8 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
                 this.bot = bot;
                 this._boundingBox = null;
                 this._boundingSphere = null;
+
+                this.pointable = isBotPointable(calc, this.bot);
             }
             for (let i = 0; i < this.decorators.length; i++) {
                 this.decorators[i].botUpdated(calc);

--- a/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
@@ -1,5 +1,5 @@
 import { GameObject } from './GameObject';
-import { Object3D, Box3, Sphere, Group, Color } from 'three';
+import { Object3D, Box3, Sphere, Group, Color, Vector3 } from 'three';
 import {
     Bot,
     BotCalculationContext,
@@ -127,6 +127,18 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
         }
 
         this._boundingBox.setFromObject(this.display);
+
+        if (this._boundingBox.isEmpty()) {
+            // Set to the virtual box.
+            const worldPosition = new Vector3();
+            this.display.getWorldPosition(worldPosition);
+            const worldScale = new Vector3();
+            this.display.getWorldScale(worldScale);
+            this._boundingBox = new Box3().setFromCenterAndSize(
+                worldPosition,
+                worldScale
+            );
+        }
 
         // Calculate Bounding Sphere
         if (this._boundingSphere === null) {

--- a/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
@@ -55,6 +55,8 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
     private _frameUpdateList: AuxBot3DDecorator[];
     private _boundingBox: Box3 = null;
     private _boundingSphere: Sphere = null;
+    private _unitBoundingBox: Box3 = null;
+    private _unitBoundingSphere: Sphere = null;
     private _updatesInFrame: number = 0;
 
     /**
@@ -76,6 +78,30 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
             this._computeBoundingObjects();
         }
         return this._boundingSphere.clone();
+    }
+
+    /**
+     * Returns a copy of the bot 3d's bounding box which simply represents the
+     * virtual bounding box that the bot uses.
+     */
+    get unitBoundingBox(): Box3 {
+        if (!this._unitBoundingBox) {
+            this._computeBoundingObjects();
+        }
+
+        return this._unitBoundingBox.clone();
+    }
+
+    /**
+     * Returns a copy of the bot 3d's bounding sphere which simply represents the
+     * virtual bounding box that the bot uses.
+     */
+    get unitBoundingSphere(): Sphere {
+        if (!this._unitBoundingSphere) {
+            this._computeBoundingObjects();
+        }
+
+        return this._unitBoundingSphere.clone();
     }
 
     get gridScale(): number {
@@ -121,6 +147,23 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
      * Update the internally cached representation of this aux bot 3d's bounding box and sphere.
      */
     private _computeBoundingObjects(): void {
+        if (this._unitBoundingBox === null) {
+            this._unitBoundingBox = new Box3();
+        }
+
+        // Set to the virtual box.
+        const worldPosition = new Vector3();
+        this.display.getWorldPosition(worldPosition);
+        const worldScale = new Vector3();
+        this.scaleContainer.getWorldScale(worldScale);
+        this._unitBoundingBox.setFromCenterAndSize(worldPosition, worldScale);
+
+        if (this._unitBoundingSphere === null) {
+            this._unitBoundingSphere = new Sphere();
+        }
+
+        this._unitBoundingBox.getBoundingSphere(this._unitBoundingSphere);
+
         // Calculate Bounding Box
         if (this._boundingBox === null) {
             this._boundingBox = new Box3();
@@ -129,15 +172,7 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
         this._boundingBox.setFromObject(this.display);
 
         if (this._boundingBox.isEmpty()) {
-            // Set to the virtual box.
-            const worldPosition = new Vector3();
-            this.display.getWorldPosition(worldPosition);
-            const worldScale = new Vector3();
-            this.display.getWorldScale(worldScale);
-            this._boundingBox = new Box3().setFromCenterAndSize(
-                worldPosition,
-                worldScale
-            );
+            this._boundingBox.copy(this._unitBoundingBox);
         }
 
         // Calculate Bounding Sphere

--- a/src/aux-server/aux-web/shared/scene/GameObject.ts
+++ b/src/aux-server/aux-web/shared/scene/GameObject.ts
@@ -29,10 +29,16 @@ export class GameObject extends Object3D implements IGameObject {
      */
     pointable: boolean;
 
+    /**
+     * Whether the object can receive focus events.
+     */
+    focusable: boolean;
+
     constructor() {
         super();
         this.colliders = [];
         this.pointable = true;
+        this.focusable = true;
     }
 
     /**

--- a/src/aux-server/aux-web/shared/scene/GameObject.ts
+++ b/src/aux-server/aux-web/shared/scene/GameObject.ts
@@ -24,9 +24,15 @@ export class GameObject extends Object3D implements IGameObject {
      */
     colliders: Object3D[];
 
+    /**
+     * Whether the object can receive pointer events.
+     */
+    pointable: boolean;
+
     constructor() {
         super();
         this.colliders = [];
+        this.pointable = true;
     }
 
     /**

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -592,6 +592,14 @@ export function objectWorldDirectionRay(
 }
 
 /**
+ * Creates a ray for the forward facing direction for the given camera.
+ * @param camera The camera.
+ */
+export function cameraForwardRay(camera: Camera): Ray {
+    return objectWorldDirectionRay(new Vector3(0, 0, -1), camera);
+}
+
+/**
  * Creates a ray for the given direction from the given object's perspective.
  * @param direction The direction.
  * @param obj The object.

--- a/src/aux-server/aux-web/shared/scene/Simulation3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Simulation3D.ts
@@ -29,6 +29,7 @@ import {
 import { DimensionGroup } from './DimensionGroup';
 import { DimensionGroup3D } from './DimensionGroup3D';
 import { AuxBot3D } from './AuxBot3D';
+import { PortalConfig } from 'aux-web/aux-player/scene/PortalConfig';
 
 /**
  * Defines a class that is able to render a simulation.

--- a/src/aux-server/aux-web/shared/scene/Text3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Text3D.ts
@@ -151,7 +151,9 @@ export class Text3D extends Object3D {
      * Sets the position of the text based on the size of the given bounding box.
      */
     public setPositionForBounds(bounds: Box3) {
-        if (!bounds || bounds.isEmpty()) return;
+        if (!bounds || bounds.isEmpty()) {
+            return;
+        }
 
         this.updateBoundingBox();
 

--- a/src/aux-server/aux-web/shared/scene/decorators/BotLODDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotLODDecorator.ts
@@ -86,7 +86,7 @@ export class BotLODDecorator extends AuxBot3DDecoratorBase {
     private _updateLOD(calc: BotCalculationContext) {
         const percent = percentOfScreen(
             this._camera,
-            this.bot3D.boundingSphere
+            this.bot3D.unitBoundingSphere
         );
         const nextLOD = calculateBotLOD(
             percent,

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -337,6 +337,9 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
             } else {
                 this._createHtmlIframe();
             }
+        } else if (this._shape === 'nothing') {
+            this.stroke = null;
+            this._canHaveStroke = false;
         }
 
         this.onMeshUpdated.invoke(this);

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -66,11 +66,9 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
     private _address: string = null;
     private _animation: any = null;
     private _canHaveStroke = false;
-    private _pointable = false;
     private _animationMixer: AnimationMixer;
     private _animClips: AnimationAction[];
     private _animClipMap: Map<string, AnimationAction>;
-    private _collider: Object3D;
 
     /**
      * The 3d plane object used to display an iframe.
@@ -82,14 +80,7 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
     container: Group;
     mesh: Mesh;
 
-    get collider(): Object3D {
-        return this._collider;
-    }
-
-    set collider(value: Object3D) {
-        this._collider = this._pointable ? value : null;
-    }
-
+    collider: Object3D;
     scene: Scene;
 
     get allowModifications() {
@@ -111,7 +102,7 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         super(bot3D);
 
         this._game = game;
-        this._rebuildShape('cube', null, null, null, true);
+        this._rebuildShape('cube', null, null, null);
     }
 
     frameUpdate() {
@@ -140,9 +131,8 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
             this.bot3D.bot,
             'auxFormAnimation'
         );
-        const pointable = isBotPointable(calc, this.bot3D.bot);
-        if (this._needsUpdate(shape, subShape, address, version, pointable)) {
-            this._rebuildShape(shape, subShape, address, version, pointable);
+        if (this._needsUpdate(shape, subShape, address, version)) {
+            this._rebuildShape(shape, subShape, address, version);
         }
 
         this._updateColor(calc);
@@ -155,13 +145,11 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         shape: string,
         subShape: string,
         address: string,
-        version: number,
-        pointable: boolean
+        version: number
     ) {
         return (
             this._shape !== shape ||
             this._subShape !== subShape ||
-            this._pointable !== pointable ||
             (shape === 'mesh' &&
                 (this._address !== address || this._gltfVersion !== version))
         );
@@ -315,14 +303,12 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         shape: BotShape,
         subShape: BotSubShape,
         address: string,
-        version: number,
-        pointable: boolean
+        version: number
     ) {
         this._shape = shape;
         this._subShape = subShape;
         this._address = address;
         this._gltfVersion = version;
-        this._pointable = pointable;
         if (this.mesh || this.scene) {
             this.dispose();
         }


### PR DESCRIPTION
-   :rocket: Improvements

    -   Added the `#auxPointable` tag to determine whether a bot can interact with pointers.
        -   Defaults to `true`.
        -   When `false`, the bot won't be clickable or hoverable and will not receive drop events.
        -   Depending on the `#auxPositioningMode` it is still possible to stack bots on top of it though.
    -   Added the `@onFocusEnter`, `@onFocusExit`, `@onAnyFocusEnter` and `@onAnyFocusExit` listen tags.
        -   These are triggered when a bot is directly in the center of the screen.
        -   Uses the `#auxFocusable` tag to determine whether a bot is focusable.
        -   `that` is an object with the following properties:
            -   `dimension` - The dimension that the the bot was (un)focused in.
            -   `bot` - The bot that was (un)focused.
    -   Added the `nothing` aux form.
        -   Does exactly what it seems. A bot with the `nothing` form has no shape and is unable to be clicked, hovered, or focused.
        -   Labels still work though which makes it convienent for adding extra labels around the dimension.

-   :bug: Bug Fixes

    -   Fixed an issue where LODs would flicker upon changing the bot form by ensuring consistent sizing for the related bounding boxes.
    -   Fixed an issue with panning that would cause the camera orbiting position to be moved off the ground.